### PR TITLE
Updated contractRead and contractWrite tests for the separated metadata

### DIFF
--- a/examples/config.ts
+++ b/examples/config.ts
@@ -6,7 +6,7 @@ const optionDefinitions = [
     name: "avs-target",
     alias: "t",
     type: String,
-    defaultValue: "development",
+    defaultValue: "dev",
   },
   { name: "args", type: String, multiple: true, defaultValue: [] }, // Captures extra arguments like `0`
 ];
@@ -28,16 +28,30 @@ export const commandArgs = {
 
 console.log("commandArgs", commandArgs);
 
-export const env = commandArgs["avs-target"] || "development";
+export const env = commandArgs["avs-target"] || "dev";
 
 export const config = {
-  // The development environment is the local environment run on your machine. It can be bring up following the instructions in this file https://github.com/AvaProtocol/EigenLayer-AVS/blob/main/docs/development.md
-  development: {
+  // The dev environment is the local environment run on your machine. It can be bring up following the instructions in this file https://github.com/AvaProtocol/EigenLayer-AVS/blob/main/docs/dev.md
+  dev: {
     AP_AVS_RPC: "localhost:2206",
     TEST_TRANSFER_TOKEN: "0x2e8bdb63d09ef989a0018eeb1c47ef84e3e61f7b",
     TEST_TRANSFER_TO: "0xe0f7D11FD714674722d325Cd86062A5F1882E13a",
     ORACLE_PRICE_CONTRACT: "0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1",
     RPC_PROVIDER: "https://sepolia.gateway.tenderly.co",
+    TOKENS: {
+      USDC: {
+        address: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+        name: "USD Coin",
+        symbol: "USDC",
+        decimals: 6,
+      },
+    },
+    ORACLES: {
+      "ETH / USD": {
+        pair: "ETH / USD",
+        address: "0x694AA1769357215DE4FAC081bf1f309aDC325306",
+      },
+    },
   },
 
   sepolia: {

--- a/grpc_codegen/avs.proto
+++ b/grpc_codegen/avs.proto
@@ -3,8 +3,6 @@ package aggregator;
 
 option go_package = "./avsproto";
 
-import "google/protobuf/wrappers.proto";
-import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 
 // ============================================================================
@@ -370,12 +368,8 @@ message ContractWriteNode {
 
   message Output {
     // Changed from repeated MethodResult to google.protobuf.Value for better JavaScript native type support
-    // Data will be a JSON object containing decoded event logs, where each event log is represented as a top-level key-value pair.
-    // "Flattened" means that any nested structures within the event logs are converted to a single-level object,
-    // with nested keys concatenated using dots (e.g., "eventName.fieldName"). This provides user-facing results in a simple, non-nested format.
+    // Data will be a flattened JSON object with decoded event logs (user-facing results)
     google.protobuf.Value data = 1;
-    // Metadata contains the raw method execution results with receipts and detailed information
-    google.protobuf.Value metadata = 2;
   }
 
   message MethodResult {
@@ -427,8 +421,6 @@ message ContractReadNode {
     // Changed from repeated MethodResult to google.protobuf.Value for better JavaScript native type support
     // Data will be a JSON array of method results with flattened key-value structure
     google.protobuf.Value data = 1;
-    // Metadata contains the raw backend responses with methodName, methodABI, success, error details
-    google.protobuf.Value metadata = 2;
   }
 
   // Include Config as field 
@@ -622,6 +614,10 @@ message Execution {
     repeated string inputs = 16;
     // Configuration data that was set on this trigger/node
     google.protobuf.Value config = 19;
+    // Optional structured metadata for testing/debugging; not consumed by subsequent nodes
+    google.protobuf.Value metadata = 25;
+    // Optional execution context for runtime flags and extra info (e.g., is_simulated)
+    google.protobuf.Value execution_context = 26;
     oneof output_data {
       // Trigger outputs
       BlockTrigger.Output block_trigger = 20;
@@ -1108,6 +1104,8 @@ message RunNodeWithInputsResp {
   string error = 3; // Error message if execution failed
   string node_id = 4; // ID of the executed node
   google.protobuf.Value metadata = 5; // Optional structured metadata for testing/debugging
+  // Optional execution context for runtime flags and extra info (e.g., is_simulated)
+  google.protobuf.Value execution_context = 6;
   
   // Use specific output types for nodes only
   oneof output_data {
@@ -1137,6 +1135,8 @@ message RunTriggerResp {
   string error = 2; // Error message if execution failed
   string trigger_id = 3; // ID of the executed trigger
   google.protobuf.Value metadata = 4; // Optional structured metadata for testing/debugging
+  // Optional execution context for runtime flags and extra info (e.g., is_simulated)
+  google.protobuf.Value execution_context = 5;
   
   // Use specific output types for triggers
   oneof output_data {

--- a/grpc_codegen/avs_grpc_pb.d.ts
+++ b/grpc_codegen/avs_grpc_pb.d.ts
@@ -6,8 +6,6 @@
 
 import * as grpc from "@grpc/grpc-js";
 import * as avs_pb from "./avs_pb";
-import * as google_protobuf_wrappers_pb from "google-protobuf/google/protobuf/wrappers_pb";
-import * as google_protobuf_any_pb from "google-protobuf/google/protobuf/any_pb";
 import * as google_protobuf_struct_pb from "google-protobuf/google/protobuf/struct_pb";
 
 interface IAggregatorService extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {

--- a/grpc_codegen/avs_grpc_pb.js
+++ b/grpc_codegen/avs_grpc_pb.js
@@ -3,8 +3,6 @@
 'use strict';
 var grpc = require('@grpc/grpc-js');
 var avs_pb = require('./avs_pb.js');
-var google_protobuf_wrappers_pb = require('google-protobuf/google/protobuf/wrappers_pb.js');
-var google_protobuf_any_pb = require('google-protobuf/google/protobuf/any_pb.js');
 var google_protobuf_struct_pb = require('google-protobuf/google/protobuf/struct_pb.js');
 
 function serialize_aggregator_CancelTaskResp(arg) {

--- a/grpc_codegen/avs_pb.d.ts
+++ b/grpc_codegen/avs_pb.d.ts
@@ -5,8 +5,6 @@
 /* eslint-disable */
 
 import * as jspb from "google-protobuf";
-import * as google_protobuf_wrappers_pb from "google-protobuf/google/protobuf/wrappers_pb";
-import * as google_protobuf_any_pb from "google-protobuf/google/protobuf/any_pb";
 import * as google_protobuf_struct_pb from "google-protobuf/google/protobuf/struct_pb";
 
 export class TokenMetadata extends jspb.Message { 
@@ -810,11 +808,6 @@ export namespace ContractWriteNode {
         getData(): google_protobuf_struct_pb.Value | undefined;
         setData(value?: google_protobuf_struct_pb.Value): Output;
 
-        hasMetadata(): boolean;
-        clearMetadata(): void;
-        getMetadata(): google_protobuf_struct_pb.Value | undefined;
-        setMetadata(value?: google_protobuf_struct_pb.Value): Output;
-
         serializeBinary(): Uint8Array;
         toObject(includeInstance?: boolean): Output.AsObject;
         static toObject(includeInstance: boolean, msg: Output): Output.AsObject;
@@ -828,7 +821,6 @@ export namespace ContractWriteNode {
     export namespace Output {
         export type AsObject = {
             data?: google_protobuf_struct_pb.Value.AsObject,
-            metadata?: google_protobuf_struct_pb.Value.AsObject,
         }
     }
 
@@ -1039,11 +1031,6 @@ export namespace ContractReadNode {
         getData(): google_protobuf_struct_pb.Value | undefined;
         setData(value?: google_protobuf_struct_pb.Value): Output;
 
-        hasMetadata(): boolean;
-        clearMetadata(): void;
-        getMetadata(): google_protobuf_struct_pb.Value | undefined;
-        setMetadata(value?: google_protobuf_struct_pb.Value): Output;
-
         serializeBinary(): Uint8Array;
         toObject(includeInstance?: boolean): Output.AsObject;
         static toObject(includeInstance: boolean, msg: Output): Output.AsObject;
@@ -1057,7 +1044,6 @@ export namespace ContractReadNode {
     export namespace Output {
         export type AsObject = {
             data?: google_protobuf_struct_pb.Value.AsObject,
-            metadata?: google_protobuf_struct_pb.Value.AsObject,
         }
     }
 
@@ -1764,6 +1750,16 @@ export namespace Execution {
         getConfig(): google_protobuf_struct_pb.Value | undefined;
         setConfig(value?: google_protobuf_struct_pb.Value): Step;
 
+        hasMetadata(): boolean;
+        clearMetadata(): void;
+        getMetadata(): google_protobuf_struct_pb.Value | undefined;
+        setMetadata(value?: google_protobuf_struct_pb.Value): Step;
+
+        hasExecutionContext(): boolean;
+        clearExecutionContext(): void;
+        getExecutionContext(): google_protobuf_struct_pb.Value | undefined;
+        setExecutionContext(value?: google_protobuf_struct_pb.Value): Step;
+
         hasBlockTrigger(): boolean;
         clearBlockTrigger(): void;
         getBlockTrigger(): BlockTrigger.Output | undefined;
@@ -1860,6 +1856,8 @@ export namespace Execution {
             log: string,
             inputsList: Array<string>,
             config?: google_protobuf_struct_pb.Value.AsObject,
+            metadata?: google_protobuf_struct_pb.Value.AsObject,
+            executionContext?: google_protobuf_struct_pb.Value.AsObject,
             blockTrigger?: BlockTrigger.Output.AsObject,
             fixedTimeTrigger?: FixedTimeTrigger.Output.AsObject,
             cronTrigger?: CronTrigger.Output.AsObject,
@@ -3170,6 +3168,11 @@ export class RunNodeWithInputsResp extends jspb.Message {
     getMetadata(): google_protobuf_struct_pb.Value | undefined;
     setMetadata(value?: google_protobuf_struct_pb.Value): RunNodeWithInputsResp;
 
+    hasExecutionContext(): boolean;
+    clearExecutionContext(): void;
+    getExecutionContext(): google_protobuf_struct_pb.Value | undefined;
+    setExecutionContext(value?: google_protobuf_struct_pb.Value): RunNodeWithInputsResp;
+
     hasEthTransfer(): boolean;
     clearEthTransfer(): void;
     getEthTransfer(): ETHTransferNode.Output | undefined;
@@ -3233,6 +3236,7 @@ export namespace RunNodeWithInputsResp {
         error: string,
         nodeId: string,
         metadata?: google_protobuf_struct_pb.Value.AsObject,
+        executionContext?: google_protobuf_struct_pb.Value.AsObject,
         ethTransfer?: ETHTransferNode.Output.AsObject,
         graphql?: GraphQLQueryNode.Output.AsObject,
         contractRead?: ContractReadNode.Output.AsObject,
@@ -3302,6 +3306,11 @@ export class RunTriggerResp extends jspb.Message {
     getMetadata(): google_protobuf_struct_pb.Value | undefined;
     setMetadata(value?: google_protobuf_struct_pb.Value): RunTriggerResp;
 
+    hasExecutionContext(): boolean;
+    clearExecutionContext(): void;
+    getExecutionContext(): google_protobuf_struct_pb.Value | undefined;
+    setExecutionContext(value?: google_protobuf_struct_pb.Value): RunTriggerResp;
+
     hasBlockTrigger(): boolean;
     clearBlockTrigger(): void;
     getBlockTrigger(): BlockTrigger.Output | undefined;
@@ -3345,6 +3354,7 @@ export namespace RunTriggerResp {
         error: string,
         triggerId: string,
         metadata?: google_protobuf_struct_pb.Value.AsObject,
+        executionContext?: google_protobuf_struct_pb.Value.AsObject,
         blockTrigger?: BlockTrigger.Output.AsObject,
         fixedTimeTrigger?: FixedTimeTrigger.Output.AsObject,
         cronTrigger?: CronTrigger.Output.AsObject,

--- a/grpc_codegen/avs_pb.js
+++ b/grpc_codegen/avs_pb.js
@@ -21,10 +21,6 @@ var global = (function() {
   return Function('return this')();
 }.call(null));
 
-var google_protobuf_wrappers_pb = require('google-protobuf/google/protobuf/wrappers_pb.js');
-goog.object.extend(proto, google_protobuf_wrappers_pb);
-var google_protobuf_any_pb = require('google-protobuf/google/protobuf/any_pb.js');
-goog.object.extend(proto, google_protobuf_any_pb);
 var google_protobuf_struct_pb = require('google-protobuf/google/protobuf/struct_pb.js');
 goog.object.extend(proto, google_protobuf_struct_pb);
 goog.exportSymbol('proto.aggregator.BlockTrigger', null, global);
@@ -7888,8 +7884,7 @@ proto.aggregator.ContractWriteNode.Output.prototype.toObject = function(opt_incl
  */
 proto.aggregator.ContractWriteNode.Output.toObject = function(includeInstance, msg) {
   var f, obj = {
-    data: (f = msg.getData()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f),
-    metadata: (f = msg.getMetadata()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f)
+    data: (f = msg.getData()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -7931,11 +7926,6 @@ proto.aggregator.ContractWriteNode.Output.deserializeBinaryFromReader = function
       reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
       msg.setData(value);
       break;
-    case 2:
-      var value = new google_protobuf_struct_pb.Value;
-      reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
-      msg.setMetadata(value);
-      break;
     default:
       reader.skipField();
       break;
@@ -7969,14 +7959,6 @@ proto.aggregator.ContractWriteNode.Output.serializeBinaryToWriter = function(mes
   if (f != null) {
     writer.writeMessage(
       1,
-      f,
-      google_protobuf_struct_pb.Value.serializeBinaryToWriter
-    );
-  }
-  f = message.getMetadata();
-  if (f != null) {
-    writer.writeMessage(
-      2,
       f,
       google_protobuf_struct_pb.Value.serializeBinaryToWriter
     );
@@ -8018,43 +8000,6 @@ proto.aggregator.ContractWriteNode.Output.prototype.clearData = function() {
  */
 proto.aggregator.ContractWriteNode.Output.prototype.hasData = function() {
   return jspb.Message.getField(this, 1) != null;
-};
-
-
-/**
- * optional google.protobuf.Value metadata = 2;
- * @return {?proto.google.protobuf.Value}
- */
-proto.aggregator.ContractWriteNode.Output.prototype.getMetadata = function() {
-  return /** @type{?proto.google.protobuf.Value} */ (
-    jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Value, 2));
-};
-
-
-/**
- * @param {?proto.google.protobuf.Value|undefined} value
- * @return {!proto.aggregator.ContractWriteNode.Output} returns this
-*/
-proto.aggregator.ContractWriteNode.Output.prototype.setMetadata = function(value) {
-  return jspb.Message.setWrapperField(this, 2, value);
-};
-
-
-/**
- * Clears the message field making it undefined.
- * @return {!proto.aggregator.ContractWriteNode.Output} returns this
- */
-proto.aggregator.ContractWriteNode.Output.prototype.clearMetadata = function() {
-  return this.setMetadata(undefined);
-};
-
-
-/**
- * Returns whether this field is set.
- * @return {boolean}
- */
-proto.aggregator.ContractWriteNode.Output.prototype.hasMetadata = function() {
-  return jspb.Message.getField(this, 2) != null;
 };
 
 
@@ -9598,8 +9543,7 @@ proto.aggregator.ContractReadNode.Output.prototype.toObject = function(opt_inclu
  */
 proto.aggregator.ContractReadNode.Output.toObject = function(includeInstance, msg) {
   var f, obj = {
-    data: (f = msg.getData()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f),
-    metadata: (f = msg.getMetadata()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f)
+    data: (f = msg.getData()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -9641,11 +9585,6 @@ proto.aggregator.ContractReadNode.Output.deserializeBinaryFromReader = function(
       reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
       msg.setData(value);
       break;
-    case 2:
-      var value = new google_protobuf_struct_pb.Value;
-      reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
-      msg.setMetadata(value);
-      break;
     default:
       reader.skipField();
       break;
@@ -9679,14 +9618,6 @@ proto.aggregator.ContractReadNode.Output.serializeBinaryToWriter = function(mess
   if (f != null) {
     writer.writeMessage(
       1,
-      f,
-      google_protobuf_struct_pb.Value.serializeBinaryToWriter
-    );
-  }
-  f = message.getMetadata();
-  if (f != null) {
-    writer.writeMessage(
-      2,
       f,
       google_protobuf_struct_pb.Value.serializeBinaryToWriter
     );
@@ -9728,43 +9659,6 @@ proto.aggregator.ContractReadNode.Output.prototype.clearData = function() {
  */
 proto.aggregator.ContractReadNode.Output.prototype.hasData = function() {
   return jspb.Message.getField(this, 1) != null;
-};
-
-
-/**
- * optional google.protobuf.Value metadata = 2;
- * @return {?proto.google.protobuf.Value}
- */
-proto.aggregator.ContractReadNode.Output.prototype.getMetadata = function() {
-  return /** @type{?proto.google.protobuf.Value} */ (
-    jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Value, 2));
-};
-
-
-/**
- * @param {?proto.google.protobuf.Value|undefined} value
- * @return {!proto.aggregator.ContractReadNode.Output} returns this
-*/
-proto.aggregator.ContractReadNode.Output.prototype.setMetadata = function(value) {
-  return jspb.Message.setWrapperField(this, 2, value);
-};
-
-
-/**
- * Clears the message field making it undefined.
- * @return {!proto.aggregator.ContractReadNode.Output} returns this
- */
-proto.aggregator.ContractReadNode.Output.prototype.clearMetadata = function() {
-  return this.setMetadata(undefined);
-};
-
-
-/**
- * Returns whether this field is set.
- * @return {boolean}
- */
-proto.aggregator.ContractReadNode.Output.prototype.hasMetadata = function() {
-  return jspb.Message.getField(this, 2) != null;
 };
 
 
@@ -14398,6 +14292,8 @@ proto.aggregator.Execution.Step.toObject = function(includeInstance, msg) {
     log: jspb.Message.getFieldWithDefault(msg, 12, ""),
     inputsList: (f = jspb.Message.getRepeatedField(msg, 16)) == null ? undefined : f,
     config: (f = msg.getConfig()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f),
+    metadata: (f = msg.getMetadata()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f),
+    executionContext: (f = msg.getExecutionContext()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f),
     blockTrigger: (f = msg.getBlockTrigger()) && proto.aggregator.BlockTrigger.Output.toObject(includeInstance, f),
     fixedTimeTrigger: (f = msg.getFixedTimeTrigger()) && proto.aggregator.FixedTimeTrigger.Output.toObject(includeInstance, f),
     cronTrigger: (f = msg.getCronTrigger()) && proto.aggregator.CronTrigger.Output.toObject(includeInstance, f),
@@ -14482,6 +14378,16 @@ proto.aggregator.Execution.Step.deserializeBinaryFromReader = function(msg, read
       var value = new google_protobuf_struct_pb.Value;
       reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
       msg.setConfig(value);
+      break;
+    case 25:
+      var value = new google_protobuf_struct_pb.Value;
+      reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
+      msg.setMetadata(value);
+      break;
+    case 26:
+      var value = new google_protobuf_struct_pb.Value;
+      reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
+      msg.setExecutionContext(value);
       break;
     case 20:
       var value = new proto.aggregator.BlockTrigger.Output;
@@ -14643,6 +14549,22 @@ proto.aggregator.Execution.Step.serializeBinaryToWriter = function(message, writ
   if (f != null) {
     writer.writeMessage(
       19,
+      f,
+      google_protobuf_struct_pb.Value.serializeBinaryToWriter
+    );
+  }
+  f = message.getMetadata();
+  if (f != null) {
+    writer.writeMessage(
+      25,
+      f,
+      google_protobuf_struct_pb.Value.serializeBinaryToWriter
+    );
+  }
+  f = message.getExecutionContext();
+  if (f != null) {
+    writer.writeMessage(
+      26,
       f,
       google_protobuf_struct_pb.Value.serializeBinaryToWriter
     );
@@ -14955,6 +14877,80 @@ proto.aggregator.Execution.Step.prototype.clearConfig = function() {
  */
 proto.aggregator.Execution.Step.prototype.hasConfig = function() {
   return jspb.Message.getField(this, 19) != null;
+};
+
+
+/**
+ * optional google.protobuf.Value metadata = 25;
+ * @return {?proto.google.protobuf.Value}
+ */
+proto.aggregator.Execution.Step.prototype.getMetadata = function() {
+  return /** @type{?proto.google.protobuf.Value} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Value, 25));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Value|undefined} value
+ * @return {!proto.aggregator.Execution.Step} returns this
+*/
+proto.aggregator.Execution.Step.prototype.setMetadata = function(value) {
+  return jspb.Message.setWrapperField(this, 25, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.aggregator.Execution.Step} returns this
+ */
+proto.aggregator.Execution.Step.prototype.clearMetadata = function() {
+  return this.setMetadata(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.aggregator.Execution.Step.prototype.hasMetadata = function() {
+  return jspb.Message.getField(this, 25) != null;
+};
+
+
+/**
+ * optional google.protobuf.Value execution_context = 26;
+ * @return {?proto.google.protobuf.Value}
+ */
+proto.aggregator.Execution.Step.prototype.getExecutionContext = function() {
+  return /** @type{?proto.google.protobuf.Value} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Value, 26));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Value|undefined} value
+ * @return {!proto.aggregator.Execution.Step} returns this
+*/
+proto.aggregator.Execution.Step.prototype.setExecutionContext = function(value) {
+  return jspb.Message.setWrapperField(this, 26, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.aggregator.Execution.Step} returns this
+ */
+proto.aggregator.Execution.Step.prototype.clearExecutionContext = function() {
+  return this.setExecutionContext(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.aggregator.Execution.Step.prototype.hasExecutionContext = function() {
+  return jspb.Message.getField(this, 26) != null;
 };
 
 
@@ -25252,6 +25248,7 @@ proto.aggregator.RunNodeWithInputsResp.toObject = function(includeInstance, msg)
     error: jspb.Message.getFieldWithDefault(msg, 3, ""),
     nodeId: jspb.Message.getFieldWithDefault(msg, 4, ""),
     metadata: (f = msg.getMetadata()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f),
+    executionContext: (f = msg.getExecutionContext()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f),
     ethTransfer: (f = msg.getEthTransfer()) && proto.aggregator.ETHTransferNode.Output.toObject(includeInstance, f),
     graphql: (f = msg.getGraphql()) && proto.aggregator.GraphQLQueryNode.Output.toObject(includeInstance, f),
     contractRead: (f = msg.getContractRead()) && proto.aggregator.ContractReadNode.Output.toObject(includeInstance, f),
@@ -25313,6 +25310,11 @@ proto.aggregator.RunNodeWithInputsResp.deserializeBinaryFromReader = function(ms
       var value = new google_protobuf_struct_pb.Value;
       reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
       msg.setMetadata(value);
+      break;
+    case 6:
+      var value = new google_protobuf_struct_pb.Value;
+      reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
+      msg.setExecutionContext(value);
       break;
     case 10:
       var value = new proto.aggregator.ETHTransferNode.Output;
@@ -25413,6 +25415,14 @@ proto.aggregator.RunNodeWithInputsResp.serializeBinaryToWriter = function(messag
   if (f != null) {
     writer.writeMessage(
       5,
+      f,
+      google_protobuf_struct_pb.Value.serializeBinaryToWriter
+    );
+  }
+  f = message.getExecutionContext();
+  if (f != null) {
+    writer.writeMessage(
+      6,
       f,
       google_protobuf_struct_pb.Value.serializeBinaryToWriter
     );
@@ -25580,6 +25590,43 @@ proto.aggregator.RunNodeWithInputsResp.prototype.clearMetadata = function() {
  */
 proto.aggregator.RunNodeWithInputsResp.prototype.hasMetadata = function() {
   return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * optional google.protobuf.Value execution_context = 6;
+ * @return {?proto.google.protobuf.Value}
+ */
+proto.aggregator.RunNodeWithInputsResp.prototype.getExecutionContext = function() {
+  return /** @type{?proto.google.protobuf.Value} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Value, 6));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Value|undefined} value
+ * @return {!proto.aggregator.RunNodeWithInputsResp} returns this
+*/
+proto.aggregator.RunNodeWithInputsResp.prototype.setExecutionContext = function(value) {
+  return jspb.Message.setWrapperField(this, 6, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.aggregator.RunNodeWithInputsResp} returns this
+ */
+proto.aggregator.RunNodeWithInputsResp.prototype.clearExecutionContext = function() {
+  return this.setExecutionContext(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.aggregator.RunNodeWithInputsResp.prototype.hasExecutionContext = function() {
+  return jspb.Message.getField(this, 6) != null;
 };
 
 
@@ -26177,6 +26224,7 @@ proto.aggregator.RunTriggerResp.toObject = function(includeInstance, msg) {
     error: jspb.Message.getFieldWithDefault(msg, 2, ""),
     triggerId: jspb.Message.getFieldWithDefault(msg, 3, ""),
     metadata: (f = msg.getMetadata()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f),
+    executionContext: (f = msg.getExecutionContext()) && google_protobuf_struct_pb.Value.toObject(includeInstance, f),
     blockTrigger: (f = msg.getBlockTrigger()) && proto.aggregator.BlockTrigger.Output.toObject(includeInstance, f),
     fixedTimeTrigger: (f = msg.getFixedTimeTrigger()) && proto.aggregator.FixedTimeTrigger.Output.toObject(includeInstance, f),
     cronTrigger: (f = msg.getCronTrigger()) && proto.aggregator.CronTrigger.Output.toObject(includeInstance, f),
@@ -26234,6 +26282,11 @@ proto.aggregator.RunTriggerResp.deserializeBinaryFromReader = function(msg, read
       var value = new google_protobuf_struct_pb.Value;
       reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
       msg.setMetadata(value);
+      break;
+    case 5:
+      var value = new google_protobuf_struct_pb.Value;
+      reader.readMessage(value,google_protobuf_struct_pb.Value.deserializeBinaryFromReader);
+      msg.setExecutionContext(value);
       break;
     case 10:
       var value = new proto.aggregator.BlockTrigger.Output;
@@ -26314,6 +26367,14 @@ proto.aggregator.RunTriggerResp.serializeBinaryToWriter = function(message, writ
   if (f != null) {
     writer.writeMessage(
       4,
+      f,
+      google_protobuf_struct_pb.Value.serializeBinaryToWriter
+    );
+  }
+  f = message.getExecutionContext();
+  if (f != null) {
+    writer.writeMessage(
+      5,
       f,
       google_protobuf_struct_pb.Value.serializeBinaryToWriter
     );
@@ -26449,6 +26510,43 @@ proto.aggregator.RunTriggerResp.prototype.clearMetadata = function() {
  */
 proto.aggregator.RunTriggerResp.prototype.hasMetadata = function() {
   return jspb.Message.getField(this, 4) != null;
+};
+
+
+/**
+ * optional google.protobuf.Value execution_context = 5;
+ * @return {?proto.google.protobuf.Value}
+ */
+proto.aggregator.RunTriggerResp.prototype.getExecutionContext = function() {
+  return /** @type{?proto.google.protobuf.Value} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Value, 5));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.Value|undefined} value
+ * @return {!proto.aggregator.RunTriggerResp} returns this
+*/
+proto.aggregator.RunTriggerResp.prototype.setExecutionContext = function(value) {
+  return jspb.Message.setWrapperField(this, 5, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.aggregator.RunTriggerResp} returns this
+ */
+proto.aggregator.RunTriggerResp.prototype.clearExecutionContext = function() {
+  return this.setExecutionContext(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.aggregator.RunTriggerResp.prototype.hasExecutionContext = function() {
+  return jspb.Message.getField(this, 5) != null;
 };
 
 

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -1281,7 +1281,6 @@ class Client extends BaseClient {
         success: false,
         error: `Trigger type "${nodeType}" should use the runTrigger() method instead of runNodeWithInputs()`,
         data: null,
-        nodeId: "",
       };
     }
 
@@ -1314,9 +1313,11 @@ class Client extends BaseClient {
       success: result.getSuccess(),
       data: NodeFactory.fromOutputData(result),
       error: result.getError(),
-      nodeId: result.getNodeId(),
       metadata: result.hasMetadata()
         ? convertProtobufValueToJs(result.getMetadata()!)
+        : undefined,
+      executionContext: result.hasExecutionContext()
+        ? convertProtobufValueToJs(result.getExecutionContext()!)
         : undefined,
     };
   }
@@ -1369,8 +1370,10 @@ class Client extends BaseClient {
       success: result.getSuccess(),
       data: TriggerFactory.fromOutputData(result),
       error: result.getError(),
-      triggerId: result.getTriggerId(),
       metadata: metadata,
+      executionContext: result.hasExecutionContext()
+        ? convertProtobufValueToJs(result.getExecutionContext()!)
+        : undefined,
     };
   }
 

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -61,6 +61,7 @@ import {
   convertProtobufValueToJs,
   convertJSValueToProtobuf,
   cleanGrpcErrorMessage,
+  toCamelCaseKeys,
 } from "./utils";
 
 /**
@@ -1311,13 +1312,13 @@ class Client extends BaseClient {
 
     return {
       success: result.getSuccess(),
-      data: NodeFactory.fromOutputData(result),
+      data: toCamelCaseKeys(NodeFactory.fromOutputData(result)),
       error: result.getError(),
       metadata: result.hasMetadata()
-        ? convertProtobufValueToJs(result.getMetadata()!)
+        ? toCamelCaseKeys(convertProtobufValueToJs(result.getMetadata()!))
         : undefined,
       executionContext: result.hasExecutionContext()
-        ? convertProtobufValueToJs(result.getExecutionContext()!)
+        ? toCamelCaseKeys(convertProtobufValueToJs(result.getExecutionContext()!))
         : undefined,
     };
   }
@@ -1368,11 +1369,11 @@ class Client extends BaseClient {
 
     return {
       success: result.getSuccess(),
-      data: TriggerFactory.fromOutputData(result),
+      data: toCamelCaseKeys(TriggerFactory.fromOutputData(result)),
       error: result.getError(),
-      metadata: metadata,
+      metadata: toCamelCaseKeys(metadata),
       executionContext: result.hasExecutionContext()
-        ? convertProtobufValueToJs(result.getExecutionContext()!)
+        ? toCamelCaseKeys(convertProtobufValueToJs(result.getExecutionContext()!))
         : undefined,
     };
   }

--- a/packages/sdk-js/src/models/step.ts
+++ b/packages/sdk-js/src/models/step.ts
@@ -19,6 +19,7 @@ class Step implements StepProps {
   startAt: number;
   endAt: number;
   metadata?: any;
+  executionContext?: any;
 
   constructor(props: StepProps) {
     this.id = props.id;
@@ -33,6 +34,7 @@ class Step implements StepProps {
     this.startAt = props.startAt;
     this.endAt = props.endAt;
     this.metadata = (props as any).metadata;
+    this.executionContext = (props as any).executionContext;
   }
 
   /**
@@ -53,6 +55,7 @@ class Step implements StepProps {
       startAt: this.startAt,
       endAt: this.endAt,
       metadata: this.metadata,
+      executionContext: this.executionContext,
     };
   }
 
@@ -259,6 +262,23 @@ class Step implements StepProps {
       stepMetadata = (step as any).metadata;
     }
 
+    // Extract executionContext if present on the step
+    let executionContext: any = undefined;
+    if (
+      typeof (step as any).getExecutionContext === "function" &&
+      (step as any).getExecutionContext()
+    ) {
+      try {
+        executionContext = convertProtobufValueToJs(
+          (step as any).getExecutionContext()
+        );
+      } catch (e) {
+        executionContext = (step as any).getExecutionContext();
+      }
+    } else if ((step as any).executionContext) {
+      executionContext = (step as any).executionContext;
+    }
+
     return new Step({
       id: getId(),
       type: convertProtobufStepTypeToSdk(getType()),
@@ -272,6 +292,7 @@ class Step implements StepProps {
       startAt: getStartAt(),
       endAt: getEndAt(),
       metadata: stepMetadata,
+      executionContext,
     } as any);
   }
 

--- a/packages/sdk-js/src/models/step.ts
+++ b/packages/sdk-js/src/models/step.ts
@@ -18,6 +18,7 @@ class Step implements StepProps {
   output: OutputDataProps;
   startAt: number;
   endAt: number;
+  metadata?: any;
 
   constructor(props: StepProps) {
     this.id = props.id;
@@ -31,6 +32,7 @@ class Step implements StepProps {
     this.output = props.output;
     this.startAt = props.startAt;
     this.endAt = props.endAt;
+    this.metadata = (props as any).metadata;
   }
 
   /**
@@ -50,62 +52,43 @@ class Step implements StepProps {
       output: this.output,
       startAt: this.startAt,
       endAt: this.endAt,
+      metadata: this.metadata,
     };
   }
 
   static getOutput(step: avs_pb.Execution.Step): OutputDataProps {
-    const outputData = this.extractOutputData(step);
-    if (!outputData) return null;
-    
-    const outputCase = this.getOutputDataCase(step);
-    
-    // 🚀 Special handling for ContractWrite and ContractRead - return both data and metadata
-    if (outputCase === avs_pb.Execution.Step.OutputDataCase.CONTRACT_WRITE ||
-        outputCase === avs_pb.Execution.Step.OutputDataCase.CONTRACT_READ) {
+    // Always return Output.data; step-level metadata is separate.
+    const outputObj = this.extractOutputData(step);
+    if (!outputObj) return null;
+
+    // Protobuf accessor path
+    if (typeof (outputObj as any).getData === "function") {
+      const val = (outputObj as any).getData();
+      if (!val) return null;
       try {
-        const result: any = {};
-        
-        // Extract data field (decoded events/results)
-        if (typeof outputData.getData === "function") {
-          result.data = convertProtobufValueToJs(outputData.getData());
-        }
-        
-        // Extract metadata field (method execution details)
-        if (typeof outputData.getMetadata === "function") {
-          result.metadata = convertProtobufValueToJs(outputData.getMetadata());
-        }
-        
-        // Return both data and metadata for ContractWrite and ContractRead
-        // This ensures consistent structure between simulated and deployed workflow execution
-        return result;
-      } catch (error) {
-        console.warn("Failed to convert ContractWrite/ContractRead protobuf to JavaScript:", error);
-        return outputData.getData ? outputData.getData() : null;
-      }
-    }
-    
-    // STANDARDIZED Direct Mapping - ALL other triggers and nodes use the same logic
-    if (typeof outputData.hasData === "function" && outputData.hasData()) {
-      try {
-        return convertProtobufValueToJs(outputData.getData());
+        return convertProtobufValueToJs(val);
       } catch (error) {
         console.warn("Failed to convert protobuf Value to JavaScript:", error);
-        return outputData.getData();
+        return val as any;
       }
-    } else if (typeof outputData.getData === "function") {
-      try {
-        return convertProtobufValueToJs(outputData.getData());
-      } catch (error) {
-        console.warn("Failed to convert protobuf Value to JavaScript:", error);
-        return outputData.getData();
-      }
-    } else if (outputData.data) {
-      // For plain objects, try to convert or use directly
-      return typeof outputData.data.getKindCase === "function"
-        ? convertProtobufValueToJs(outputData.data)
-        : outputData.data;
     }
-    
+
+    // Plain object fallback
+    const data = (outputObj as any).data;
+    if (data) {
+      try {
+        return typeof (data as any).getKindCase === "function"
+          ? convertProtobufValueToJs(data)
+          : data;
+      } catch (error) {
+        console.warn(
+          "Failed to convert plain object Value to JavaScript:",
+          error
+        );
+        return data;
+      }
+    }
+
     return null;
   }
 
@@ -114,67 +97,69 @@ class Step implements StepProps {
     const outputCase = this.getOutputDataCase(step);
     switch (outputCase) {
       case avs_pb.Execution.Step.OutputDataCase.BLOCK_TRIGGER:
-        return typeof step.getBlockTrigger === "function" 
-          ? step.getBlockTrigger() 
+        return typeof step.getBlockTrigger === "function"
+          ? step.getBlockTrigger()
           : (step as any).blockTrigger;
       case avs_pb.Execution.Step.OutputDataCase.FIXED_TIME_TRIGGER:
-        return typeof step.getFixedTimeTrigger === "function" 
-          ? step.getFixedTimeTrigger() 
+        return typeof step.getFixedTimeTrigger === "function"
+          ? step.getFixedTimeTrigger()
           : (step as any).fixedTimeTrigger;
       case avs_pb.Execution.Step.OutputDataCase.CRON_TRIGGER:
-        return typeof step.getCronTrigger === "function" 
-          ? step.getCronTrigger() 
+        return typeof step.getCronTrigger === "function"
+          ? step.getCronTrigger()
           : (step as any).cronTrigger;
       case avs_pb.Execution.Step.OutputDataCase.EVENT_TRIGGER:
-        return typeof step.getEventTrigger === "function" 
-          ? step.getEventTrigger() 
+        return typeof step.getEventTrigger === "function"
+          ? step.getEventTrigger()
           : (step as any).eventTrigger;
       case avs_pb.Execution.Step.OutputDataCase.MANUAL_TRIGGER:
-        return typeof step.getManualTrigger === "function" 
-          ? step.getManualTrigger() 
+        return typeof step.getManualTrigger === "function"
+          ? step.getManualTrigger()
           : (step as any).manualTrigger;
       case avs_pb.Execution.Step.OutputDataCase.ETH_TRANSFER:
-        return typeof step.getEthTransfer === "function" 
-          ? step.getEthTransfer() 
+        return typeof step.getEthTransfer === "function"
+          ? step.getEthTransfer()
           : (step as any).ethTransfer;
       case avs_pb.Execution.Step.OutputDataCase.GRAPHQL:
-        return typeof step.getGraphql === "function" 
-          ? step.getGraphql() 
+        return typeof step.getGraphql === "function"
+          ? step.getGraphql()
           : (step as any).graphql;
       case avs_pb.Execution.Step.OutputDataCase.CONTRACT_READ:
-        return typeof step.getContractRead === "function" 
-          ? step.getContractRead() 
+        return typeof step.getContractRead === "function"
+          ? step.getContractRead()
           : (step as any).contractRead;
       case avs_pb.Execution.Step.OutputDataCase.CONTRACT_WRITE:
-        return typeof step.getContractWrite === "function" 
-          ? step.getContractWrite() 
+        return typeof step.getContractWrite === "function"
+          ? step.getContractWrite()
           : (step as any).contractWrite;
       case avs_pb.Execution.Step.OutputDataCase.CUSTOM_CODE:
-        return typeof step.getCustomCode === "function" 
-          ? step.getCustomCode() 
+        return typeof step.getCustomCode === "function"
+          ? step.getCustomCode()
           : (step as any).customCode;
       case avs_pb.Execution.Step.OutputDataCase.REST_API:
-        return typeof step.getRestApi === "function" 
-          ? step.getRestApi() 
+        return typeof step.getRestApi === "function"
+          ? step.getRestApi()
           : (step as any).restApi;
       case avs_pb.Execution.Step.OutputDataCase.BRANCH:
-        return typeof step.getBranch === "function" 
-          ? step.getBranch() 
+        return typeof step.getBranch === "function"
+          ? step.getBranch()
           : (step as any).branch;
       case avs_pb.Execution.Step.OutputDataCase.FILTER:
-        return typeof step.getFilter === "function" 
-          ? step.getFilter() 
+        return typeof step.getFilter === "function"
+          ? step.getFilter()
           : (step as any).filter;
       case avs_pb.Execution.Step.OutputDataCase.LOOP:
-        return typeof step.getLoop === "function" 
-          ? step.getLoop() 
+        return typeof step.getLoop === "function"
+          ? step.getLoop()
           : (step as any).loop;
       default:
         return null;
     }
   }
 
-  private static getOutputDataCase(step: avs_pb.Execution.Step): avs_pb.Execution.Step.OutputDataCase {
+  private static getOutputDataCase(
+    step: avs_pb.Execution.Step
+  ): avs_pb.Execution.Step.OutputDataCase {
     if (typeof step.getOutputDataCase === "function") {
       return step.getOutputDataCase();
     }
@@ -259,6 +244,56 @@ class Step implements StepProps {
         ? step.getEndAt()
         : (step as any).endAt;
 
+    // Extract step-level metadata if present
+    let stepMetadata: any = undefined;
+    const outCaseForMeta = this.getOutputDataCase(step);
+    const outObjForMeta = this.extractOutputData(step);
+    if (
+      outObjForMeta &&
+      (outCaseForMeta === avs_pb.Execution.Step.OutputDataCase.CONTRACT_WRITE ||
+        outCaseForMeta === avs_pb.Execution.Step.OutputDataCase.CONTRACT_READ)
+    ) {
+      // Prefer reading metadata from the node-specific output when present
+      if (
+        typeof (outObjForMeta as any).hasMetadata === "function" &&
+        (outObjForMeta as any).hasMetadata()
+      ) {
+        try {
+          stepMetadata = convertProtobufValueToJs(
+            (outObjForMeta as any).getMetadata()
+          );
+        } catch (e) {
+          stepMetadata = (outObjForMeta as any).getMetadata();
+        }
+      } else if (typeof (outObjForMeta as any).getMetadata === "function") {
+        const mv = (outObjForMeta as any).getMetadata();
+        if (mv) {
+          try {
+            stepMetadata = convertProtobufValueToJs(mv);
+          } catch (e) {
+            stepMetadata = mv as any;
+          }
+        }
+      } else if ((outObjForMeta as any).metadata) {
+        stepMetadata = (outObjForMeta as any).metadata;
+      }
+    }
+    // Fallback to step-level metadata if present
+    if (stepMetadata === undefined) {
+      if (
+        typeof (step as any).getMetadata === "function" &&
+        (step as any).getMetadata()
+      ) {
+        try {
+          stepMetadata = convertProtobufValueToJs((step as any).getMetadata());
+        } catch (e) {
+          stepMetadata = (step as any).getMetadata();
+        }
+      } else if ((step as any).metadata) {
+        stepMetadata = (step as any).metadata;
+      }
+    }
+
     return new Step({
       id: getId(),
       type: convertProtobufStepTypeToSdk(getType()),
@@ -271,7 +306,8 @@ class Step implements StepProps {
       output: Step.getOutput(step),
       startAt: getStartAt(),
       endAt: getEndAt(),
-    });
+      metadata: stepMetadata,
+    } as any);
   }
 
   // Client side does not generate the step, so there's no toRequest() method

--- a/packages/sdk-js/src/utils.ts
+++ b/packages/sdk-js/src/utils.ts
@@ -91,6 +91,25 @@ export function convertJSValueToProtobuf(value: any): ProtobufValue {
 }
 
 /**
+ * Recursively convert object keys from snake_case to camelCase.
+ * Leaves non-objects and arrays intact (arrays are mapped over).
+ */
+export function toCamelCaseKeys<T = any>(input: any): T {
+  if (input === null || input === undefined) return input as T;
+  if (Array.isArray(input)) {
+    return input.map((item) => toCamelCaseKeys(item)) as unknown as T;
+  }
+  if (typeof input !== "object") return input as T;
+
+  const result: Record<string, any> = {};
+  for (const [key, value] of Object.entries(input)) {
+    const camelKey = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+    result[camelKey] = toCamelCaseKeys(value);
+  }
+  return result as T;
+}
+
+/**
  * Convert protobuf trigger type string to SDK trigger type string
  *
  * @param protobufType - The protobuf trigger type string (e.g., "TRIGGER_TYPE_MANUAL")

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -236,13 +236,8 @@ export interface RunNodeWithInputsResponse {
   success: boolean;
   data: NodeOutputData;
   error?: string;
-  executionId?: string;
-  nodeId?: string;
-  metadata?: {
-    _raw?: any[]; // Array of raw method results for contract reads
-    eval?: any; // Evaluation metadata (for consistency with eventTrigger)
-    [key: string]: any; // Allow additional metadata fields for other node types
-  };
+  metadata?: Record<string, any> | any[];
+  executionContext?: Record<string, any>;
 }
 
 export interface RunTriggerRequest {
@@ -254,8 +249,8 @@ export interface RunTriggerResponse {
   success: boolean;
   data: TriggerOutputData;
   error?: string;
-  triggerId?: string;
-  metadata?: string; // Optional JSON-encoded metadata for testing/debugging
+  metadata?: Record<string, any> | any[];
+  executionContext?: Record<string, any>;
 }
 
 export interface SimulateWorkflowRequest {

--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -17,6 +17,7 @@ export interface PageInfo {
   hasPreviousPage: boolean;
   hasNextPage: boolean;
 }
+
 export type SecretProps = {
   name: string;
   secret?: string;

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -76,6 +76,7 @@ export type StepProps = Omit<
 > & {
   output: OutputDataProps;
   metadata?: any;
+  executionContext?: any;
 };
 
 // Execution Props

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -75,6 +75,7 @@ export type StepProps = Omit<
   | "manualTrigger"
 > & {
   output: OutputDataProps;
+  metadata?: any;
 };
 
 // Execution Props

--- a/tests/executions/execution.test.ts
+++ b/tests/executions/execution.test.ts
@@ -10,6 +10,7 @@ import {
   TIMEOUT_DURATION,
   SALT_BUCKET_SIZE,
 } from "../utils/utils";
+import { executionHasWriteFailure } from "../utils/utils";
 import { createFromTemplate, defaultTriggerId } from "../utils/templates";
 import { getConfig } from "../utils/envalid";
 
@@ -75,16 +76,7 @@ describe("Execution Management Tests", () => {
         expect(execution).toBeDefined();
         expect(execution.id).toEqual(triggerResult.executionId);
         // Overall success must be false if any blockchain write step failed
-        const hasWriteFailure = execution.steps.some(
-          (s: any) =>
-            s.type === NodeType.ContractWrite &&
-            s.metadata &&
-            Array.isArray(s.metadata) &&
-            s.metadata.some(
-              (m: any) =>
-                m.success === false || (m.receipt && m.receipt.status === "0x0")
-            )
-        );
+        const hasWriteFailure = executionHasWriteFailure(execution as any);
         expect(execution.success).toBe(!hasWriteFailure);
 
         // The execution now contains both trigger and node steps

--- a/tests/executions/execution.test.ts
+++ b/tests/executions/execution.test.ts
@@ -74,7 +74,18 @@ describe("Execution Management Tests", () => {
 
         expect(execution).toBeDefined();
         expect(execution.id).toEqual(triggerResult.executionId);
-        expect(execution.success).toBe(true);
+        // Overall success must be false if any blockchain write step failed
+        const hasWriteFailure = execution.steps.some(
+          (s: any) =>
+            s.type === NodeType.ContractWrite &&
+            s.metadata &&
+            Array.isArray(s.metadata) &&
+            s.metadata.some(
+              (m: any) =>
+                m.success === false || (m.receipt && m.receipt.status === "0x0")
+            )
+        );
+        expect(execution.success).toBe(!hasWriteFailure);
 
         // The execution now contains both trigger and node steps
         // Step 0: Trigger step, Step 1: ETH transfer node

--- a/tests/executions/getExecution.test.ts
+++ b/tests/executions/getExecution.test.ts
@@ -16,6 +16,7 @@ import {
   TIMEOUT_DURATION,
   SALT_BUCKET_SIZE,
 } from "../utils/utils";
+import { executionHasWriteFailure } from "../utils/utils";
 import { createFromTemplate, defaultTriggerId } from "../utils/templates";
 import { getConfig } from "../utils/envalid";
 
@@ -82,8 +83,8 @@ describe("getExecution Tests", () => {
       expect(execution).toBeDefined();
       expect(execution.id).toEqual(triggerResult.executionId);
       // Ensure success reflects step outcomes: no failed blockchain write steps
-      const stepFailures = execution.steps.filter((s: any) => s.type === NodeType.ContractWrite && s.metadata && Array.isArray(s.metadata) && s.metadata.some((m: any) => m.success === false || (m.receipt && m.receipt.status === "0x0")));
-      expect(execution.success).toBe(stepFailures.length === 0);
+      const hasWriteFailure = executionHasWriteFailure(execution as any);
+      expect(execution.success).toBe(!hasWriteFailure);
 
       // The execution now contains both trigger and node steps
       // Step 0: Trigger step, Step 1: ETH transfer node

--- a/tests/nodes/RestAPi.test.ts
+++ b/tests/nodes/RestAPi.test.ts
@@ -78,7 +78,6 @@ describe("RestAPI Node Tests", () => {
 
       expect(response.success).toBe(true);
       expect(response.error).toBe("");
-      expect(response.nodeId).toBeDefined();
 
       if (response.data) {
         const data = response.data as RestApiResponse;
@@ -127,7 +126,7 @@ describe("RestAPI Node Tests", () => {
       });
 
       expect(response.success).toBe(false); // HTTP 404 should be categorized as failed
-      
+
       // NOTE: Backend currently doesn't populate detailed response data for failed runNodeWithInputs calls
       // This is different from simulateWorkflow which does return full status information
       expect(response.data).toEqual({}); // Empty object for failed requests via runNodeWithInputs
@@ -392,7 +391,6 @@ describe("RestAPI Node Tests", () => {
           expect(simulatedOutput.data).toBeDefined();
           expect(executedOutput.data).toBeDefined();
         }
-
       } finally {
         if (workflowId) {
           await client.deleteWorkflow(workflowId);

--- a/tests/nodes/branchNode.test.ts
+++ b/tests/nodes/branchNode.test.ts
@@ -73,7 +73,7 @@ describe("BranchNode Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.nodeId).toBeDefined();
+      
       
       // Validate data format - should be clean JSON, not protobuf structures
       expect(result.data).toEqual(
@@ -112,7 +112,7 @@ describe("BranchNode Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.nodeId).toBeDefined();
+      
       
       // Validate data format - should be clean JSON, not protobuf structures
       expect(result.data).toEqual(
@@ -153,7 +153,7 @@ describe("BranchNode Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.nodeId).toBeDefined();
+      
       
       // Validate data format - should be clean JSON, not protobuf structures
       expect(result.data).toEqual(
@@ -196,7 +196,7 @@ describe("BranchNode Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.nodeId).toBeDefined();
+      
       
       // Validate data format - should be clean JSON, not protobuf structures
       expect(result.data).toEqual(

--- a/tests/nodes/contractRead.test.ts
+++ b/tests/nodes/contractRead.test.ts
@@ -764,26 +764,25 @@ describe("ContractRead Node Tests", () => {
       const output = contractReadStep!.output as any;
       expect(output).toBeDefined();
       
-      // Verify structure has both data and metadata fields
+      // Output is the data object directly; metadata is step-level
       expect(typeof output).toBe("object");
       expect(output).not.toBeNull();
       expect(Array.isArray(output)).toBe(false);
-      expect(output).toHaveProperty("data");
-      expect(output).toHaveProperty("metadata");
+      expect(contractReadStep as any).toHaveProperty("metadata");
 
-      // Verify that the actual data fields are present in data field
-      expect(output.data.latestRoundData).toBeDefined();
-      expect(output.data.decimals).toBeDefined();
-      expect(output.data.latestRoundData).toHaveProperty("answer");
-      expect(output.data.latestRoundData).toHaveProperty("roundId");
-      expect(typeof output.data.decimals).toBe("string");
+      // Verify that the actual data fields are present directly on output
+      expect(output.latestRoundData).toBeDefined();
+      expect(output.decimals).toBeDefined();
+      expect(output.latestRoundData).toHaveProperty("answer");
+      expect(output.latestRoundData).toHaveProperty("roundId");
+      expect(typeof output.decimals).toBe("string");
 
       // 🔍 TYPE CHECK: Verify ABI type improvements are working in simulation mode
-      if (output.data.latestRoundData.answer) {
-        expect(typeof output.data.latestRoundData.answer).toBe("string"); // int256 -> string (large number)
+      if (output.latestRoundData.answer) {
+        expect(typeof output.latestRoundData.answer).toBe("string"); // int256 -> string (large number)
       }
-      if (output.data.latestRoundData.roundId) {
-        expect(typeof output.data.latestRoundData.roundId).toBe("string"); // uint80 -> string (large number)
+      if (output.latestRoundData.roundId) {
+        expect(typeof output.latestRoundData.roundId).toBe("string"); // uint80 -> string (large number)
       }
     });
 
@@ -844,25 +843,24 @@ describe("ContractRead Node Tests", () => {
       const output = contractReadStep!.output as any;
       expect(output).toBeDefined();
       
-      // Verify structure has both data and metadata fields
+      // Output is the data object directly; metadata is step-level
       expect(typeof output).toBe("object");
       expect(output).not.toBeNull();
       expect(Array.isArray(output)).toBe(false);
-      expect(output).toHaveProperty("data");
-      expect(output).toHaveProperty("metadata");
+      expect(contractReadStep as any).toHaveProperty("metadata");
 
-      // Verify that the actual data fields are present in data field
-      expect(output.data.latestRoundData).toBeDefined();
-      expect(output.data.decimals).toBeDefined();
-      expect(output.data.latestRoundData).toHaveProperty("answer");
-      expect(output.data.latestRoundData).toHaveProperty("roundId");
-      expect(typeof output.data.decimals).toBe("string");
+      // Verify that the actual data fields are present directly on output
+      expect(output.latestRoundData).toBeDefined();
+      expect(output.decimals).toBeDefined();
+      expect(output.latestRoundData).toHaveProperty("answer");
+      expect(output.latestRoundData).toHaveProperty("roundId");
+      expect(typeof output.decimals).toBe("string");
 
       // Check that decimal formatting was applied
-      if (output.data.latestRoundData.answer) {
+      if (output.latestRoundData.answer) {
         // 🔍 TYPE CHECK: Verify ABI type improvements are working in simulation mode
-        expect(typeof output.data.latestRoundData.answer).toBe("string");
-        expect(output.data.latestRoundData.answer).toMatch(/^\d+\.\d+$/); // Should be a decimal number
+        expect(typeof output.latestRoundData.answer).toBe("string");
+        expect(output.latestRoundData.answer).toMatch(/^\d+\.\d+$/); // Should be a decimal number
       }
     });
   });
@@ -960,16 +958,15 @@ describe("ContractRead Node Tests", () => {
         const output = contractReadStep.output as any;
         expect(output).toBeDefined();
         
-        // Verify structure has both data and metadata fields
+        // Output is the data object directly; metadata is step-level
         expect(typeof output).toBe("object");
         expect(output).not.toBeNull();
         expect(Array.isArray(output)).toBe(false);
-        expect(output).toHaveProperty("data");
-        expect(output).toHaveProperty("metadata");
+        expect(contractReadStep as any).toHaveProperty("metadata");
 
-        // Verify that the actual data fields are present in data field
-        expect(output.data.latestRoundData).toBeDefined();
-        expect(output.data.description).toBeDefined();
+        // Verify that the actual data fields are present directly on output
+        expect(output.latestRoundData).toBeDefined();
+        expect(output.description).toBeDefined();
       } finally {
         if (workflowId) {
           await client.deleteWorkflow(workflowId);
@@ -1077,29 +1074,28 @@ describe("ContractRead Node Tests", () => {
         const output = contractReadStep.output as any;
         expect(output).toBeDefined();
         
-        // Verify structure has both data and metadata fields
+        // Output is the data object directly; metadata is step-level
         expect(typeof output).toBe("object");
         expect(output).not.toBeNull();
         expect(Array.isArray(output)).toBe(false);
-        expect(output).toHaveProperty("data");
-        expect(output).toHaveProperty("metadata");
+        expect(contractReadStep as any).toHaveProperty("metadata");
 
-        // Verify that both method calls are included in the response in data field
-        expect(output.data.decimals).toBeDefined();
-        expect(output.data.latestRoundData).toBeDefined();
+        // Verify that both method calls are included directly on output
+        expect(output.decimals).toBeDefined();
+        expect(output.latestRoundData).toBeDefined();
 
         // Verify that decimals result contains the decimals value
-        expect(typeof output.data.decimals).toBe("string");
+        expect(typeof output.decimals).toBe("string");
 
         // Verify that latestRoundData result contains formatted values
-        expect(output.data.latestRoundData).toHaveProperty("answer");
-        expect(output.data.latestRoundData).toHaveProperty("roundId");
-        expect(output.data.latestRoundData).toHaveProperty("answeredInRound");
-        expect(output.data.latestRoundData).toHaveProperty("startedAt");
-        expect(output.data.latestRoundData).toHaveProperty("updatedAt");
+        expect(output.latestRoundData).toHaveProperty("answer");
+        expect(output.latestRoundData).toHaveProperty("roundId");
+        expect(output.latestRoundData).toHaveProperty("answeredInRound");
+        expect(output.latestRoundData).toHaveProperty("startedAt");
+        expect(output.latestRoundData).toHaveProperty("updatedAt");
 
         // Verify decimal formatting was applied to answer field
-        const answer = output.data.latestRoundData.answer;
+        const answer = output.latestRoundData.answer;
 
         expect(typeof answer).toBe("string");
 
@@ -1268,32 +1264,30 @@ describe("ContractRead Node Tests", () => {
         // Verify consistent structure
         const directOutput = directResponse.data; // runNodeWithInputs returns flattened data
         
-        // For simulateWorkflow/deployWorkflow, extract the data field for comparison
+        // For simulateWorkflow/deployWorkflow, outputs are the data objects directly
         const simulatedOutput = simulatedStep?.output as any;
         const executedOutput = executedStep?.output as any;
 
-        // Check that simulateWorkflow/deployWorkflow have both data and metadata fields
-        expect(simulatedOutput).toHaveProperty("data");
-        expect(simulatedOutput).toHaveProperty("metadata");
-        expect(executedOutput).toHaveProperty("data");
-        expect(executedOutput).toHaveProperty("metadata");
+        // Check that simulateWorkflow/deployWorkflow have step-level metadata property
+        expect(simulatedStep as any).toHaveProperty("metadata");
+        expect(executedStep as any).toHaveProperty("metadata");
 
-        // Check that all data outputs have the same structure - they should all be flattened objects
-        expect(typeof executedOutput.data).toBe("object");
-        expect(typeof simulatedOutput.data).toBe("object");
+        // Check that all outputs have the same structure - they should all be flattened objects
+        expect(typeof executedOutput).toBe("object");
+        expect(typeof simulatedOutput).toBe("object");
         expect(typeof directOutput).toBe("object");
-        expect(Array.isArray(executedOutput.data)).toBe(false);
-        expect(Array.isArray(simulatedOutput.data)).toBe(false);
+        expect(Array.isArray(executedOutput)).toBe(false);
+        expect(Array.isArray(simulatedOutput)).toBe(false);
         expect(Array.isArray(directOutput)).toBe(false);
 
         // Check that none of them have the old results wrapper
-        expect(executedOutput.data).not.toHaveProperty("results");
-        expect(simulatedOutput.data).not.toHaveProperty("results");
+        expect(executedOutput).not.toHaveProperty("results");
+        expect(simulatedOutput).not.toHaveProperty("results");
         expect(directOutput).not.toHaveProperty("results");
 
         // Check that all have the same method fields (flattened object format)
-        const simulatedKeys = Object.keys(simulatedOutput.data || {}).sort();
-        const executedKeys = Object.keys(executedOutput.data || {}).sort();
+        const simulatedKeys = Object.keys(simulatedOutput || {}).sort();
+        const executedKeys = Object.keys(executedOutput || {}).sort();
         const directKeys = Object.keys(directOutput || {}).sort();
 
         expect(simulatedKeys).toEqual(executedKeys);
@@ -1768,29 +1762,28 @@ describe("ContractRead Node Tests", () => {
       const output = contractReadStep!.output as any;
       expect(output).toBeDefined();
       
-      // Verify structure has both data and metadata fields
+      // Output is the data object directly; metadata is step-level
       expect(typeof output).toBe("object");
       expect(output).not.toBeNull();
       expect(Array.isArray(output)).toBe(false);
-      expect(output).toHaveProperty("data");
-      expect(output).toHaveProperty("metadata");
+      expect(contractReadStep as any).toHaveProperty("metadata");
 
-      // Verify that both method calls are included in the response in data field
-      expect(output.data.decimals).toBeDefined();
-      expect(output.data.latestRoundData).toBeDefined();
+      // Verify that both method calls are included directly on output
+      expect(output.decimals).toBeDefined();
+      expect(output.latestRoundData).toBeDefined();
 
       // Verify that decimals result contains the decimals value
-      expect(typeof output.data.decimals).toBe("string");
+      expect(typeof output.decimals).toBe("string");
 
       // Verify that latestRoundData result contains formatted values
-      expect(output.data.latestRoundData).toHaveProperty("answer");
-      expect(output.data.latestRoundData).toHaveProperty("roundId");
-      expect(output.data.latestRoundData).toHaveProperty("answeredInRound");
-      expect(output.data.latestRoundData).toHaveProperty("startedAt");
-      expect(output.data.latestRoundData).toHaveProperty("updatedAt");
+      expect(output.latestRoundData).toHaveProperty("answer");
+      expect(output.latestRoundData).toHaveProperty("roundId");
+      expect(output.latestRoundData).toHaveProperty("answeredInRound");
+      expect(output.latestRoundData).toHaveProperty("startedAt");
+      expect(output.latestRoundData).toHaveProperty("updatedAt");
 
       // Verify decimal formatting was applied to answer field
-      const answer = output.data.latestRoundData.answer;
+      const answer = output.latestRoundData.answer;
 
       expect(typeof answer).toBe("string");
 

--- a/tests/nodes/contractRead.test.ts
+++ b/tests/nodes/contractRead.test.ts
@@ -675,30 +675,31 @@ describe("ContractRead Node Tests", () => {
 
       const output = contractReadStep!.output as any;
       expect(output).toBeDefined();
-      
-      // Verify structure has both data and metadata fields
+
+      // Output should be a plain object containing method results directly
       expect(typeof output).toBe("object");
       expect(output).not.toBeNull();
       expect(Array.isArray(output)).toBe(false);
-      expect(output).toHaveProperty("data");
-      expect(output).toHaveProperty("metadata");
 
-      // Verify that both method calls are included in the response in data field
-      expect(output.data.decimals).toBeDefined();
-      expect(output.data.latestRoundData).toBeDefined();
+      // Verify both method calls are included directly on output
+      expect(output.decimals).toBeDefined();
+      expect(output.latestRoundData).toBeDefined();
 
       // Verify that decimals result contains the decimals value
-      expect(typeof output.data.decimals).toBe("string");
+      expect(typeof output.decimals).toBe("string");
 
       // Verify that latestRoundData result contains formatted values
-      expect(output.data.latestRoundData).toHaveProperty("answer");
-      expect(output.data.latestRoundData).toHaveProperty("roundId");
-      expect(output.data.latestRoundData).toHaveProperty("answeredInRound");
-      expect(output.data.latestRoundData).toHaveProperty("startedAt");
-      expect(output.data.latestRoundData).toHaveProperty("updatedAt");
+      expect(output.latestRoundData).toHaveProperty("answer");
+      expect(output.latestRoundData).toHaveProperty("roundId");
+      expect(output.latestRoundData).toHaveProperty("answeredInRound");
+      expect(output.latestRoundData).toHaveProperty("startedAt");
+      expect(output.latestRoundData).toHaveProperty("updatedAt");
 
       // Verify decimal formatting was applied to answer field
-      const answer = output.data.latestRoundData.answer;
+      const answer = output.latestRoundData.answer;
+
+      // Step-level metadata property should exist (may be undefined if backend didn't set it)
+      expect(contractReadStep as any).toHaveProperty("metadata");
 
       expect(typeof answer).toBe("string");
 

--- a/tests/nodes/contractRead.test.ts
+++ b/tests/nodes/contractRead.test.ts
@@ -16,6 +16,7 @@ import {
   removeCreatedWorkflows,
   getBlockNumber,
   SALT_BUCKET_SIZE,
+  resultIndicatesAllWritesSuccessful,
 } from "../utils/utils";
 import { defaultTriggerId, createFromTemplate } from "../utils/templates";
 import { getConfig, isSepolia } from "../utils/envalid";
@@ -443,7 +444,10 @@ describe("ContractRead Node Tests", () => {
         util.inspect(result, { depth: null, colors: true })
       );
 
+      // success must reflect per-method metadata/receipt outcomes
+
       expect(result.success).toBe(true);
+      expect(result.success).toBe(resultIndicatesAllWritesSuccessful(result as any));
       expect(result.data).toBeDefined();
       expect(result.metadata).toBeDefined();
 
@@ -567,7 +571,9 @@ describe("ContractRead Node Tests", () => {
         util.inspect(result, { depth: null, colors: true })
       );
 
+
       expect(result.success).toBe(true);
+      expect(result.success).toBe(resultIndicatesAllWritesSuccessful(result as any));
       expect(result.data).toBeDefined();
       expect(typeof result.data).toBe("object");
 
@@ -1530,6 +1536,7 @@ describe("ContractRead Node Tests", () => {
       );
 
       expect(result.success).toBe(true);
+      expect(result.success).toBe(resultIndicatesAllWritesSuccessful(result as any));
       expect(result.data).toBeDefined();
       expect(result.metadata).toBeDefined();
 
@@ -1654,6 +1661,7 @@ describe("ContractRead Node Tests", () => {
       );
 
       expect(result.success).toBe(true);
+      expect(result.success).toBe(resultIndicatesAllWritesSuccessful(result as any));
       expect(result.data).toBeDefined();
       expect(typeof result.data).toBe("object");
 

--- a/tests/nodes/contractRead.test.ts
+++ b/tests/nodes/contractRead.test.ts
@@ -194,7 +194,7 @@ describe("ContractRead Node Tests", () => {
         expect(data.latestRoundData.answeredInRound).toBeDefined();
       }
 
-      expect(result.nodeId).toBeDefined();
+      
     });
 
     test("should read multiple methods from contract", async () => {
@@ -233,7 +233,7 @@ describe("ContractRead Node Tests", () => {
       expect(typeof result.data).toBe("object");
       expect(result.data).not.toBeNull();
       expect(Array.isArray(result.data)).toBe(false);
-      expect(result.nodeId).toBeDefined();
+      
 
       // Check that we got results for both methods in flattened format
       const data = result.data as Record<string, any>;
@@ -373,7 +373,7 @@ describe("ContractRead Node Tests", () => {
       expect(typeof result.data).toBe("object");
       expect(result.data).not.toBeNull();
       expect(Array.isArray(result.data)).toBe(false);
-      expect(result.nodeId).toBeDefined();
+      
 
       // Check that we got results for the description method in flattened format
       const data = result.data as Record<string, any>;

--- a/tests/nodes/contractWrite.test.ts
+++ b/tests/nodes/contractWrite.test.ts
@@ -584,20 +584,19 @@ describe("ContractWrite Node Tests", () => {
       expect(Array.isArray(output)).toBe(false); // Should be flattened object, not array
       expect(output).not.toHaveProperty("results");
 
-      // Verify structure has both data and metadata fields
-      expect(output).toHaveProperty("data");
-      expect(output).toHaveProperty("metadata");
+      // Verify flattened structure by method name directly on output
+      expect(output).toHaveProperty("approve");
+      expect(output).toHaveProperty("transfer");
+      expect(typeof output.approve).toBe("object");
+      expect(typeof output.transfer).toBe("object");
 
-      // Verify flattened structure by method name in data field
-      expect(output.data).toHaveProperty("approve");
-      expect(output.data).toHaveProperty("transfer");
-      expect(typeof output.data.approve).toBe("object");
-      expect(typeof output.data.transfer).toBe("object");
-
-      // Should have same number of methods as methodCalls in data field
-      expect(Object.keys(output.data).length).toBe(
+      // Should have same number of methods as methodCalls
+      expect(Object.keys(output).length).toBe(
         (contractWriteNode.data as any).methodCalls.length
       );
+
+      // Step-level metadata property should exist (may be undefined if backend didn't set it)
+      expect(contractWriteStep as any).toHaveProperty("metadata");
     });
   });
 

--- a/tests/nodes/contractWrite.test.ts
+++ b/tests/nodes/contractWrite.test.ts
@@ -761,14 +761,7 @@ describe("ContractWrite Node Tests", () => {
 
         // Note: The step might succeed or fail depending on wallet funding and gas
         // step success must reflect metadata/receipt success
-      // Return true if any metadata item indicates a failed write (success === false or receipt.status === "0x0")
-      const stepFail =
-          (contractWriteStep as any).metadata &&
-          Array.isArray((contractWriteStep as any).metadata) &&
-          (contractWriteStep as any).metadata.some(
-            (m: any) =>
-              m.success === false || (m.receipt && m.receipt.status === "0x0")
-          );
+        const stepFail = stepIndicatesWriteFailure(contractWriteStep as any);
         expect(contractWriteStep.success).toBe(!stepFail);
       } finally {
         if (workflowId) {
@@ -1539,14 +1532,7 @@ describe("ContractWrite Node Tests", () => {
           }
         }
 
-      // Return true if any metadata item indicates a failed write (success === false or receipt.status === "0x0")
-      const stepFail2 =
-          (contractWriteStep as any).metadata &&
-          Array.isArray((contractWriteStep as any).metadata) &&
-          (contractWriteStep as any).metadata.some(
-            (m: any) =>
-              m.success === false || (m.receipt && m.receipt.status === "0x0")
-          );
+      const stepFail2 = stepIndicatesWriteFailure(contractWriteStep as any);
         expect(contractWriteStep.success).toBe(!stepFail2);
       } finally {
         if (workflowId) {

--- a/tests/nodes/contractWrite.test.ts
+++ b/tests/nodes/contractWrite.test.ts
@@ -679,16 +679,16 @@ describe("ContractWrite Node Tests", () => {
         expect(Array.isArray(output)).toBe(false); // Should be flattened object, not array
         expect(output).not.toHaveProperty("results");
 
-        // Verify structure has both data and metadata fields
-        expect(output).toHaveProperty("data");
-        expect(output).toHaveProperty("metadata");
+        // Output is the data object directly; metadata is step-level
+        expect(typeof output).toBe("object");
+        expect(contractWriteStep as any).toHaveProperty("metadata");
 
         // Verify flattened structure by method name - this test only has approve
-        expect(output.data).toHaveProperty("approve");
-        expect(typeof output.data.approve).toBe("object");
+        expect(output).toHaveProperty("approve");
+        expect(typeof output.approve).toBe("object");
 
-        // Should have same number of methods as methodCalls in data field
-        expect(Object.keys(output.data).length).toBe(
+        // Should have same number of methods as methodCalls
+        expect(Object.keys(output).length).toBe(
           (contractWriteNode.data as any).methodCalls.length
         );
 
@@ -839,16 +839,16 @@ describe("ContractWrite Node Tests", () => {
           contractWriteConfig.methodCalls.length
         );
 
-        // 🚀 NEW: Verify simulatedOutput and executedOutput have both data and metadata fields
-        expect(simulatedOutput).toHaveProperty("data");
-        expect(simulatedOutput).toHaveProperty("metadata");
-        expect(executedOutput).toHaveProperty("data");
-        expect(executedOutput).toHaveProperty("metadata");
+        // Output should be the data object directly; metadata is step-level
+        expect(typeof simulatedOutput).toBe("object");
+        expect(typeof executedOutput).toBe("object");
+        expect(simulatedStep as any).toHaveProperty("metadata");
+        expect(executedStep as any).toHaveProperty("metadata");
 
         // Verify all outputs have the same method names (keys) in their data fields
         const directDataKeys = Object.keys(directData).sort();
-        const simulatedDataKeys = Object.keys(simulatedOutput.data).sort();
-        const executedDataKeys = Object.keys(executedOutput.data).sort();
+        const simulatedDataKeys = Object.keys(simulatedOutput || {}).sort();
+        const executedDataKeys = Object.keys(executedOutput || {}).sort();
 
         expect(directDataKeys).toEqual(simulatedDataKeys);
         expect(simulatedDataKeys).toEqual(executedDataKeys);
@@ -857,13 +857,13 @@ describe("ContractWrite Node Tests", () => {
         for (const methodName of directDataKeys) {
           // All should have the same method represented in their data fields
           expect(directData[methodName]).toBeDefined();
-          expect(simulatedOutput.data[methodName]).toBeDefined();
-          expect(executedOutput.data[methodName]).toBeDefined();
+          expect(simulatedOutput[methodName]).toBeDefined();
+          expect(executedOutput[methodName]).toBeDefined();
 
           // All should be objects (decoded events)
           expect(typeof directData[methodName]).toBe("object");
-          expect(typeof simulatedOutput.data[methodName]).toBe("object");
-          expect(typeof executedOutput.data[methodName]).toBe("object");
+          expect(typeof simulatedOutput[methodName]).toBe("object");
+          expect(typeof executedOutput[methodName]).toBe("object");
         }
 
         // Verify consistent structure
@@ -879,13 +879,9 @@ describe("ContractWrite Node Tests", () => {
 
         // simulateWorkflow and deployWorkflow should have object structure with data and metadata
         expect(typeof simulatedStep?.output).toBe("object");
-        expect(Array.isArray(simulatedStep?.output)).toBe(false); // Should be object with data/metadata
-        expect(simulatedStep?.output).toHaveProperty("data");
-        expect(simulatedStep?.output).toHaveProperty("metadata");
+        expect(Array.isArray(simulatedStep?.output)).toBe(false);
         expect(typeof executedStep?.output).toBe("object");
-        expect(Array.isArray(executedStep?.output)).toBe(false); // Should be object with data/metadata
-        expect(executedStep?.output).toHaveProperty("data");
-        expect(executedStep?.output).toHaveProperty("metadata");
+        expect(Array.isArray(executedStep?.output)).toBe(false);
 
         // Check that all have the same method names
         const directMethods = (directResponse.metadata as any[])
@@ -1172,21 +1168,21 @@ describe("ContractWrite Node Tests", () => {
       expect(Array.isArray(output)).toBe(false); // Should be flattened object, not array
       expect(output).not.toHaveProperty("results");
 
-      // Verify structure has both data and metadata fields
-      expect(output).toHaveProperty("data");
-      expect(output).toHaveProperty("metadata");
+      // Output is the data object directly; metadata is step-level
+      expect(typeof output).toBe("object");
+      expect(contractWriteStep as any).toHaveProperty("metadata");
 
       // Verify flattened structure by method name - this test only has approve
-      expect(output.data).toHaveProperty("approve");
-      expect(typeof output.data.approve).toBe("object");
+      expect(output).toHaveProperty("approve");
+      expect(typeof output.approve).toBe("object");
 
-      // Should have same number of methods as methodCalls in data field
-      expect(Object.keys(output.data).length).toBe(
+      // Should have same number of methods as methodCalls
+      expect(Object.keys(output).length).toBe(
         (contractWriteNode.data as any).methodCalls.length
       );
 
       // Access the approve result directly from flattened structure
-      const approveResult = output.data.approve;
+      const approveResult = output.approve;
       expect(approveResult).toBeDefined();
       expect(typeof approveResult).toBe("object");
     });
@@ -1271,21 +1267,21 @@ describe("ContractWrite Node Tests", () => {
         expect(Array.isArray(output)).toBe(false); // Should be flattened object, not array
         expect(output).not.toHaveProperty("results");
 
-        // Verify structure has both data and metadata fields
-        expect(output).toHaveProperty("data");
-        expect(output).toHaveProperty("metadata");
+        // Output is the data object directly; metadata is step-level
+        expect(typeof output).toBe("object");
+        expect(contractWriteStep as any).toHaveProperty("metadata");
 
         // Verify flattened structure by method name - this test only has approve
-        expect(output.data).toHaveProperty("approve");
-        expect(typeof output.data.approve).toBe("object");
+        expect(output).toHaveProperty("approve");
+        expect(typeof output.approve).toBe("object");
 
-        // Should have same number of methods as methodCalls in data field
-        expect(Object.keys(output.data).length).toBe(
+        // Should have same number of methods as methodCalls
+        expect(Object.keys(output).length).toBe(
           (contractWriteNode.data as any).methodCalls.length
         );
 
         // Access the approve result directly from flattened structure
-        const approveResult = output.data.approve;
+        const approveResult = output.approve;
         expect(approveResult).toBeDefined();
         expect(typeof approveResult).toBe("object");
       } finally {

--- a/tests/nodes/contractWrite.test.ts
+++ b/tests/nodes/contractWrite.test.ts
@@ -232,7 +232,7 @@ describe("ContractWrite Node Tests", () => {
 
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.nodeId).toBeDefined();
+      
       expect(result.data).toBeDefined();
 
       // NEW: Check new response structure with data and metadata at top level
@@ -597,6 +597,12 @@ describe("ContractWrite Node Tests", () => {
 
       // Step-level metadata property should exist (may be undefined if backend didn't set it)
       expect(contractWriteStep as any).toHaveProperty("metadata");
+
+      // Execution context: should indicate simulated run with provider tenderly
+      expect((contractWriteStep as any).executionContext).toBeDefined();
+      const ctx = (contractWriteStep as any).executionContext as any;
+      expect(ctx.is_simulated).toBe(true);
+      expect(ctx.provider).toBe("tenderly");
     });
   });
 

--- a/tests/nodes/customCode.test.ts
+++ b/tests/nodes/customCode.test.ts
@@ -79,7 +79,7 @@ describe("CustomCode Node Tests", () => {
       return {
         inputData: inputData,
         processedData: inputData.map(item => item * 2),
-        metadata: {
+        stats: {
           count: inputData.length,
           sum: inputData.reduce((a, b) => a + b, 0)
         }
@@ -101,7 +101,7 @@ describe("CustomCode Node Tests", () => {
             preferences: userPreferences
           }
         },
-        metadata: {
+        details: {
           timestamp: new Date().toISOString(),
           processed: true,
           version: "1.0.0"
@@ -274,11 +274,13 @@ describe("CustomCode Node Tests", () => {
       expect(result.data).toEqual({
         inputData: [1, 2, 3, 4, 5],
         processedData: [2, 4, 6, 8, 10],
-        metadata: {
+        stats: {
           count: 5,
           sum: 15,
         },
       });
+      expect(result.executionContext).toBeDefined();
+      expect(result.executionContext!.isSimulated).toBe(true);
     });
 
     test("CustomCode should handle complex object with nested data", async () => {
@@ -307,7 +309,7 @@ describe("CustomCode Node Tests", () => {
             preferences: { theme: "dark", notifications: true },
           },
         },
-        metadata: {
+        details: {
           timestamp: expect.any(String),
           processed: true,
           version: "1.0.0",
@@ -318,6 +320,8 @@ describe("CustomCode Node Tests", () => {
           conversionRate: 0.75,
         },
       });
+      expect(result.executionContext).toBeDefined();
+      expect(result.executionContext!.isSimulated).toBe(true);
     });
   });
 

--- a/tests/nodes/customCode.test.ts
+++ b/tests/nodes/customCode.test.ts
@@ -353,7 +353,7 @@ describe("CustomCode Node Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBe(30);
-      expect(result.nodeId).toBeDefined();
+      
     });
 
     test("should execute JavaScript with lodash module", async () => {
@@ -391,7 +391,7 @@ describe("CustomCode Node Tests", () => {
       expect(data).toBeDefined();
       expect(data.sum).toBe(21);
       expect(data.max).toBe(6);
-      expect(result.nodeId).toBeDefined();
+      
     });
 
     test("should execute JavaScript with date manipulation", async () => {
@@ -430,7 +430,7 @@ describe("CustomCode Node Tests", () => {
       expect(data).toBeDefined();
       expect(data.formatted).toBe("2023-12-25");
       expect(data.addDays).toBe("2024-01-01");
-      expect(result.nodeId).toBeDefined();
+      
     });
 
     test("should handle error in custom code execution", async () => {

--- a/tests/nodes/filterNode.test.ts
+++ b/tests/nodes/filterNode.test.ts
@@ -68,7 +68,7 @@ describe("FilterNode Tests", () => {
       expect(typeof result.success).toBe("boolean");
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.nodeId).toBeDefined();
+      
       expect(Array.isArray(result.data)).toBe(true);
       expect(result.data.length).toBe(2);
     });
@@ -93,7 +93,7 @@ describe("FilterNode Tests", () => {
       expect(typeof result.success).toBe("boolean");
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.nodeId).toBeDefined();
+      
       expect(Array.isArray(result.data)).toBe(true);
       expect(result.data.length).toBe(1);
     });
@@ -118,7 +118,7 @@ describe("FilterNode Tests", () => {
       expect(typeof result.success).toBe("boolean");
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.nodeId).toBeDefined();
+      
       expect(Array.isArray(result.data)).toBe(true);
       expect(result.data.length).toBe(2);
     });
@@ -148,7 +148,7 @@ describe("FilterNode Tests", () => {
       expect(typeof result.success).toBe("boolean");
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.nodeId).toBeDefined();
+      
       expect(Array.isArray(result.data)).toBe(true);
       expect(result.data.length).toBe(2);
     });

--- a/tests/nodes/graphqlQuery.test.ts
+++ b/tests/nodes/graphqlQuery.test.ts
@@ -174,7 +174,7 @@ describe("GraphQL Query Node Tests", () => {
       // Verify the response structure (should fail due to network but show GraphQL implementation works)
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.nodeId).toBeDefined();
+      
 
       // The request should fail due to network (mock endpoint doesn't exist)
       // but this proves GraphQL node creation and execution pipeline is working

--- a/tests/nodes/loopNode.test.ts
+++ b/tests/nodes/loopNode.test.ts
@@ -220,7 +220,7 @@ describe("LoopNode Tests", () => {
       // With the consistency fix, result.data is now the array directly
       expect(Array.isArray(result.data)).toBe(true);
       expect((result.data as ProcessedLoopItem[]).length).toBe(5);
-      expect(result.nodeId).toBeDefined();
+      
 
       // Check first processed item
       const firstItem = (
@@ -263,7 +263,7 @@ describe("LoopNode Tests", () => {
       // With the consistency fix, result.data is now the array directly
       expect(Array.isArray(result.data)).toBe(true);
       expect((result.data as Record<string, unknown>[]).length).toBe(2);
-      expect(result.nodeId).toBeDefined();
+      
 
       // Check that each item has the expected structure
       const firstItem = (result.data as Record<string, unknown>[])[0] as Record<
@@ -302,7 +302,7 @@ describe("LoopNode Tests", () => {
       // With the consistency fix, result.data is now the array directly
       expect(Array.isArray(result.data)).toBe(true);
       expect((result.data as ProcessedLoopItem[]).length).toBe(0);
-      expect(result.nodeId).toBeDefined();
+      
     });
 
     test("should handle complex object array", async () => {
@@ -338,7 +338,7 @@ describe("LoopNode Tests", () => {
       // With the consistency fix, result.data is now the array directly
       expect(Array.isArray(result.data)).toBe(true);
       expect((result.data as ProcessedLoopItem[]).length).toBe(3);
-      expect(result.nodeId).toBeDefined();
+      
 
       const firstResult = (
         result.data as ProcessedLoopItem[]
@@ -404,7 +404,7 @@ describe("LoopNode Tests", () => {
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
       expect(result.data).toBeDefined();
-      expect(result.nodeId).toBeDefined();
+      
 
       // Note: The test may fail due to contract validation or network issues,
       // but the important part is that the backend now supports contractRead as a loop runner
@@ -475,7 +475,7 @@ describe("LoopNode Tests", () => {
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
       expect(result.data).toBeDefined();
-      expect(result.nodeId).toBeDefined();
+      
 
       // Note: The test may fail due to contract validation or network issues,
       // but the important part is that the backend now supports contractWrite as a loop runner

--- a/tests/templates/exported-workflow-consistency.test.ts
+++ b/tests/templates/exported-workflow-consistency.test.ts
@@ -128,7 +128,7 @@ describe("Exported Workflow Consistency Tests", () => {
       expect(result.success).toBe(true);
       expect(Array.isArray(result.data)).toBe(true);
       expect(result.data).toEqual(["value1", "value2"]); // Should return array of key values
-      expect(result.nodeId).toBeDefined();
+      
     });
 
     test("should test FilterNode with inputNodeName", async () => {
@@ -153,7 +153,7 @@ describe("Exported Workflow Consistency Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toEqual([{ key: "value1" }]); // FilterNode now returns array of filtered items
-      expect(result.nodeId).toBeDefined();
+      
     });
 
     test("should test CustomCode node accessing trigger data", async () => {
@@ -180,7 +180,7 @@ describe("Exported Workflow Consistency Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toEqual(inputData); // Should return the trigger data
-      expect(result.nodeId).toBeDefined();
+      
     });
   });
 

--- a/tests/templates/exported-workflow-consistency.test.ts
+++ b/tests/templates/exported-workflow-consistency.test.ts
@@ -82,7 +82,6 @@ describe("Exported Workflow Consistency Tests", () => {
         headers: { headerKey: "headerValue" },
         pathParams: { pathKey: "pathValue" },
       });
-      expect(result.triggerId).toBeDefined();
     });
 
     test("should test LoopNode with CustomCode runner", async () => {
@@ -128,7 +127,6 @@ describe("Exported Workflow Consistency Tests", () => {
       expect(result.success).toBe(true);
       expect(Array.isArray(result.data)).toBe(true);
       expect(result.data).toEqual(["value1", "value2"]); // Should return array of key values
-      
     });
 
     test("should test FilterNode with inputNodeName", async () => {
@@ -153,7 +151,6 @@ describe("Exported Workflow Consistency Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toEqual([{ key: "value1" }]); // FilterNode now returns array of filtered items
-      
     });
 
     test("should test CustomCode node accessing trigger data", async () => {
@@ -180,7 +177,6 @@ describe("Exported Workflow Consistency Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toEqual(inputData); // Should return the trigger data
-      
     });
   });
 

--- a/tests/templates/telegram-alert-on-transfer.test.ts
+++ b/tests/templates/telegram-alert-on-transfer.test.ts
@@ -284,7 +284,7 @@ return message;`,
 
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.triggerId).toBeDefined();
+      
 
       // For event triggers, no matching events is a valid outcome
       expect(result.success).toBe(true);

--- a/tests/triggers/block.test.ts
+++ b/tests/triggers/block.test.ts
@@ -214,7 +214,7 @@ describe("BlockTrigger Tests", () => {
       expect(typeof result.success).toBe("boolean");
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
 
     test("should run trigger with medium interval", async () => {
@@ -234,7 +234,7 @@ describe("BlockTrigger Tests", () => {
       expect(typeof result.success).toBe("boolean");
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
 
     test("should run trigger with large interval", async () => {
@@ -254,7 +254,7 @@ describe("BlockTrigger Tests", () => {
       expect(typeof result.success).toBe("boolean");
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
 
     test("should run trigger with single block interval", async () => {
@@ -274,7 +274,7 @@ describe("BlockTrigger Tests", () => {
       expect(typeof result.success).toBe("boolean");
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
   });
 

--- a/tests/triggers/cron.test.ts
+++ b/tests/triggers/cron.test.ts
@@ -241,7 +241,7 @@ describe("CronTrigger Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
 
     test("should run trigger with hourly schedule", async () => {
@@ -260,7 +260,7 @@ describe("CronTrigger Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
 
     test("should run trigger with every 15 minutes schedule", async () => {
@@ -279,7 +279,7 @@ describe("CronTrigger Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
 
     test("should run trigger with complex schedule", async () => {
@@ -298,7 +298,7 @@ describe("CronTrigger Tests", () => {
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
 
     test("should run trigger with minute-based schedule", async () => {
@@ -317,7 +317,7 @@ describe("CronTrigger Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
 
     test("should run trigger with weekly schedule", async () => {
@@ -336,7 +336,7 @@ describe("CronTrigger Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
 
     test("should handle standard cron expressions", async () => {
@@ -391,7 +391,7 @@ describe("CronTrigger Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
 
     test("should handle step values in cron expressions", async () => {
@@ -410,7 +410,7 @@ describe("CronTrigger Tests", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.triggerId).toBeDefined();
+      
     });
 
     test("should validate cron expression format in TriggerFactory", () => {

--- a/tests/triggers/eventTrigger.test.ts
+++ b/tests/triggers/eventTrigger.test.ts
@@ -401,7 +401,7 @@ describe("EventTrigger Tests", () => {
 
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.triggerId).toBeDefined();
+      
       expect(result.metadata).toBeDefined();
 
       // For specific address filters, no matching events is a valid outcome
@@ -452,7 +452,7 @@ describe("EventTrigger Tests", () => {
 
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.triggerId).toBeDefined();
+      
       expect(result.metadata).toBeDefined();
 
       // For specific address filters, no matching events is a valid outcome
@@ -488,7 +488,7 @@ describe("EventTrigger Tests", () => {
 
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.triggerId).toBeDefined();
+      
 
       // For specific address filters, no matching events is a valid outcome
       expect(result.success).toBe(true);
@@ -526,7 +526,7 @@ describe("EventTrigger Tests", () => {
 
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.triggerId).toBeDefined();
+      
       expect(result.metadata).toBeDefined();
 
       // Conditions filter events, so no matching events is expected when condition is not met
@@ -591,7 +591,7 @@ describe("EventTrigger Tests", () => {
 
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.triggerId).toBeDefined();
+      
 
       expect(result.success).toBe(true);
       // Data can be null (no events found) or an object (events found)
@@ -654,7 +654,7 @@ describe("EventTrigger Tests", () => {
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
       expect(result.error).toBe("");
-      expect(result.triggerId).toBeDefined();
+      
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
@@ -1732,7 +1732,7 @@ describe("EventTrigger Tests", () => {
 
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.triggerId).toBeDefined();
+      
 
       // For specific filters like minting events, no matching events is expected
       expect(result.success).toBe(true);
@@ -1785,7 +1785,6 @@ describe("EventTrigger Tests", () => {
       expect(noEventsResult.success).toBe(true);
       expect(noEventsResult.error).toBe("");
       expect(noEventsResult.data).toBe(null);
-      expect(noEventsResult.triggerId).toBeDefined();
     });
 
     test("should handle empty address arrays consistently", async () => {
@@ -1819,7 +1818,7 @@ describe("EventTrigger Tests", () => {
 
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.triggerId).toBeDefined();
+      
 
       // Should either succeed with broad monitoring or handle gracefully
       expect(result.success).toBe(true);
@@ -1859,7 +1858,7 @@ describe("EventTrigger Tests", () => {
 
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.triggerId).toBeDefined();
+      
 
       // Should handle empty topics gracefully
       expect(result.success).toBe(true);
@@ -1973,7 +1972,7 @@ describe("EventTrigger Tests", () => {
 
       expect(result).toBeDefined();
       expect(typeof result.success).toBe("boolean");
-      expect(result.triggerId).toBeDefined();
+      
 
       // Should handle gracefully - either succeed with null data or fail with error
       expect(result.success).toBe(true);

--- a/tests/utils/envalid.ts
+++ b/tests/utils/envalid.ts
@@ -15,6 +15,11 @@ const ALLOWED_ENVIRONMENTS = [
 ] as const;
 type Environment = (typeof ALLOWED_ENVIRONMENTS)[number];
 
+type OracleDef = {
+  address: string;
+  pair: string;
+};
+
 // Token configuration types
 type TokenDef = {
   address: string;
@@ -22,15 +27,18 @@ type TokenDef = {
   symbol: string;
   decimals: number;
 };
+
 type TokenMap = Record<string, TokenDef>;
+type OracleMap = Record<string, OracleDef>;
 
 // Environment-specific configurations (with chain-specific token presets)
-const ENV_CONFIGS: Record<
+export const ENV_CONFIGS: Record<
   Environment,
   {
     avsEndpoint: string;
     chainId: string;
     tokens: TokenMap;
+    oracles: OracleMap;
     factoryAddress: string;
   }
 > = {
@@ -51,6 +59,16 @@ const ENV_CONFIGS: Record<
         decimals: 18,
       },
     },
+    oracles: {
+      "BTC / USD": {
+        pair: "BTC / USD",
+        address: "0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43",
+      },
+      "ETH / USD": {
+        pair: "ETH / USD",
+        address: "0x694AA1769357215DE4FAC081bf1f309aDC325306",
+      },
+    },
     // From docs/Contract.md Factory Proxy
     factoryAddress: "0xB99BC2E399e06CddCF5E725c0ea341E8f0322834",
   },
@@ -58,6 +76,7 @@ const ENV_CONFIGS: Record<
     avsEndpoint: "aggregator.avaprotocol.org:2206",
     chainId: "1",
     tokens: {},
+    oracles: {},
     factoryAddress: "0xB99BC2E399e06CddCF5E725c0ea341E8f0322834",
   },
   sepolia: {
@@ -77,42 +96,49 @@ const ENV_CONFIGS: Record<
         decimals: 18,
       },
     },
+    oracles: {},
     factoryAddress: "0xB99BC2E399e06CddCF5E725c0ea341E8f0322834",
   },
   base: {
     avsEndpoint: "aggregator-base.avaprotocol.org:3206", // TODO:Change to 2207
     chainId: "8453",
     tokens: {},
+    oracles: {},
     factoryAddress: "0xB99BC2E399e06CddCF5E725c0ea341E8f0322834",
   },
   "base-sepolia": {
     avsEndpoint: "aggregator-base-sepolia.avaprotocol.org:3206", // TODO:Change to 2207
     chainId: "84532",
     tokens: {},
+    oracles: {},
     factoryAddress: "0xB99BC2E399e06CddCF5E725c0ea341E8f0322834",
   },
   soneium: {
     avsEndpoint: "aggregator-soneium.avaprotocol.org:2208",
     chainId: "1868",
     tokens: {},
+    oracles: {},
     factoryAddress: "0xB99BC2E399e06CddCF5E725c0ea341E8f0322834",
   },
   "soneium-minato": {
     avsEndpoint: "aggregator-soneium-minato.avaprotocol.org:2208",
     chainId: "1946",
     tokens: {},
+    oracles: {},
     factoryAddress: "0xB99BC2E399e06CddCF5E725c0ea341E8f0322834",
   },
   bsc: {
     avsEndpoint: "aggregator-bsc.avaprotocol.org:2209",
     chainId: "56",
     tokens: {},
+    oracles: {},
     factoryAddress: "0xB99BC2E399e06CddCF5E725c0ea341E8f0322834",
   },
   "bsc-testnet": {
     avsEndpoint: "aggregator-bsc-testnet.avaprotocol.org:2209",
     chainId: "97",
     tokens: {},
+    oracles: {},
     factoryAddress: "0xB99BC2E399e06CddCF5E725c0ea341E8f0322834",
   },
 } as const;
@@ -181,6 +207,7 @@ export const getConfig = () => ({
   // factoryAddress: FACTORY_ADDRESS, // Let aggregator use its default factory
   environment: validatedEnv.TEST_ENV,
   tokens: envConfig.tokens,
+  oracles: envConfig.oracles,
   factoryAddress: envConfig.factoryAddress,
 });
 

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -86,7 +86,7 @@ export async function generateAuthPayloadWithApiKey(
 
     const { message } = await client.getSignatureFormat(address);
     return { message, apiKey };
-  } catch (_) {
+  } catch (error) {
     console.warn("GetSignatureFormat not available, using fallback format");
     const now = Date.now();
     const message = `Please sign the below text for ownership verification.

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -79,14 +79,14 @@ export async function generateAuthPayloadWithApiKey(
   address: string,
   apiKey: string
 ): Promise<GetKeyRequestApiKey> {
-  try {;
+  try {
     const client = new Client({
       endpoint: config.avsEndpoint,
     });
 
     const { message } = await client.getSignatureFormat(address);
     return { message, apiKey };
-  } catch (error) {
+  } catch (_) {
     console.warn("GetSignatureFormat not available, using fallback format");
     const now = Date.now();
     const message = `Please sign the below text for ownership verification.
@@ -153,8 +153,8 @@ export const cleanupWorkflows = async (
   // Filter out undefined ids and convert the array to a Map
   const workflowIds = new Map(
     workflowArray.items
-      .filter((item: any) => item.id !== undefined)
-      .map((item: any) => [item.id as string, false])
+      .filter((item: { id?: string }) => item.id !== undefined)
+      .map((item: { id?: string }) => [item.id as string, false])
   );
 
   await removeCreatedWorkflows(client, workflowIds);
@@ -220,16 +220,18 @@ export const getBlockNumber = async (): Promise<number> => {
       ),
     ]);
     return blockNumber;
-  } catch (error: any) {
+  } catch (error: unknown) {
     throw new Error(
-      `Failed to get block number: ${error?.message || "Unknown error"}`
+      `Failed to get block number: ${
+        (error as { message?: string })?.message || "Unknown error"
+      }`
     );
   }
 };
 
 export const getChainId = async (): Promise<number> => {
-  const config = getTestConfig();
-  const provider = new ethers.JsonRpcProvider(config.chainEndpoint);
+  const cfg = getConfig();
+  const provider = new ethers.JsonRpcProvider(cfg.chainEndpoint);
   try {
     // Set a 5 second timeout for the connection
     const network = await Promise.race<ethers.Network>([
@@ -239,12 +241,57 @@ export const getChainId = async (): Promise<number> => {
       ),
     ]);
     return Number(network.chainId);
-  } catch (error: any) {
+  } catch (error: unknown) {
     throw new Error(
-      `Failed to get chain ID: ${error?.message || "Unknown error"}`
+      `Failed to get chain ID: ${
+        (error as { message?: string })?.message || "Unknown error"
+      }`
     );
   }
 };
+
+// ===== Test helpers for blockchain write success/failure checks =====
+
+type ReceiptLike = { status?: string } | null | undefined;
+type MethodMetadataLike =
+  | { success?: boolean; receipt?: ReceiptLike }
+  | null
+  | undefined;
+
+/**
+ * Return true if any metadata item indicates a failed write
+ * (success === false or receipt.status === "0x0").
+ */
+export function hasWriteFailureFromMetadata(metadata: unknown): boolean {
+  if (!Array.isArray(metadata)) return false;
+  return (metadata as MethodMetadataLike[]).some(
+    (m) =>
+      !!m && (m.success === false || (m.receipt && m.receipt.status === "0x0"))
+  );
+}
+
+/** Return true if a step has metadata that indicates a failed write. */
+export function stepIndicatesWriteFailure(
+  step: { metadata?: unknown } | null | undefined
+): boolean {
+  if (!step || step.metadata === undefined) return false;
+  return hasWriteFailureFromMetadata(step.metadata);
+}
+
+/**
+ * Return true if any ContractWrite step in an execution indicates a failed write.
+ */
+export function executionHasWriteFailure(
+  execution:
+    | { steps?: Array<{ type?: string; metadata?: unknown }> }
+    | null
+    | undefined
+): boolean {
+  if (!execution || !Array.isArray(execution.steps)) return false;
+  return execution.steps
+    .filter((s) => s && s.type === "contractWrite")
+    .some((s) => hasWriteFailureFromMetadata(s.metadata));
+}
 
 export const verifyExecutionStepResults = (
   expected: StepProps,

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -15,9 +15,6 @@ export const TIMEOUT_DURATION = 60000; // 60 seconds to reduce flaky timeouts
 // Salt bucket size per suite to ensure total salts < 2000
 export const SALT_BUCKET_SIZE = 20;
 
-// Salt bucket size per suite to ensure total salts < 2000
-export const SALT_BUCKET_SIZE = 20;
-
 // Test addresses
 export const TEST_SMART_WALLET_ADDRESS =
   "0x6C6244dFd5d0bA3230B6600bFA380f0bB4E8AC49"; // User's test smart wallet with ETH and USDC on Sepolia

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -15,6 +15,9 @@ export const TIMEOUT_DURATION = 60000; // 60 seconds to reduce flaky timeouts
 // Salt bucket size per suite to ensure total salts < 2000
 export const SALT_BUCKET_SIZE = 20;
 
+// Salt bucket size per suite to ensure total salts < 2000
+export const SALT_BUCKET_SIZE = 20;
+
 // Test addresses
 export const TEST_SMART_WALLET_ADDRESS =
   "0x6C6244dFd5d0bA3230B6600bFA380f0bB4E8AC49"; // User's test smart wallet with ETH and USDC on Sepolia

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -270,6 +270,24 @@ export function hasWriteFailureFromMetadata(metadata: unknown): boolean {
   );
 }
 
+/** Return true if every metadata item indicates a successful write. */
+export function metadataIndicatesAllWritesSuccessful(
+  metadata: unknown
+): boolean {
+  if (!Array.isArray(metadata)) return true;
+  return (metadata as MethodMetadataLike[]).every(
+    (m) => !!m && m.success === true && (!m.receipt || m.receipt.status === "0x1")
+  );
+}
+
+/** Return true if the given result object has metadata and it indicates all writes succeeded. */
+export function resultIndicatesAllWritesSuccessful(
+  result: { metadata?: unknown } | null | undefined
+): boolean {
+  if (!result || result.metadata === undefined) return true;
+  return metadataIndicatesAllWritesSuccessful(result.metadata);
+}
+
 /** Return true if a step has metadata that indicates a failed write. */
 export function stepIndicatesWriteFailure(
   step: { metadata?: unknown } | null | undefined


### PR DESCRIPTION
This pull request refactors how step output and metadata are handled in the SDK and updates the ContractRead/ContractWrite node output structure for consistency. Now, output data is returned as a flattened object (without nested `data` or `metadata` fields), and step-level metadata is exposed as a separate property. Tests are updated to reflect and verify this new structure.

**SDK and Types Refactor:**

- The `Step` class and `StepProps` type now include an optional `metadata` property, and the constructor and serialization logic are updated to support it. Step-level metadata is extracted from protobuf responses if present. [[1]](diffhunk://#diff-56e524d53172c89dc6108944b18d0760951522209c3689453710762bfa8cd1f3R21) [[2]](diffhunk://#diff-56e524d53172c89dc6108944b18d0760951522209c3689453710762bfa8cd1f3R35) [[3]](diffhunk://#diff-56e524d53172c89dc6108944b18d0760951522209c3689453710762bfa8cd1f3R55-L106) [[4]](diffhunk://#diff-56e524d53172c89dc6108944b18d0760951522209c3689453710762bfa8cd1f3R247-R261) [[5]](diffhunk://#diff-56e524d53172c89dc6108944b18d0760951522209c3689453710762bfa8cd1f3L274-R275) [[6]](diffhunk://#diff-b2c5b2eba542366bcd0ba4b771e1bae08654a60d1a5ca6e42bc7b81b1f97e152R78)

**Output Structure Changes:**

- The output of ContractRead and ContractWrite nodes is now a flattened object with method results as top-level properties, instead of being nested under a `data` field. Metadata is no longer included in the output object but is available as a separate step-level property.

**Test Updates:**

- All relevant tests for ContractRead and ContractWrite nodes are updated to expect the new output structure: method results are accessed directly on the output object, and metadata is checked as a separate property on the step. [[1]](diffhunk://#diff-9621c122793e619027bf99601710cb36dfcbede93ac9627ab595ac1ea9666842L679-R702) [[2]](diffhunk://#diff-9621c122793e619027bf99601710cb36dfcbede93ac9627ab595ac1ea9666842L766-R785) [[3]](diffhunk://#diff-9621c122793e619027bf99601710cb36dfcbede93ac9627ab595ac1ea9666842L846-R863) [[4]](diffhunk://#diff-9621c122793e619027bf99601710cb36dfcbede93ac9627ab595ac1ea9666842L962-R969) [[5]](diffhunk://#diff-9621c122793e619027bf99601710cb36dfcbede93ac9627ab595ac1ea9666842L1079-R1098) [[6]](diffhunk://#diff-9621c122793e619027bf99601710cb36dfcbede93ac9627ab595ac1ea9666842L1270-R1290) [[7]](diffhunk://#diff-9621c122793e619027bf99601710cb36dfcbede93ac9627ab595ac1ea9666842L1770-R1786) [[8]](diffhunk://#diff-bb32402e6ab274f11d7b6713f0f7084346aba430d5fccd66ed8bf1d4891fefeaL587-R599)