### PR TITLE
feat: require chainId+version in buildAuthMessage (Position D)

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -169,6 +169,13 @@ async function ensureAuth(client: Client): Promise<string> {
   // operating on a different chain swap in their wallet's
   // currently-connected chainId.
   const { version } = await client.health.check();
+  if (!version) {
+    fail(
+      EXIT_SDK_ERROR,
+      "GATEWAY_NO_VERSION",
+      "Gateway /health did not return a version field — the gateway predates Position D auth (AVS PR #554). Upgrade the gateway.",
+    );
+  }
   const resp = await client.auth.exchangeWithKey(pk, {
     chainId: 11_155_111,
     version,

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -164,7 +164,15 @@ async function ensureAuth(client: Client): Promise<string> {
       "Set TEST_PRIVATE_KEY (EOA private key) or AVS_API_KEY (pre-minted JWT) before running this command.",
     );
   }
-  const resp = await client.auth.exchangeWithKey(pk);
+  // Stamp the message with the live gateway version (cheap /health
+  // round trip) and the dev/test stack chain (Sepolia). Callers
+  // operating on a different chain swap in their wallet's
+  // currently-connected chainId.
+  const { version } = await client.health.check();
+  const resp = await client.auth.exchangeWithKey(pk, {
+    chainId: 11_155_111,
+    version,
+  });
   if (!client.token) {
     // Shouldn't happen — auth.exchangeWithKey sets the token — but
     // surface the wire response if it ever does.

--- a/packages/sdk-js/src/v4/auth.ts
+++ b/packages/sdk-js/src/v4/auth.ts
@@ -27,6 +27,12 @@ export interface BuildAuthMessageInput {
    * the JWT `aud` claim, which becomes the default chain for
    * subsequent wallet RPCs. Hardcoding a value here would silently
    * route every request to the wrong chain.
+   *
+   * Source this from the wallet itself (`provider.getNetwork()`,
+   * `wallet.getChainId()`, EIP-1193 `eth_chainId`), NOT from
+   * user-typed input or URL params — those can lie, and a JWT
+   * minted against a forged chain id will route the user's wallet
+   * RPCs to the wrong chain bucket.
    */
   chainId: number;
   /**
@@ -102,6 +108,15 @@ export async function signAuthMessage(
   privateKey: string,
   input: Omit<BuildAuthMessageInput, "ownerAddress"> & { ownerAddress?: string },
 ): Promise<{ message: string; signature: string; ownerAddress: string; expireAt: Date }> {
+  // Defensive runtime guard for JS callers / TS callers casting through
+  // `any` who'd otherwise hit a cryptic "Cannot read properties of
+  // undefined" inside buildAuthMessage. The type-level requirement
+  // stands; this just makes the breaking-change error legible.
+  if (input == null || typeof input !== "object") {
+    throw new Error(
+      "signAuthMessage: input is required — pass { chainId, version } (chainId from the wallet's connected chain, version from client.health.check()).",
+    );
+  }
   const signer = new Wallet(privateKey);
   const built = buildAuthMessage({
     ownerAddress: input.ownerAddress ?? signer.address,

--- a/packages/sdk-js/src/v4/auth.ts
+++ b/packages/sdk-js/src/v4/auth.ts
@@ -1,7 +1,5 @@
 import { Wallet, getAddress } from "ethers";
 
-import { Chains } from "./chains";
-
 /**
  * Canonical EIP-191 message template the aggregator's auth handler
  * verifies. Must match the format documented in the API spec.
@@ -23,14 +21,22 @@ export interface BuildAuthMessageInput {
   /** EOA the JWT will be bound to. Lowercased / checksummed both work. */
   ownerAddress: string;
   /**
-   * Chain id to embed in the canonical message. Defaults to
-   * `Chains.EigenLayerAuth` — the auth flow is chain-agnostic, the
-   * embedded id only tells the verifier which chain bucket the
-   * minted JWT belongs to.
+   * Chain ID to embed in the canonical message. Required — callers
+   * MUST pass the user's currently-connected wallet chain (e.g.
+   * `await wallet.getChainId()`). The aggregator echoes this into
+   * the JWT `aud` claim, which becomes the default chain for
+   * subsequent wallet RPCs. Hardcoding a value here would silently
+   * route every request to the wrong chain.
    */
-  chainId?: number;
-  /** SDK version string surfaced in the message (purely informational). */
-  version?: string;
+  chainId: number;
+  /**
+   * Gateway binary version to stamp into the message. Required —
+   * fetch it once per session via `client.health.check()` and pass
+   * the `version` field through. Pinning a literal here (the old
+   * `"v4-sdk"` default) lies about which gateway the message was
+   * signed against and breaks support triage.
+   */
+  version: string;
   /** Issuance timestamp; defaults to `new Date()`. */
   issuedAt?: Date;
   /** Token expiry; defaults to 24h from issuedAt. */
@@ -48,21 +54,37 @@ export interface BuiltAuthMessage {
  * Build the canonical auth message a wallet must sign. Pure — does
  * no signing — so it can run in the browser before opening the wallet
  * popup.
+ *
+ * @example
+ *   const { version } = await client.health.check();
+ *   const chainId = await wallet.getChainId();
+ *   const { message } = buildAuthMessage({ ownerAddress, chainId, version });
+ *   const signature = await wallet.signMessage(message);
+ *   const { token } = await client.auth.exchange({ ownerAddress, message, signature });
  */
 export function buildAuthMessage(input: BuildAuthMessageInput): BuiltAuthMessage {
+  if (!Number.isInteger(input.chainId) || input.chainId <= 0) {
+    throw new Error(
+      "buildAuthMessage: chainId must be a positive integer (the wallet's currently-connected chain).",
+    );
+  }
+  if (typeof input.version !== "string" || input.version.length === 0) {
+    throw new Error(
+      "buildAuthMessage: version must be a non-empty string (fetch it from `client.health.check()`).",
+    );
+  }
   const issuedAt = input.issuedAt ?? new Date();
   const expireAt = input.expireAt ?? new Date(issuedAt.getTime() + 24 * 60 * 60 * 1000);
-  const chainId = input.chainId ?? Chains.EigenLayerAuth;
   // Canonicalize the address so the wire form matches what the
   // aggregator extracts via crypto.PubkeyToAddress.
   const ownerAddress = getAddress(input.ownerAddress);
   const message = AUTH_TEMPLATE
-    .replace("{chainId}", String(chainId))
-    .replace("{version}", input.version ?? "v4-sdk")
+    .replace("{chainId}", String(input.chainId))
+    .replace("{version}", input.version)
     .replace("{issuedAt}", toRFC3339Millis(issuedAt))
     .replace("{expireAt}", toRFC3339Millis(expireAt))
     .replace("{wallet}", ownerAddress);
-  return { message, chainId, ownerAddress, expireAt };
+  return { message, chainId: input.chainId, ownerAddress, expireAt };
 }
 
 /**
@@ -71,18 +93,22 @@ export function buildAuthMessage(input: BuildAuthMessageInput): BuiltAuthMessage
  * `client.auth.exchange()`. Only useful in tests / Node tooling
  * where the private key is in hand; browser flows use
  * `buildAuthMessage` + a wallet's `personal_sign`.
+ *
+ * `chainId` and `version` are required for the same reasons as
+ * `buildAuthMessage` — silent defaults would lie about the chain
+ * the JWT is bound to and the gateway it was signed against.
  */
 export async function signAuthMessage(
   privateKey: string,
-  input?: Omit<BuildAuthMessageInput, "ownerAddress"> & { ownerAddress?: string },
+  input: Omit<BuildAuthMessageInput, "ownerAddress"> & { ownerAddress?: string },
 ): Promise<{ message: string; signature: string; ownerAddress: string; expireAt: Date }> {
   const signer = new Wallet(privateKey);
   const built = buildAuthMessage({
-    ownerAddress: input?.ownerAddress ?? signer.address,
-    chainId: input?.chainId,
-    version: input?.version,
-    issuedAt: input?.issuedAt,
-    expireAt: input?.expireAt,
+    ownerAddress: input.ownerAddress ?? signer.address,
+    chainId: input.chainId,
+    version: input.version,
+    issuedAt: input.issuedAt,
+    expireAt: input.expireAt,
   });
   // signMessage performs EIP-191 personal_sign — the same prefix
   // accounts.TextHash uses on the verifier side.

--- a/packages/sdk-js/src/v4/resources/auth.ts
+++ b/packages/sdk-js/src/v4/resources/auth.ts
@@ -38,10 +38,16 @@ export class AuthResource {
    * stashed on the transport. Designed for Node tooling — browser
    * callers should use `buildAuthMessage` + a wallet's
    * `personal_sign` and then call `exchange()` directly.
+   *
+   * `chainId` and `version` are required for the same reasons as
+   * `buildAuthMessage` — silently defaulting either field would
+   * mis-route every wallet RPC the resulting JWT is used for.
+   * `version` is the gateway binary version; the simplest source
+   * is the `version` field returned by `client.health.check()`.
    */
   async exchangeWithKey(
     privateKey: string,
-    opts?: { ownerAddress?: string; chainId?: number; version?: string },
+    opts: { ownerAddress?: string; chainId: number; version: string },
   ): Promise<v4.AuthExchangeResponse> {
     const signed = await signAuthMessage(privateKey, opts);
     return this.exchange({

--- a/packages/types/openapi/openapi.yaml
+++ b/packages/types/openapi/openapi.yaml
@@ -220,13 +220,18 @@ components:
       type: object
       required:
         - status
+        - version
       properties:
         status:
           type: string
           enum: [ok, degraded, starting]
         version:
           type: string
-          description: Aggregator binary version (e.g., `v1.9.6`).
+          description: |
+            Aggregator binary version (e.g., `v3.2.0`). Always set —
+            SDK clients use this to stamp the canonical EIP-191 auth
+            message so the signed `Version` field reflects the
+            gateway the user actually authenticated against.
         chainId:
           $ref: '#/components/schemas/ChainId'
           description: EigenLayer registration chain ID.
@@ -651,6 +656,26 @@ components:
           type: object
           additionalProperties: { type: string }
         body: { type: string }
+        options:
+          type: object
+          description: |
+            Generic options bag for backend features on terminal
+            RestAPI nodes. `summarize: true` opts a SendGrid /v3/mail/send
+            or Telegram /sendMessage node into the aggregator's
+            context-memory summarizer, which composes a subject + HTML
+            body from the workflow's execution context and injects them
+            into the outgoing request. Without this field set, the
+            aggregator falls back to the deterministic summarizer (no
+            LLM polish).
+          properties:
+            summarize:
+              type: boolean
+              description: |
+                When true on a terminal SendGrid or Telegram node,
+                ComposeSummarySmart runs at execution time and fills
+                in the empty content.value / text slot with an
+                AI-generated body. No-op on non-notification URLs.
+          additionalProperties: true
 
     CustomCodeNodeConfig:
       type: object
@@ -1266,6 +1291,15 @@ components:
         factoryAddress:
           $ref: '#/components/schemas/EthereumAddress'
           description: Optional factory override. Defaults to the aggregator's configured factory.
+        chainId:
+          $ref: '#/components/schemas/ChainId'
+          description: |
+            Chain to derive the wallet on. Optional override — when
+            omitted, the gateway defaults to the JWT `aud` chain (i.e.
+            the chain the caller signed the auth message for). Set
+            this when minting a wallet for a chain different from the
+            one the JWT was issued against; the JWT proves EOA
+            ownership, which is chain-independent.
 
     UpdateWalletRequest:
       type: object
@@ -2117,6 +2151,7 @@ paths:
         in: path
         required: true
         schema: { $ref: '#/components/schemas/EthereumAddress' }
+      - $ref: '#/components/parameters/ChainIdQuery'
     get:
       tags: [Wallets]
       summary: Get the smart wallet's current nonce

--- a/packages/types/src/openapi.gen.ts
+++ b/packages/types/src/openapi.gen.ts
@@ -475,7 +475,13 @@ export interface paths {
     };
     readonly "/wallets/{address}:getNonce": {
         readonly parameters: {
-            readonly query?: never;
+            readonly query?: {
+                /**
+                 * @description Chain ID filter. Omit to use the aggregator default chain. Repeat
+                 *     the parameter to filter by multiple chains.
+                 */
+                readonly chainId?: components["parameters"]["ChainIdQuery"];
+            };
             readonly header?: never;
             readonly path: {
                 readonly address: components["schemas"]["EthereumAddress"];
@@ -691,8 +697,13 @@ export interface components {
         readonly HealthStatus: {
             /** @enum {string} */
             readonly status: "ok" | "degraded" | "starting";
-            /** @description Aggregator binary version (e.g., `v1.9.6`). */
-            readonly version?: string;
+            /**
+             * @description Aggregator binary version (e.g., `v3.2.0`). Always set —
+             *     SDK clients use this to stamp the canonical EIP-191 auth
+             *     message so the signed `Version` field reflects the
+             *     gateway the user actually authenticated against.
+             */
+            readonly version: string;
             /** @description EigenLayer registration chain ID. */
             readonly chainId?: components["schemas"]["ChainId"];
         };
@@ -944,6 +955,27 @@ export interface components {
                 readonly [key: string]: string;
             };
             readonly body?: string;
+            /**
+             * @description Generic options bag for backend features on terminal
+             *     RestAPI nodes. `summarize: true` opts a SendGrid /v3/mail/send
+             *     or Telegram /sendMessage node into the aggregator's
+             *     context-memory summarizer, which composes a subject + HTML
+             *     body from the workflow's execution context and injects them
+             *     into the outgoing request. Without this field set, the
+             *     aggregator falls back to the deterministic summarizer (no
+             *     LLM polish).
+             */
+            readonly options?: {
+                /**
+                 * @description When true on a terminal SendGrid or Telegram node,
+                 *     ComposeSummarySmart runs at execution time and fills
+                 *     in the empty content.value / text slot with an
+                 *     AI-generated body. No-op on non-notification URLs.
+                 */
+                readonly summarize?: boolean;
+            } & {
+                readonly [key: string]: unknown;
+            };
         };
         readonly CustomCodeNodeConfig: {
             readonly lang: components["schemas"]["Lang"];
@@ -1426,6 +1458,15 @@ export interface components {
             readonly salt: string;
             /** @description Optional factory override. Defaults to the aggregator's configured factory. */
             readonly factoryAddress?: components["schemas"]["EthereumAddress"];
+            /**
+             * @description Chain to derive the wallet on. Optional override — when
+             *     omitted, the gateway defaults to the JWT `aud` chain (i.e.
+             *     the chain the caller signed the auth message for). Set
+             *     this when minting a wallet for a chain different from the
+             *     one the JWT was issued against; the JWT proves EOA
+             *     ownership, which is chain-independent.
+             */
+            readonly chainId?: components["schemas"]["ChainId"];
         };
         readonly UpdateWalletRequest: {
             readonly isHidden?: boolean;
@@ -2302,7 +2343,13 @@ export interface operations {
     };
     readonly getWalletNonce: {
         readonly parameters: {
-            readonly query?: never;
+            readonly query?: {
+                /**
+                 * @description Chain ID filter. Omit to use the aggregator default chain. Repeat
+                 *     the parameter to filter by multiple chains.
+                 */
+                readonly chainId?: components["parameters"]["ChainIdQuery"];
+            };
             readonly header?: never;
             readonly path: {
                 readonly address: components["schemas"]["EthereumAddress"];

--- a/tests/utils/client.ts
+++ b/tests/utils/client.ts
@@ -41,9 +41,21 @@ export function getClient(overrides?: Partial<ClientOptions>): Client {
   });
 }
 
+// TEST_AUTH_CHAIN_ID is the chain id tests sign their auth message
+// against. The dev/test stack runs on Sepolia, so we pin to that —
+// matching what the engine's settings/test fixtures use elsewhere.
+// Tests that exercise a different chain (e.g. the BNB connectivity
+// probe) call exchangeWithKey directly with their own chainId.
+const TEST_AUTH_CHAIN_ID = 11_155_111;
+
 /**
  * Drive the EIP-191 sign-then-exchange flow against the live
  * aggregator and stash the resulting JWT on the supplied client.
+ *
+ * Fetches the gateway version from /health and signs against the
+ * dev-stack chain (Sepolia). The /health round trip is cheap and
+ * keeps the test stamp honest — pinning a literal would lie about
+ * which gateway the message was signed against.
  *
  * @param client v4 Client to authenticate.
  * @param privateKey Optional override; defaults to `TEST_PRIVATE_KEY`.
@@ -54,7 +66,11 @@ export async function authenticateClient(
   privateKey?: string,
 ): Promise<string> {
   const pk = privateKey ?? testPrivateKey();
-  const resp = await client.auth.exchangeWithKey(pk);
+  const { version } = await client.health.check();
+  const resp = await client.auth.exchangeWithKey(pk, {
+    chainId: TEST_AUTH_CHAIN_ID,
+    version,
+  });
   return resp.token;
 }
 
@@ -84,15 +100,24 @@ export async function generateSignature(
  * going through `authenticateClient`. Mirrors v3's
  * `generateAuthPayloadWithApiKey` shape minus the API-key field —
  * v4 doesn't combine signature + API key in one request.
+ *
+ * Takes a `client` so it can fetch the gateway version from /health —
+ * the SDK no longer defaults `version`. Same dev-stack Sepolia chainId
+ * as `authenticateClient`.
  */
 export async function buildAuthPayload(
+  client: Client,
   privateKey?: string,
 ): Promise<{
   ownerAddress: string;
   message: string;
   signature: string;
 }> {
-  const signed = await signAuthMessage(privateKey ?? testPrivateKey());
+  const { version } = await client.health.check();
+  const signed = await signAuthMessage(privateKey ?? testPrivateKey(), {
+    chainId: TEST_AUTH_CHAIN_ID,
+    version,
+  });
   return {
     ownerAddress: signed.ownerAddress,
     message: signed.message,

--- a/tests/utils/client.ts
+++ b/tests/utils/client.ts
@@ -46,7 +46,7 @@ export function getClient(overrides?: Partial<ClientOptions>): Client {
 // matching what the engine's settings/test fixtures use elsewhere.
 // Tests that exercise a different chain (e.g. the BNB connectivity
 // probe) call exchangeWithKey directly with their own chainId.
-const TEST_AUTH_CHAIN_ID = 11_155_111;
+export const TEST_AUTH_CHAIN_ID = 11_155_111;
 
 /**
  * Drive the EIP-191 sign-then-exchange flow against the live
@@ -61,12 +61,28 @@ const TEST_AUTH_CHAIN_ID = 11_155_111;
  * @param privateKey Optional override; defaults to `TEST_PRIVATE_KEY`.
  * @returns The minted token (also already set on the client).
  */
+async function fetchGatewayVersion(client: Client): Promise<string> {
+  const { version } = await client.health.check();
+  // The HealthStatus schema marks version as required (post AVS #554),
+  // so TS guarantees a string at compile time. Belt-and-suspenders
+  // runtime check catches the transition window where an old gateway
+  // could still return undefined — that surfaces as a clear migration
+  // error here, not a confusing "version must be non-empty" deep
+  // inside buildAuthMessage.
+  if (!version) {
+    throw new Error(
+      "Gateway /health did not return a version field — the gateway is older than the Position D rollout (AVS PR #554). Upgrade the gateway or test against a newer one.",
+    );
+  }
+  return version;
+}
+
 export async function authenticateClient(
   client: Client,
   privateKey?: string,
 ): Promise<string> {
   const pk = privateKey ?? testPrivateKey();
-  const { version } = await client.health.check();
+  const version = await fetchGatewayVersion(client);
   const resp = await client.auth.exchangeWithKey(pk, {
     chainId: TEST_AUTH_CHAIN_ID,
     version,
@@ -113,7 +129,7 @@ export async function buildAuthPayload(
   message: string;
   signature: string;
 }> {
-  const { version } = await client.health.check();
+  const version = await fetchGatewayVersion(client);
   const signed = await signAuthMessage(privateKey ?? testPrivateKey(), {
     chainId: TEST_AUTH_CHAIN_ID,
     version,

--- a/tests/v4/core/auth.test.ts
+++ b/tests/v4/core/auth.test.ts
@@ -16,6 +16,7 @@
 import { APIError, Client } from "@avaprotocol/sdk-js";
 
 import {
+  TEST_AUTH_CHAIN_ID,
   authenticateClient,
   buildAuthPayload,
   generateSignature,
@@ -152,7 +153,7 @@ describe("Authentication Tests", () => {
       const c = getClient();
       const { version } = await c.health.check();
       const res = await c.auth.exchangeWithKey(testPrivateKey(), {
-        chainId: 11_155_111,
+        chainId: TEST_AUTH_CHAIN_ID,
         version,
       });
       expect(res.token).toEqual(c.token);

--- a/tests/v4/core/auth.test.ts
+++ b/tests/v4/core/auth.test.ts
@@ -130,7 +130,7 @@ describe("Authentication Tests", () => {
     });
 
     test("returns a JWT with the expected claims (issuer + subject + exp)", async () => {
-      const payload = await buildAuthPayload();
+      const payload = await buildAuthPayload(client);
       const res = await client.auth.exchange(payload);
       expect(res.token).toBeTruthy();
       // The token also gets stashed on the transport for follow-up calls.
@@ -150,7 +150,11 @@ describe("Authentication Tests", () => {
 
     test("exchangeWithKey is a one-shot helper around exchange()", async () => {
       const c = getClient();
-      const res = await c.auth.exchangeWithKey(testPrivateKey());
+      const { version } = await c.health.check();
+      const res = await c.auth.exchangeWithKey(testPrivateKey(), {
+        chainId: 11_155_111,
+        version,
+      });
       expect(res.token).toEqual(c.token);
       expect(res.subject).toBeTruthy();
       expect(res.subject?.toLowerCase()).toEqual(eoaAddress.toLowerCase());
@@ -169,7 +173,8 @@ describe("Authentication Tests", () => {
       // SimpleAccountFactory isn't deployed on the chain (the BNB
       // connectivity-only rollout state).
       const c = getClient();
-      const res = await c.auth.exchangeWithKey(testPrivateKey(), { chainId: 56 });
+      const { version } = await c.health.check();
+      const res = await c.auth.exchangeWithKey(testPrivateKey(), { chainId: 56, version });
       expect(res.token).toBeTruthy();
       // The JWT body should encode the requested chain id in the
       // audience claim — that's how downstream chain-routed handlers
@@ -181,7 +186,7 @@ describe("Authentication Tests", () => {
     });
 
     test("rejects a signature that doesn't match the owner", async () => {
-      const payload = await buildAuthPayload();
+      const payload = await buildAuthPayload(client);
       // Re-sign the message with a different key — verifier will
       // reject because the recovered address doesn't match ownerAddress.
       const otherKey = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";

--- a/tests/v4/smoke.test.ts
+++ b/tests/v4/smoke.test.ts
@@ -65,7 +65,7 @@ describe("v4 SDK smoke", () => {
     test("signAuthMessage produces a hex signature with the recovered owner", async () => {
       // Deterministic test key (no funds). Not the same as TEST_PRIVATE_KEY.
       const pk = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
-      const out = await signAuthMessage(pk, { version: "v4-test" });
+      const out = await signAuthMessage(pk, { chainId: 11155111, version: "v4-test" });
       expect(out.signature.startsWith("0x")).toBe(true);
       expect(out.signature.length).toBe(132); // 65 bytes hex + 0x prefix
       expect(out.ownerAddress.length).toBe(42);

--- a/tests/v4/smoke.test.ts
+++ b/tests/v4/smoke.test.ts
@@ -49,7 +49,7 @@ describe("v4 SDK smoke", () => {
     test("buildAuthMessage produces a canonical EIP-191 template", () => {
       const built = buildAuthMessage({
         ownerAddress: "0xD7050816337a3f8f690F8083B5Ff8019D50c0E50",
-        chainId: 11155111,
+        chainId: 11_155_111,
         issuedAt: new Date("2026-05-25T12:00:00.000Z"),
         expireAt: new Date("2026-05-26T12:00:00.000Z"),
         version: "v4-test",
@@ -59,16 +59,38 @@ describe("v4 SDK smoke", () => {
       expect(built.message).toContain("Issued At: 2026-05-25T12:00:00.000Z");
       expect(built.message).toContain("Expire At: 2026-05-26T12:00:00.000Z");
       expect(built.message).toContain("Wallet: 0xD7050816337a3f8f690F8083B5Ff8019D50c0E50");
-      expect(built.chainId).toBe(11155111);
+      expect(built.chainId).toBe(11_155_111);
     });
 
     test("signAuthMessage produces a hex signature with the recovered owner", async () => {
       // Deterministic test key (no funds). Not the same as TEST_PRIVATE_KEY.
       const pk = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
-      const out = await signAuthMessage(pk, { chainId: 11155111, version: "v4-test" });
+      const out = await signAuthMessage(pk, { chainId: 11_155_111, version: "v4-test" });
       expect(out.signature.startsWith("0x")).toBe(true);
       expect(out.signature.length).toBe(132); // 65 bytes hex + 0x prefix
       expect(out.ownerAddress.length).toBe(42);
+    });
+
+    test("buildAuthMessage throws on invalid chainId (zero, negative, non-integer)", () => {
+      const owner = "0xD7050816337a3f8f690F8083B5Ff8019D50c0E50";
+      expect(() => buildAuthMessage({ ownerAddress: owner, chainId: 0, version: "v4-test" })).toThrow(/chainId/);
+      expect(() => buildAuthMessage({ ownerAddress: owner, chainId: -1, version: "v4-test" })).toThrow(/chainId/);
+      expect(() => buildAuthMessage({ ownerAddress: owner, chainId: 1.5, version: "v4-test" })).toThrow(/chainId/);
+    });
+
+    test("buildAuthMessage throws on missing/empty version", () => {
+      const owner = "0xD7050816337a3f8f690F8083B5Ff8019D50c0E50";
+      expect(() => buildAuthMessage({ ownerAddress: owner, chainId: 1, version: "" })).toThrow(/version/);
+      expect(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        buildAuthMessage({ ownerAddress: owner, chainId: 1, version: undefined as any }),
+      ).toThrow(/version/);
+    });
+
+    test("signAuthMessage throws when called without input", async () => {
+      const pk = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await expect(signAuthMessage(pk, undefined as any)).rejects.toThrow(/input is required/);
     });
   });
 


### PR DESCRIPTION
## Summary

Coordinated SDK half of the Position D auth migration. Pairs with the EigenLayer-AVS work just merged to staging (PR #554).

`buildAuthMessage`, `signAuthMessage`, and `client.auth.exchangeWithKey` no longer have silent defaults for `chainId` or `version` — both are now **required**. Previously the SDK silently defaulted:

- `chainId` → `Chains.EigenLayerAuth` (11155111 / Sepolia)
- `version` → literal string `"v4-sdk"`

Both defaults actively lied. A user signing in from Rabby on Ethereum saw `Chain ID: 11155111` in the wallet popup, the minted JWT `aud` claim pointed at Sepolia regardless, and the literal `"v4-sdk"` was neither the SDK version nor the gateway version.

## What callers do now

| Field | Source |
|---|---|
| `chainId` | The wallet's currently-connected chain (`wallet.getChainId()` or equivalent). Source from the wallet itself, never from URL params / user input. |
| `version` | The gateway version from `client.health.check()` (now a required field on the response schema) |

Passing `undefined` for either field throws synchronously at the call site — no silent fallback to wrong values.

## Why this is not Position B from USEAUTHEDCLIENT_PATTERN.md (studio)

The studio's existing doc proposes a "canonical Sepolia aud, sign once forever" design. That document is now obsolete — see `studio/docs/AUTH_POSITION_D_MIGRATION.md` (shipping alongside the studio call-site changes) for the design rationale and the coordinated migration steps.

Short version: Position B leaves the wallet popup dishonest (`Chain ID: 11155111` on Ethereum) and the JWT `aud` actively wrong. Position D embeds the wallet's real connected chain, re-signs only when the wallet's network changes (rare, intentional user action), and preserves cross-chain ops via per-request `body.chainId` overrides on the gateway side.

## What's in this diff that isn't strictly auth

The `openapi.yaml` regen pulled in three groups of changes from the EigenLayer-AVS staging snapshot. Two are part of the Position D coordination; one is unrelated catch-up that came along for the ride:

| Hunk | Part of Position D? | Why it's here |
|---|---|---|
| `HealthStatus.version` required | ✅ Yes | SDK depends on it being non-undefined |
| `CreateWalletRequest.chainId` (body) | ✅ Yes | Per-request chain override path for cross-chain ops on one JWT |
| `getWalletNonce` `?chainId=` query param | ✅ Yes | Same override semantic for the nonce endpoint |
| `RestAPINodeConfig.options.summarize` + LLM docs | ❌ No | Routine openapi snapshot catch-up; this feature already shipped on the gateway via a separate PR. Not split into its own SDK PR because it's just an openapi-yaml hunk with no SDK code change. |

If you'd rather see `RestAPINodeConfig.options.summarize` split out, I can revert that hunk on this branch and ship it separately — let me know.

## Test plan

- [x] `yarn workspace @avaprotocol/sdk-js build` — clean
- [x] `yarn test tests/v4/smoke.test.ts` — 12/12 pass (includes 3 new tests locking in the buildAuthMessage / signAuthMessage validation guards)
- [x] `npx tsc --noEmit -p .` — clean on all files this PR touches
- [ ] Integration E2E against a gateway deployed from EigenLayer-AVS staging post-#554 merge — verify the Rabby popup shows the wallet's actually-connected chainId and the live gateway version
- [ ] Studio rollout per `studio/docs/AUTH_POSITION_D_MIGRATION.md` — shipped in lockstep, since this SDK bump throws on every sign-in attempt that has not been updated

## Breaking change

Yes — `buildAuthMessage`, `signAuthMessage`, and `AuthResource.exchangeWithKey` all tighten their input types. Any caller passing both `chainId` and `version` explicitly already works; any caller relying on the silent Sepolia / `"v4-sdk"` defaults gets a synchronous error pointing at the right migration.

## Review feedback addressed

Round-1 fixes in commit `facb61f`:

- **Copilot 1**: `signAuthMessage(undefined)` now throws a clear error instead of "Cannot read properties of undefined"
- **Reviewer 1**: `auth.test.ts` uses the shared `TEST_AUTH_CHAIN_ID` constant
- **Reviewer 2**: `smoke.test.ts` numeric literals normalized to use `_` separators
- **Reviewer 4**: Test helpers + example defend against `version === undefined` with a clear "upgrade the gateway" error
- **Reviewer 6**: JSDoc on `chainId` warns callers to source from the wallet, not user input
- **Reviewer 7**: New `toThrow` tests lock in the validation guards (3 added)

Deferred (with reasoning in the commit message): version caching (premature opt), chainId upper bound (gateway validates), splitting the unrelated `RestAPI.summarize` hunk (just an openapi snapshot catch-up; see table above), ChainIdQuery description on getNonce (backend follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
