### PR TITLE
chore: revert RestAPI options.summarize openapi hunk (bundled into #214)

### DIFF
--- a/packages/types/openapi/openapi.yaml
+++ b/packages/types/openapi/openapi.yaml
@@ -656,26 +656,6 @@ components:
           type: object
           additionalProperties: { type: string }
         body: { type: string }
-        options:
-          type: object
-          description: |
-            Generic options bag for backend features on terminal
-            RestAPI nodes. `summarize: true` opts a SendGrid /v3/mail/send
-            or Telegram /sendMessage node into the aggregator's
-            context-memory summarizer, which composes a subject + HTML
-            body from the workflow's execution context and injects them
-            into the outgoing request. Without this field set, the
-            aggregator falls back to the deterministic summarizer (no
-            LLM polish).
-          properties:
-            summarize:
-              type: boolean
-              description: |
-                When true on a terminal SendGrid or Telegram node,
-                ComposeSummarySmart runs at execution time and fills
-                in the empty content.value / text slot with an
-                AI-generated body. No-op on non-notification URLs.
-          additionalProperties: true
 
     CustomCodeNodeConfig:
       type: object

--- a/packages/types/src/openapi.gen.ts
+++ b/packages/types/src/openapi.gen.ts
@@ -955,27 +955,6 @@ export interface components {
                 readonly [key: string]: string;
             };
             readonly body?: string;
-            /**
-             * @description Generic options bag for backend features on terminal
-             *     RestAPI nodes. `summarize: true` opts a SendGrid /v3/mail/send
-             *     or Telegram /sendMessage node into the aggregator's
-             *     context-memory summarizer, which composes a subject + HTML
-             *     body from the workflow's execution context and injects them
-             *     into the outgoing request. Without this field set, the
-             *     aggregator falls back to the deterministic summarizer (no
-             *     LLM polish).
-             */
-            readonly options?: {
-                /**
-                 * @description When true on a terminal SendGrid or Telegram node,
-                 *     ComposeSummarySmart runs at execution time and fills
-                 *     in the empty content.value / text slot with an
-                 *     AI-generated body. No-op on non-notification URLs.
-                 */
-                readonly summarize?: boolean;
-            } & {
-                readonly [key: string]: unknown;
-            };
         };
         readonly CustomCodeNodeConfig: {
             readonly lang: components["schemas"]["Lang"];


### PR DESCRIPTION
## Summary

PR #214 (Position D auth) regenerated `packages/types/openapi/openapi.yaml` from the EigenLayer-AVS staging snapshot. That refresh pulled in the `RestAPINodeConfig.options.summarize` block — which is unrelated to the Position D auth migration but landed in the same squash because the openapi resync is wholesale.

This PR removes just that hunk so the `summarize` feature can land in its own dedicated PR with the proper "feat: document RestAPI options.summarize" framing, instead of arriving silently via an auth-migration squash merge.

## Why this is safe to revert

The SDK builder at [packages/sdk-js/src/v4/builders/nodes.ts:119](packages/sdk-js/src/v4/builders/nodes.ts#L119) declares its own local annotation:

```ts
options?: { summarize?: boolean };
```

and spreads it into the node config without referencing the generated `RestAPINodeConfig.options` type. So removing the openapi-side declaration doesn't break the builder's call surface, and the AAVE template test ([tests/v4/templates/aave-health-factor-alert.test.ts:231](tests/v4/templates/aave-health-factor-alert.test.ts#L231)) keeps typechecking + running.

## Verification

- [x] `yarn workspace @avaprotocol/types build` — clean
- [x] `yarn workspace @avaprotocol/sdk-js build` — clean
- [x] `npx tsc --noEmit -p .` — no errors on `nodes.ts` or AAVE test
- [x] `yarn test tests/v4/smoke.test.ts` — 12/12 pass

## What's next

A separate PR will re-add the `RestAPINodeConfig.options.summarize` schema entry alongside whatever additional SDK + test coverage the summarize feature warrants — that PR is the right home for the schema documentation since it ships the SDK-side support together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
