### PR TITLE
[AVS 1.3.1]- Remove method field on contract read/write

### DIFF
--- a/grpc_codegen/avs.proto
+++ b/grpc_codegen/avs.proto
@@ -128,18 +128,16 @@ message ContractWriteNode {
   // If we don’t need the result and only want the transaction hash (which is usually sufficient),
   // then we don’t need to provide the ABI.
   string contract_abi = 3;
-  string method = 4;
 }
 
 message ContractReadNode {
   string contract_address = 1;
   string call_data = 2;
 
-  // The ABI and method name are required to decode the return value and pass it to the next step.
+  // The ABI are required to decode the return value and pass it to the next step.
   // Currently, we need to provide the contract ABI as a JSON string.
   // We don’t need to include the full ABI—just enough to decode the method call.
   string contract_abi = 3;
-  string method = 4;
 }
 
 

--- a/grpc_codegen/avs_pb.d.ts
+++ b/grpc_codegen/avs_pb.d.ts
@@ -239,8 +239,6 @@ export class ContractWriteNode extends jspb.Message {
     setCallData(value: string): ContractWriteNode;
     getContractAbi(): string;
     setContractAbi(value: string): ContractWriteNode;
-    getMethod(): string;
-    setMethod(value: string): ContractWriteNode;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): ContractWriteNode.AsObject;
@@ -257,7 +255,6 @@ export namespace ContractWriteNode {
         contractAddress: string,
         callData: string,
         contractAbi: string,
-        method: string,
     }
 }
 
@@ -268,8 +265,6 @@ export class ContractReadNode extends jspb.Message {
     setCallData(value: string): ContractReadNode;
     getContractAbi(): string;
     setContractAbi(value: string): ContractReadNode;
-    getMethod(): string;
-    setMethod(value: string): ContractReadNode;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): ContractReadNode.AsObject;
@@ -286,7 +281,6 @@ export namespace ContractReadNode {
         contractAddress: string,
         callData: string,
         contractAbi: string,
-        method: string,
     }
 }
 

--- a/grpc_codegen/avs_pb.js
+++ b/grpc_codegen/avs_pb.js
@@ -2674,8 +2674,7 @@ proto.aggregator.ContractWriteNode.toObject = function(includeInstance, msg) {
   var f, obj = {
     contractAddress: jspb.Message.getFieldWithDefault(msg, 1, ""),
     callData: jspb.Message.getFieldWithDefault(msg, 2, ""),
-    contractAbi: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    method: jspb.Message.getFieldWithDefault(msg, 4, "")
+    contractAbi: jspb.Message.getFieldWithDefault(msg, 3, "")
   };
 
   if (includeInstance) {
@@ -2724,10 +2723,6 @@ proto.aggregator.ContractWriteNode.deserializeBinaryFromReader = function(msg, r
       var value = /** @type {string} */ (reader.readString());
       msg.setContractAbi(value);
       break;
-    case 4:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setMethod(value);
-      break;
     default:
       reader.skipField();
       break;
@@ -2775,13 +2770,6 @@ proto.aggregator.ContractWriteNode.serializeBinaryToWriter = function(message, w
   if (f.length > 0) {
     writer.writeString(
       3,
-      f
-    );
-  }
-  f = message.getMethod();
-  if (f.length > 0) {
-    writer.writeString(
-      4,
       f
     );
   }
@@ -2842,24 +2830,6 @@ proto.aggregator.ContractWriteNode.prototype.setContractAbi = function(value) {
 };
 
 
-/**
- * optional string method = 4;
- * @return {string}
- */
-proto.aggregator.ContractWriteNode.prototype.getMethod = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
-};
-
-
-/**
- * @param {string} value
- * @return {!proto.aggregator.ContractWriteNode} returns this
- */
-proto.aggregator.ContractWriteNode.prototype.setMethod = function(value) {
-  return jspb.Message.setProto3StringField(this, 4, value);
-};
-
-
 
 
 
@@ -2894,8 +2864,7 @@ proto.aggregator.ContractReadNode.toObject = function(includeInstance, msg) {
   var f, obj = {
     contractAddress: jspb.Message.getFieldWithDefault(msg, 1, ""),
     callData: jspb.Message.getFieldWithDefault(msg, 2, ""),
-    contractAbi: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    method: jspb.Message.getFieldWithDefault(msg, 4, "")
+    contractAbi: jspb.Message.getFieldWithDefault(msg, 3, "")
   };
 
   if (includeInstance) {
@@ -2944,10 +2913,6 @@ proto.aggregator.ContractReadNode.deserializeBinaryFromReader = function(msg, re
       var value = /** @type {string} */ (reader.readString());
       msg.setContractAbi(value);
       break;
-    case 4:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setMethod(value);
-      break;
     default:
       reader.skipField();
       break;
@@ -2995,13 +2960,6 @@ proto.aggregator.ContractReadNode.serializeBinaryToWriter = function(message, wr
   if (f.length > 0) {
     writer.writeString(
       3,
-      f
-    );
-  }
-  f = message.getMethod();
-  if (f.length > 0) {
-    writer.writeString(
-      4,
       f
     );
   }
@@ -3059,24 +3017,6 @@ proto.aggregator.ContractReadNode.prototype.getContractAbi = function() {
  */
 proto.aggregator.ContractReadNode.prototype.setContractAbi = function(value) {
   return jspb.Message.setProto3StringField(this, 3, value);
-};
-
-
-/**
- * optional string method = 4;
- * @return {string}
- */
-proto.aggregator.ContractReadNode.prototype.getMethod = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
-};
-
-
-/**
- * @param {string} value
- * @return {!proto.aggregator.ContractReadNode} returns this
- */
-proto.aggregator.ContractReadNode.prototype.setMethod = function(value) {
-  return jspb.Message.setProto3StringField(this, 4, value);
 };
 
 

--- a/packages/sdk-js/src/models/node/contractRead.ts
+++ b/packages/sdk-js/src/models/node/contractRead.ts
@@ -36,7 +36,6 @@ class ContractReadNode extends Node {
     );
     nodeData.setCallData((this.data as ContractReadNodeData).callData);
     nodeData.setContractAbi((this.data as ContractReadNodeData).contractAbi);
-    nodeData.setMethod((this.data as ContractReadNodeData).method);
 
     request.setContractRead(nodeData);
 

--- a/packages/sdk-js/src/models/node/contractWrite.ts
+++ b/packages/sdk-js/src/models/node/contractWrite.ts
@@ -36,7 +36,6 @@ class ContractWriteNode extends Node {
     );
     nodeData.setCallData((this.data as ContractWriteNodeData).callData);
     nodeData.setContractAbi((this.data as ContractWriteNodeData).contractAbi);
-    nodeData.setMethod((this.data as ContractWriteNodeData).method);
 
     request.setContractWrite(nodeData);
 

--- a/tests/templates.ts
+++ b/tests/templates.ts
@@ -64,7 +64,6 @@ const contractReadNodeProps: ContractReadNodeProps = {
         ]
       }
     ]`,
-    method: "balanceOf",
   },
 };
 


### PR DESCRIPTION
simplify how to detect the method. Instead of providing this field, we can decode it from the calldata.

Will update title to reflect version on avs that we target.