### PR TITLE
docs: update the usage of create-api-key aggregator command

### DIFF
--- a/.github/workflows/dev-test-on-pr.yml
+++ b/.github/workflows/dev-test-on-pr.yml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Generate AVS API key
         run: |
-          API_KEY=$(docker compose exec aggregator /ava create-api-key --config /app/config/aggregator.runtime.yaml --role=admin --subject=apikey 2>/dev/null)
+          API_KEY=$(docker compose exec aggregator /ava create-api-key --config /app/config/aggregator.runtime.yaml --role=admin --subject=0x804e49e8C4eDb560AE7c48B554f6d2e27Bb81557 2>/dev/null)
           echo "AVS_API_KEY=$API_KEY" >> $GITHUB_ENV
           echo "API key generated (${#API_KEY} chars)"
 

--- a/.github/workflows/dev-test-on-pr.yml
+++ b/.github/workflows/dev-test-on-pr.yml
@@ -94,7 +94,7 @@ jobs:
       TENDERLY_ACCOUNT: ${{ vars.TENDERLY_ACCOUNT }}
       TENDERLY_PROJECT: ${{ vars.TENDERLY_PROJECT }}
       THEGRAPH_API_KEY: ${{ vars.THEGRAPH_API_KEY }}
-      BUNDLER_URL: ${{ vars.BUNDLER_URL }}
+      BUNDLER_URL: ${{ secrets.BUNDLER_URL }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/prod-test-on-pr.yml
+++ b/.github/workflows/prod-test-on-pr.yml
@@ -27,7 +27,7 @@ jobs:
         env: [sepolia, ethereum, base, base-sepolia] # soneium-minato disabled
     environment: ${{ matrix.env }}
     env:
-      CHAIN_ENDPOINT: ${{ vars.CHAIN_ENDPOINT }}
+      CHAIN_ENDPOINT: ${{ secrets.CHAIN_ENDPOINT }}
       TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
       TEST_ENV: ${{ matrix.env }}
       AVS_API_KEY: ${{ secrets.AVS_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ To ensure the SDK is functioning correctly, we have a comprehensive test suite. 
    npm run gen-apikey
 
    # or if not using docker, run the following command in ./EigenLayer-AVS/out
-   ./out/ap create-api-key --config ./config/aggregator-base.yaml --role=admin --subject=apikey
+   # --subject must be the owner EOA address you want this admin key bound to.
+   # For local tests, use the wallet derived from TEST_PRIVATE_KEY (default below).
+   ./out/ap create-api-key --config ./config/aggregator-base.yaml --role=admin --subject=<OWNER_EOA_ADDRESS>
    ```
 
 5. Run the test command with env variables set in `.env.test`.

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -24,8 +24,30 @@
  *   Example: yarn start getWallet 0x1234...5678 0
  * - getWorkflows <owner-address> <smart-wallet-address?> ...: Query workflows for a specific owner
  *   Example: yarn start getWorkflows 0x1234...5678
+ * - getExecutions <workflow-id> [cursor] [limit]: Get execution history for a workflow
+ *   Example: yarn start getExecutions 01knnzdfpm2bygwarxndm2fs50
+ * - getExecution <workflow-id> <execution-id>: Get a single workflow execution
+ *   Example: yarn start getExecution 01knnzdfpm2bygwarxndm2fs50 <execution-id>
  * - When using API key authentication, you can query any owner's data, not just your own
  * - Without API key, commands default to your own wallets (derived from TEST_PRIVATE_KEY)
+ *
+ * 🔐 Getting an AVS_API_KEY:
+ * The API key is a JWT minted by the aggregator's `create-api-key` command. The JWT
+ * subject MUST be a 0x-prefixed EOA address — that EOA becomes the "owner" the key
+ * is bound to. See ../README.md ("Generate a test API key") for the full setup.
+ *
+ * Quick reference (run from the EigenLayer-AVS repo against your local aggregator):
+ *   ./out/ap create-api-key \
+ *     --config ./config/aggregator-sepolia.yaml \
+ *     --role=admin \
+ *     --subject=0xYourOwnerEoaAddress
+ *
+ * Then place the printed token in `.env.dev` (or your env-specific file) as:
+ *   AVS_API_KEY=eyJhbGciOi...
+ *
+ * The example loader auto-loads `.env.<currentEnv>` (including `.env.dev`), so no
+ * extra flags are needed — `yarn start <command>` will pick it up. You can also
+ * override per-invocation: `AVS_API_KEY=... yarn start getWorkflow <id>`.
  */
 
 import { Client, TriggerFactory, NodeFactory, Edge } from "@avaprotocol/sdk-js";
@@ -54,7 +76,7 @@ if (fs.existsSync(baseEnvPath)) {
 }
 
 // 2. Then load environment-specific .env file if currentEnv is set
-if (currentEnv && currentEnv !== "dev") {
+if (currentEnv) {
   const envSpecificPath = path.join(rootDir, `.env.${currentEnv}`);
   if (fs.existsSync(envSpecificPath)) {
     console.log(`📁 Loading environment from: .env.${currentEnv}`);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "version": "changeset version",
     "proto-download": "curl -s https://raw.githubusercontent.com/AvaProtocol/EigenLayer-AVS/staging/protobuf/avs.proto > grpc_codegen/avs.proto",
     "protoc-gen": "grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./grpc_codegen/ --grpc_out=grpc_js:./grpc_codegen/ --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./grpc_codegen --proto_path=./grpc_codegen grpc_codegen/avs.proto",
-    "apikey-gen": "sh -c 'API_KEY=$(docker compose exec aggregator /ava create-api-key --role=admin --subject=apikey) && echo \"Generated API key for tests: $API_KEY\" && echo \"Writing to .env.test to replace the TEST_API_KEY env variable\" && sed -i \"\" -e \"s/^TEST_API_KEY=.*/TEST_API_KEY=$API_KEY/\" .env.test && echo \"Done.\"'",
+    "apikey-gen": "sh -c 'API_KEY=$(docker compose exec aggregator /ava create-api-key --role=admin --subject=0x804e49e8C4eDb560AE7c48B554f6d2e27Bb81557) && echo \"Generated API key for tests: $API_KEY\" && echo \"Writing to .env.test to replace the TEST_API_KEY env variable\" && sed -i \"\" -e \"s/^TEST_API_KEY=.*/TEST_API_KEY=$API_KEY/\" .env.test && echo \"Done.\"'",
     "build": "yarn workspaces run build",
     "clean": "rm -rf node_modules yarn.lock && yarn workspaces run clean",
     "test": "jest --config jest.config.cjs --detectOpenHandles --runInBand --silent",


### PR DESCRIPTION
- **ci: read CHAIN_ENDPOINT and BUNDLER_URL from secrets**
- **docs: update the usage of create-api-key aggregator command**
- **docs(examples): document getExecutions/getExecution and AVS_API_KEY setup**
