### PR TITLE
Clarify class and enum exports from type exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -268,17 +268,9 @@ export {
   WorkflowStatuses,
   Edge,
   Execution,
-  NodeFactory,
-  TriggerFactory,
 };
-export type {
-  WorkflowProps,
-  NodeType,
-  NodeProps,
-  EdgeProps,
-  TriggerType,
-  WorkflowStatus,
-};
+
+export type { WorkflowProps, WorkflowStatus, EdgeProps };
 
 // Add this line at the end of the file
 export { getKeyRequestMessage };

--- a/src/models/node/factory.ts
+++ b/src/models/node/factory.ts
@@ -1,9 +1,12 @@
 import * as avs_pb from "../../../grpc_codegen/avs_pb";
 import _ from "lodash";
 import ContractWriteNode, { ContractWriteNodeProps } from "./contractWrite";
-import CustomCodeNode, { CustomCodeLangs, CustomCodeNodeProps } from "./customCode";
+import CustomCodeNode, {
+  CustomCodeLangs,
+  CustomCodeNodeProps,
+} from "./customCode";
 import GraphQLQueryNode, { GraphQLQueryNodeProps } from "./graphqlQuery";
-import Node, { NodeProps, NodeTypes } from "./interface";
+import Node, { NodeProps, NodeType, NodeTypes } from "./interface";
 import RestAPINode, { RestAPINodeProps } from "./restApi";
 import ContractReadNode, { ContractReadNodeProps } from "./contractRead";
 import ETHTransferNode, { ETHTransferNodeProps } from "./ethTransfer";
@@ -63,19 +66,24 @@ export {
   Node,
   NodeTypes,
   ContractWriteNode,
-  ContractWriteNodeProps,
   ContractReadNode,
-  ContractReadNodeProps,
   BranchNode,
+  ETHTransferNode,
+  GraphQLQueryNode,
+  RestAPINode,
+  CustomCodeNode,
+  CustomCodeLangs,
+};
+
+export type {
+  NodeType,
+  NodeProps,
+  ContractWriteNodeProps,
+  ContractReadNodeProps,
   BranchNodeProps,
   BranchNodeData,
-  ETHTransferNode,
   ETHTransferNodeProps,
-  GraphQLQueryNode,
   GraphQLQueryNodeProps,
-  RestAPINode,
   RestAPINodeProps,
-  CustomCodeNode,
   CustomCodeNodeProps,
-  CustomCodeLangs,
 };

--- a/src/models/trigger/factory.ts
+++ b/src/models/trigger/factory.ts
@@ -4,7 +4,7 @@ import { BlockTriggerProps } from "./block";
 import CronTrigger, { CronTriggerProps } from "./cron";
 import EventTrigger, { EventTriggerProps } from "./event";
 import FixedTimeTrigger, { FixedTimeTriggerProps } from "./fixedTime";
-import Trigger, { TriggerTypes } from "./interface";
+import Trigger, { TriggerType, TriggerTypes } from "./interface";
 
 import { TriggerProps } from "./interface";
 import ManualTrigger, { ManualTriggerProps } from "./manual";
@@ -60,16 +60,20 @@ export default TriggerFactory;
 
 export {
   Trigger,
-  TriggerProps,
   TriggerTypes,
   BlockTrigger,
-  BlockTriggerProps,
   CronTrigger,
-  CronTriggerProps,
   EventTrigger,
-  EventTriggerProps,
   FixedTimeTrigger,
-  FixedTimeTriggerProps,
   ManualTrigger,
+};
+
+export type {
+  TriggerProps,
+  TriggerType,
+  BlockTriggerProps,
+  CronTriggerProps,
+  EventTriggerProps,
+  FixedTimeTriggerProps,
   ManualTriggerProps,
 };


### PR DESCRIPTION
In this PR, I try to fix the exports by making classname, enum distinctive from types. 

@imstar15 as you can see the `WorkflowStatues` and type `WorkflowStatus` are already exported in `src/index.ts`. Please follow the below process in README.md to publish a new dev version, and test it in Studio.

1. Publish a dev version and test it in your local environment. The `npm publish` will use the version number in `package.json`, so run `npm version prerelease --preid=dev` first if you need a new version number.

   ```bash
   # Optionally, update version with dev tag in package.json
   npm version prerelease --preid=dev

   # Publish to npm with dev tag
   npm publish --tag dev
   ```