### PR TITLE
Fix contractWrite outputdata metadata structure

### DIFF
--- a/.changeset/heavy-kids-bet.md
+++ b/.changeset/heavy-kids-bet.md
@@ -1,5 +1,0 @@
----
-"@avaprotocol/sdk-js": patch
----
-
-Update response of ContractWriteNode to fix metadata

--- a/.changeset/heavy-kids-bet.md
+++ b/.changeset/heavy-kids-bet.md
@@ -1,0 +1,5 @@
+---
+"@avaprotocol/sdk-js": patch
+---
+
+Update response of ContractWriteNode to fix metadata

--- a/grpc_codegen/avs.proto
+++ b/grpc_codegen/avs.proto
@@ -370,8 +370,10 @@ message ContractWriteNode {
 
   message Output {
     // Changed from repeated MethodResult to google.protobuf.Value for better JavaScript native type support
-    // Data will be a JSON array of method results with enhanced response structure
+    // Data will be a flattened JSON object with decoded event logs (user-facing results)
     google.protobuf.Value data = 1;
+    // Metadata contains the raw method execution results with receipts and detailed information
+    google.protobuf.Value metadata = 2;
   }
 
   message MethodResult {

--- a/grpc_codegen/avs.proto
+++ b/grpc_codegen/avs.proto
@@ -370,7 +370,9 @@ message ContractWriteNode {
 
   message Output {
     // Changed from repeated MethodResult to google.protobuf.Value for better JavaScript native type support
-    // Data will be a flattened JSON object with decoded event logs (user-facing results)
+    // Data will be a JSON object containing decoded event logs, where each event log is represented as a top-level key-value pair.
+    // "Flattened" means that any nested structures within the event logs are converted to a single-level object,
+    // with nested keys concatenated using dots (e.g., "eventName.fieldName"). This provides user-facing results in a simple, non-nested format.
     google.protobuf.Value data = 1;
     // Metadata contains the raw method execution results with receipts and detailed information
     google.protobuf.Value metadata = 2;

--- a/grpc_codegen/avs_pb.d.ts
+++ b/grpc_codegen/avs_pb.d.ts
@@ -810,6 +810,11 @@ export namespace ContractWriteNode {
         getData(): google_protobuf_struct_pb.Value | undefined;
         setData(value?: google_protobuf_struct_pb.Value): Output;
 
+        hasMetadata(): boolean;
+        clearMetadata(): void;
+        getMetadata(): google_protobuf_struct_pb.Value | undefined;
+        setMetadata(value?: google_protobuf_struct_pb.Value): Output;
+
         serializeBinary(): Uint8Array;
         toObject(includeInstance?: boolean): Output.AsObject;
         static toObject(includeInstance: boolean, msg: Output): Output.AsObject;
@@ -823,6 +828,7 @@ export namespace ContractWriteNode {
     export namespace Output {
         export type AsObject = {
             data?: google_protobuf_struct_pb.Value.AsObject,
+            metadata?: google_protobuf_struct_pb.Value.AsObject,
         }
     }
 

--- a/grpc_codegen/avs_pb.js
+++ b/grpc_codegen/avs_pb.js
@@ -7888,7 +7888,8 @@ proto.aggregator.ContractWriteNode.Output.prototype.toObject = function(opt_incl
  */
 proto.aggregator.ContractWriteNode.Output.toObject = function(includeInstance, msg) {
   var f, obj = {
-    data: (f = msg.getData()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f)
+    data: (f = msg.getData()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f),
+    metadata: (f = msg.getMetadata()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -7930,6 +7931,11 @@ proto.aggregator.ContractWriteNode.Output.deserializeBinaryFromReader = function
       reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
       msg.setData(value);
       break;
+    case 2:
+      var value = new google_protobuf_struct_pb.Value;
+      reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
+      msg.setMetadata(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -7963,6 +7969,14 @@ proto.aggregator.ContractWriteNode.Output.serializeBinaryToWriter = function(mes
   if (f != null) {
     writer.writeMessage(
       1,
+      f,
+      google_protobuf_struct_pb.Value.serializeBinaryToWriter
+    );
+  }
+  f = message.getMetadata();
+  if (f != null) {
+    writer.writeMessage(
+      2,
       f,
       google_protobuf_struct_pb.Value.serializeBinaryToWriter
     );
@@ -8004,6 +8018,43 @@ proto.aggregator.ContractWriteNode.Output.prototype.clearData = function() {
  */
 proto.aggregator.ContractWriteNode.Output.prototype.hasData = function() {
   return jspb.Message.getField(this, 1) != null;
+};
+
+
+/**
+ * optional google.protobuf.Value metadata = 2;
+ * @return {?proto.google.protobuf.Value}
+ */
+proto.aggregator.ContractWriteNode.Output.prototype.getMetadata = function() {
+  return /** @type{?proto.google.protobuf.Value} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Value, 2));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Value|undefined} value
+ * @return {!proto.aggregator.ContractWriteNode.Output} returns this
+*/
+proto.aggregator.ContractWriteNode.Output.prototype.setMetadata = function(value) {
+  return jspb.Message.setWrapperField(this, 2, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.aggregator.ContractWriteNode.Output} returns this
+ */
+proto.aggregator.ContractWriteNode.Output.prototype.clearMetadata = function() {
+  return this.setMetadata(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.aggregator.ContractWriteNode.Output.prototype.hasMetadata = function() {
+  return jspb.Message.getField(this, 2) != null;
 };
 
 

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @avaprotocol/sdk-js
 
+## 2.6.11
+
+### Patch Changes
+
+- 9261ba8: Update response of ContractWriteNode to fix metadata
+
 ## 2.6.10
 
 ### Patch Changes

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avaprotocol/sdk-js",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "description": "A JavaScript/TypeScript SDK designed to simplify integration with Ava Protocol's AVS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-js/src/models/node/contractWrite.ts
+++ b/packages/sdk-js/src/models/node/contractWrite.ts
@@ -109,7 +109,7 @@ class ContractWriteNode extends Node {
     const contractWriteOutput = outputData.getContractWrite();
     if (!contractWriteOutput) return null;
 
-    // 🚀 NEW: Only return the data part (decoded events, like ContractRead)
+    // NEW: Only return the data part (decoded events, like ContractRead)
     // The metadata is handled at the protobuf response level by the client
     const dataValue = contractWriteOutput.getData();
     

--- a/packages/sdk-js/src/models/node/contractWrite.ts
+++ b/packages/sdk-js/src/models/node/contractWrite.ts
@@ -105,44 +105,16 @@ class ContractWriteNode extends Node {
     return request;
   }
 
-  static fromOutputData(outputData: avs_pb.RunNodeWithInputsResp): unknown[] | null {
+  static fromOutputData(outputData: avs_pb.RunNodeWithInputsResp): any {
     const contractWriteOutput = outputData.getContractWrite();
     if (!contractWriteOutput) return null;
 
-    // Use the new getData() method instead of the old resultsList
-    const data = contractWriteOutput.getData();
-    if (!data) return null;
-
-    // Convert protobuf Value to JavaScript object
-    const jsData = convertProtobufValueToJs(data);
-
-    // Format response for consistency with ContractRead
-    if (Array.isArray(jsData)) {
-      return jsData.map((result: any) => {
-        // ContractWrite already uses the consistent format with method_abi and value
-        const methodName = result.method_name || result.methodName;
-        
-        return {
-          methodName: methodName,
-          methodABI: result.method_abi || null,
-          success: result.success,
-          error: result.error || "",
-          value: result.value,
-          receipt: result.receipt || null, // Add receipt field
-        };
-      });
-    } else {
-      // Single result - wrap in array for consistency
-      const methodName = jsData.method_name || jsData.methodName;
-      return [{
-        methodName: methodName,
-        methodABI: jsData.method_abi || null,
-        success: jsData.success,
-        error: jsData.error || "",
-        value: jsData.value,
-        receipt: jsData.receipt || null, // Add receipt field
-      }];
-    }
+    // 🚀 NEW: Only return the data part (decoded events, like ContractRead)
+    // The metadata is handled at the protobuf response level by the client
+    const dataValue = contractWriteOutput.getData();
+    
+    // Convert protobuf Value to JavaScript object (flattened decoded event data)
+    return dataValue ? convertProtobufValueToJs(dataValue) : {};
   }
 }
 

--- a/tests/nodes/contractWrite.test.ts
+++ b/tests/nodes/contractWrite.test.ts
@@ -200,7 +200,7 @@ describe("ContractWrite Node Tests", () => {
       expect(result.nodeId).toBeDefined();
       expect(result.data).toBeDefined();
 
-      // 🚀 NEW: Check new response structure with data and metadata at top level
+      // NEW: Check new response structure with data and metadata at top level
       expect(result.data).toBeDefined(); // Decoded event data
       expect(result.metadata).toBeDefined(); // Method execution details
       expect(Array.isArray(result.metadata)).toBe(true);

--- a/tests/nodes/contractWrite.test.ts
+++ b/tests/nodes/contractWrite.test.ts
@@ -80,7 +80,7 @@ const ERC20_ABI: any[] = [
     outputs: [{ name: "", type: "string" }],
     stateMutability: "view",
     type: "function",
-  }
+  },
 ];
 
 // Helper function to check if we're on Sepolia
@@ -199,21 +199,25 @@ describe("ContractWrite Node Tests", () => {
       expect(typeof result.success).toBe("boolean");
       expect(result.nodeId).toBeDefined();
       expect(result.data).toBeDefined();
-      
-      expect(result.data).not.toHaveProperty("results");
-      const data = result.data as any[];
-      expect(data.length).toBe(params.nodeConfig.methodCalls.length);
+
+      // 🚀 NEW: Check new response structure with data and metadata at top level
+      expect(result.data).toBeDefined(); // Decoded event data
+      expect(result.metadata).toBeDefined(); // Method execution details
+      expect(Array.isArray(result.metadata)).toBe(true);
+      expect(result.metadata.length).toBe(params.nodeConfig.methodCalls.length);
 
       expect(result.success).toBe(true);
-      expect(data.length).toBeGreaterThan(0);
+      expect(result.metadata.length).toBeGreaterThan(0);
 
       // Should have transaction hash regardless of success/failure
-      const approveResult = data.find((r: any) => r.methodName === "approve");
+      const approveResult = result.metadata.find(
+        (r: any) => r.methodName === "approve"
+      );
       expect(approveResult).toBeDefined();
       expect(approveResult.methodName).toBe("approve");
       expect(approveResult.receipt).toBeDefined();
       expect(approveResult.receipt.transactionHash).toBeDefined();
-      
+
       // Check that the receipt status matches the method success
       if (approveResult.success) {
         expect(approveResult.receipt.status).toBe("0x1"); // Success
@@ -266,15 +270,17 @@ describe("ContractWrite Node Tests", () => {
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
       expect(result.data).toBeDefined();
-      
-      expect(result.data).not.toHaveProperty("results");
-      const data = result.data as any[];
-      expect(data.length).toBe(params.nodeConfig.methodCalls.length);
+
+      // 🚀 NEW: Check new response structure with data and metadata at top level
+      expect(result.data).toBeDefined(); // Decoded event data
+      expect(result.metadata).toBeDefined(); // Method execution details
+      expect(Array.isArray(result.metadata)).toBe(true);
+      expect(result.metadata.length).toBe(params.nodeConfig.methodCalls.length);
 
       expect(result.success).toBe(true);
-      expect(data.length).toBeGreaterThan(0);
+      expect(result.metadata.length).toBeGreaterThan(0);
 
-      data.forEach((methodResult: any) => {
+      result.metadata.forEach((methodResult: any) => {
         expect(methodResult.methodName).toBe("approve");
       });
     });
@@ -317,10 +323,12 @@ describe("ContractWrite Node Tests", () => {
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
       expect(result.data).toBeDefined();
-      
-      expect(result.data).not.toHaveProperty("results");
-      const data = result.data as any[];
-      expect(data.length).toBe(params.nodeConfig.methodCalls.length);
+
+      // 🚀 NEW: Check new response structure with data and metadata at top level
+      expect(result.data).toBeDefined(); // Decoded event data
+      expect(result.metadata).toBeDefined(); // Method execution details
+      expect(Array.isArray(result.metadata)).toBe(true);
+      expect(result.metadata.length).toBe(params.nodeConfig.methodCalls.length);
 
       // Backend handles invalid addresses gracefully, returning success but may indicate issues in data
       expect(result.success).toBe(true);
@@ -363,10 +371,12 @@ describe("ContractWrite Node Tests", () => {
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
       expect(result.data).toBeDefined();
-      
-      expect(result.data).not.toHaveProperty("results");
-      const data = result.data as any[];
-      expect(data.length).toBe(params.nodeConfig.methodCalls.length);
+
+      // 🚀 NEW: Check new response structure with data and metadata at top level
+      expect(result.data).toBeDefined(); // Decoded event data
+      expect(result.metadata).toBeDefined(); // Method execution details
+      expect(Array.isArray(result.metadata)).toBe(true);
+      expect(result.metadata.length).toBe(params.nodeConfig.methodCalls.length);
 
       // Backend handles malformed call data gracefully, returning success but may indicate issues in data
       expect(result.success).toBe(true);
@@ -725,12 +735,12 @@ describe("ContractWrite Node Tests", () => {
         expect(simulatedStep?.output).toBeDefined();
         expect(executedStep?.output).toBeDefined();
 
-        // All outputs should have consistent structure (excluding dynamic fields like transaction hash)
-        const directData = directResponse.data as any[];
+        // 🚀 NEW: All outputs should have consistent structure with metadata at top level
+        const directData = directResponse.metadata as any[];
         const simulatedData = simulatedStep?.output as any[];
         const executedData = executedStep?.output as any[];
 
-        // Verify array lengths match
+        // Verify array lengths match (metadata contains the method results)
         expect(directData.length).toBe(simulatedData.length);
         expect(simulatedData.length).toBe(executedData.length);
 
@@ -756,16 +766,18 @@ describe("ContractWrite Node Tests", () => {
         expect(simulatedStep).toBeDefined();
         expect(executedStep).toBeDefined();
 
-        // Check that all outputs have the same structure - they should all be arrays directly
-        expect(Array.isArray(directResponse.data)).toBe(true);
-        expect(directResponse.data).not.toHaveProperty("results");
+        // 🚀 NEW: Check response structure - direct call has data/metadata at top level
+        expect(typeof directResponse.data).toBe("object");
+        expect(directResponse.data).toBeDefined(); // Decoded events
+        expect(directResponse.metadata).toBeDefined(); // Method results
+        expect(Array.isArray(directResponse.metadata)).toBe(true);
         expect(Array.isArray(simulatedStep?.output)).toBe(true);
         expect(simulatedStep?.output).not.toHaveProperty("results");
         expect(Array.isArray(executedStep?.output)).toBe(true);
         expect(executedStep?.output).not.toHaveProperty("results");
 
         // Check that all have the same method names
-        const directMethods = (directResponse.data as any[])
+        const directMethods = (directResponse.metadata as any[])
           ?.map((r: any) => r.methodName)
           .sort();
         const simulatedMethods = (simulatedStep?.output as any[])
@@ -806,9 +818,7 @@ describe("ContractWrite Node Tests", () => {
               type: "function",
             },
           ],
-          methodCalls: [
-            { methodName: "nonExistentMethod", methodParams: [] },
-          ],
+          methodCalls: [{ methodName: "nonExistentMethod", methodParams: [] }],
         },
         inputVariables: {
           workflowContext: {
@@ -846,15 +856,17 @@ describe("ContractWrite Node Tests", () => {
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
       expect(result.data).toBeDefined();
-      
-      expect(result.data).not.toHaveProperty("results");
-      const data = result.data as any[];
-      expect(data.length).toBe(params.nodeConfig.methodCalls.length);
+
+      // 🚀 NEW: Check new response structure with data and metadata at top level
+      expect(result.data).toBeDefined(); // Decoded event data
+      expect(result.metadata).toBeDefined(); // Method execution details
+      expect(Array.isArray(result.metadata)).toBe(true);
+      expect(result.metadata.length).toBe(params.nodeConfig.methodCalls.length);
 
       // Since we're using Tenderly simulation, it might return success even for invalid methods
       // The important thing is that we get a response with the correct structure
-      if (result.success && result.data && Array.isArray(result.data)) {
-        const errorResult = (result.data as any[]).find(
+      if (result.success && result.metadata && Array.isArray(result.metadata)) {
+        const errorResult = result.metadata.find(
           (r: any) => r.methodName === "nonExistentMethod"
         );
         expect(errorResult).toBeDefined();
@@ -879,14 +891,14 @@ describe("ContractWrite Node Tests", () => {
               methodName: "approve",
               methodParams: [
                 "0x0000000000000000000000000000000000000001",
-                "100"
+                "100",
               ],
             },
             {
               methodName: "approve",
               methodParams: [
                 "0x0000000000000000000000000000000000000002",
-                "200"
+                "200",
               ],
             },
           ],
@@ -909,7 +921,7 @@ describe("ContractWrite Node Tests", () => {
       expect(firstCall.getMethodName()).toBe("approve");
       expect(firstCall.getMethodParamsList()).toEqual([
         "0x0000000000000000000000000000000000000001",
-        "100"
+        "100",
       ]);
 
       // Check second method call
@@ -917,7 +929,7 @@ describe("ContractWrite Node Tests", () => {
       expect(secondCall.getMethodName()).toBe("approve");
       expect(secondCall.getMethodParamsList()).toEqual([
         "0x0000000000000000000000000000000000000002",
-        "200"
+        "200",
       ]);
 
       console.log(
@@ -986,13 +998,17 @@ describe("ContractWrite Node Tests", () => {
 
       expect(result).toBeDefined();
       expect(result.data).toBeDefined();
-      
-      expect(result.data).not.toHaveProperty("results");
-      const data = result.data as any[];
-      expect(data.length).toBe(params.nodeConfig.methodCalls.length);
 
-      // Find the approve result
-      const approveResult = data.find((r: any) => r.methodName === "approve");
+      // 🚀 NEW: Check new response structure with data and metadata at top level
+      expect(result.data).toBeDefined(); // Decoded event data
+      expect(result.metadata).toBeDefined(); // Method execution details
+      expect(Array.isArray(result.metadata)).toBe(true);
+      expect(result.metadata.length).toBe(params.nodeConfig.methodCalls.length);
+
+      // Find the approve result in metadata
+      const approveResult = result.metadata.find(
+        (r: any) => r.methodName === "approve"
+      );
       expect(approveResult).toBeDefined();
     });
 
@@ -1186,7 +1202,11 @@ describe("ContractWrite Node Tests", () => {
           },
           {
             methodName: "transferFrom",
-            methodParams: ["{{value.sender}}", "{{value.recipient}}", "{{value.amount}}"], // Array with 3 parameters
+            methodParams: [
+              "{{value.sender}}",
+              "{{value.recipient}}",
+              "{{value.amount}}",
+            ], // Array with 3 parameters
           },
           {
             methodName: "approve",
@@ -1210,12 +1230,19 @@ describe("ContractWrite Node Tests", () => {
     // Check first method call (transfer with 2 parameters)
     const transferCall = methodCalls[0];
     expect(transferCall.getMethodName()).toBe("transfer");
-    expect(transferCall.getMethodParamsList()).toEqual(["{{value.recipient}}", "{{value.amount}}"]);
+    expect(transferCall.getMethodParamsList()).toEqual([
+      "{{value.recipient}}",
+      "{{value.amount}}",
+    ]);
 
     // Check second method call (transferFrom with 3 parameters)
     const transferFromCall = methodCalls[1];
     expect(transferFromCall.getMethodName()).toBe("transferFrom");
-    expect(transferFromCall.getMethodParamsList()).toEqual(["{{value.sender}}", "{{value.recipient}}", "{{value.amount}}"]);
+    expect(transferFromCall.getMethodParamsList()).toEqual([
+      "{{value.sender}}",
+      "{{value.recipient}}",
+      "{{value.amount}}",
+    ]);
 
     // Check third method call (approve with empty methodParams)
     const approveCall = methodCalls[2];

--- a/tests/triggers/manual.test.ts
+++ b/tests/triggers/manual.test.ts
@@ -1118,7 +1118,7 @@ describe("ManualTrigger Tests", () => {
         age: 25,
         active: true,
         tags: ["tag1", "tag2"],
-        metadata: {
+        info: {
           created: "2023-01-01",
           version: 1.0,
         },
@@ -1141,7 +1141,7 @@ describe("ManualTrigger Tests", () => {
       expect(result.data.age).toBe(25);
       expect(result.data.active).toBe(true);
       expect(Array.isArray(result.data.tags)).toBe(true);
-      expect(typeof result.data.metadata).toBe("object");
+      expect(typeof result.data.info).toBe("object");
     });
 
     test("should preserve JSON array types", async () => {
@@ -1260,7 +1260,7 @@ describe("ManualTrigger Tests", () => {
             },
           },
         ],
-        metadata: {
+        summary: {
           total: 2,
           page: 1,
           hasMore: false,
@@ -1286,8 +1286,8 @@ describe("ManualTrigger Tests", () => {
       expect(Array.isArray(result.data.users[0].settings.preferences)).toBe(
         true
       );
-      expect(typeof result.data.metadata).toBe("object");
-      expect(typeof result.data.metadata.hasMore).toBe("boolean");
+      expect(typeof result.data.summary).toBe("object");
+      expect(typeof result.data.summary.hasMore).toBe("boolean");
     });
 
     test("should NOT convert JSON strings to objects (preserve string type)", async () => {


### PR DESCRIPTION
This pull request updates the response structure for the `ContractWriteNode` in both the protobuf definition and the JavaScript SDK, introducing a clearer separation between user-facing decoded event data and detailed method execution metadata. The tests are also refactored to validate the new structure. The goal is to improve consistency with `ContractRead`, make the API easier to use, and provide richer information for clients.

### Response structure improvements

* The `ContractWriteNode.Output` protobuf message now includes a new `metadata` field for raw method execution results, while the `data` field is reserved for flattened, user-facing decoded event logs.
* The generated JavaScript code (`avs_pb.js`) is updated to support the new `metadata` field, including serialization, deserialization, and object conversion methods. [[1]](diffhunk://#diff-57e1666d6bacf2d8b047141224d5cf604d338b88000bea1aeb44e32e2f46d852L7891-R7892) [[2]](diffhunk://#diff-57e1666d6bacf2d8b047141224d5cf604d338b88000bea1aeb44e32e2f46d852R7934-R7938) [[3]](diffhunk://#diff-57e1666d6bacf2d8b047141224d5cf604d338b88000bea1aeb44e32e2f46d852R7976-R7983) [[4]](diffhunk://#diff-57e1666d6bacf2d8b047141224d5cf604d338b88000bea1aeb44e32e2f46d852R8024-R8060)

### SDK and API changes

* The `ContractWriteNode.fromOutputData` method in the SDK now returns only the decoded event data from the `data` field, with metadata handled separately by the client. This simplifies the API and aligns it with `ContractRead`.

### Test suite refactor

* All relevant contract write node tests are refactored to check for the new top-level `data` (decoded events) and `metadata` (method execution details) fields, ensuring the new structure is validated throughout. [[1]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL203-R215) [[2]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL270-R283) [[3]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL321-R331) [[4]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL367-R379) [[5]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL728-R743) [[6]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL759-R780) [[7]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL850-R869) [[8]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL990-R1011)

### Minor consistency and formatting changes

* Minor formatting updates in test files, such as trailing commas and improved array formatting for method parameters, to enhance readability and maintain consistency. [[1]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL83-R83) [[2]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL809-R821) [[3]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL882-R901) [[4]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL1189-R1209) [[5]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL1213-R1245)

### Manual trigger test updates

* Test data in `manual.test.ts` is updated to use more descriptive field names (e.g., `info` and `summary` instead of `metadata`) for clarity and consistency. [[1]](diffhunk://#diff-939f96d236e94cda3adbc0880005981a36b4d408dfefa7860e75b65cc88b9c3aL1121-R1121) [[2]](diffhunk://#diff-939f96d236e94cda3adbc0880005981a36b4d408dfefa7860e75b65cc88b9c3aL1144-R1144) [[3]](diffhunk://#diff-939f96d236e94cda3adbc0880005981a36b4d408dfefa7860e75b65cc88b9c3aL1263-R1263)