### PR TITLE
chore: publish scripts pick npm dist-tag from semver pre-release

### DIFF
--- a/scripts/publish-packages.js
+++ b/scripts/publish-packages.js
@@ -118,6 +118,12 @@ function pickPublishTag(version) {
   if (dash === -1) return null; // stable → npm default (`latest`)
   const preRelease = version.slice(dash + 1); // e.g. "dev.4" or "rc.1"
   const identifier = preRelease.split('.')[0];
+  if (!identifier) {
+    // Malformed pre-release like "4.0.0-" or "4.0.0-.1" — refuse rather
+    // than emit `--tag ""`, which npm rejects with a cryptic error
+    // many minutes into the publish flow.
+    throw new Error(`Cannot determine dist-tag: malformed pre-release in version "${version}"`);
+  }
   if (identifier === 'rc') return 'next';
   return identifier; // "dev", "alpha", "beta", etc.
 }
@@ -154,10 +160,13 @@ async function publishPackage(packagePath, dryRun = false) {
   }
 
   // Publish the package — explicit --tag when pre-release so we never
-  // overwrite `latest` by accident.
+  // overwrite `latest` by accident. Quoted to keep a malicious or
+  // accidentally-shell-meta-bearing tag value from breaking out of
+  // the argument; npm itself rejects tags with shell metacharacters,
+  // but defense-in-depth at the call site is cheap.
   log.info(`Publishing ${packageInfo.name} to npm under ${tagSummary}...`);
   const publishCmd = tag
-    ? `npm publish --access public --tag ${tag}`
+    ? `npm publish --access public --tag "${tag}"`
     : 'npm publish --access public';
   const publishResult = runCommand(publishCmd, { cwd: packagePath });
 

--- a/scripts/publish-packages.js
+++ b/scripts/publish-packages.js
@@ -105,12 +105,31 @@ function getUserInput(question) {
   });
 }
 
+// Pick the npm dist-tag from the semver string. Stable versions
+// (no pre-release identifier, e.g. "4.0.0") publish under `latest`,
+// the npm default. Pre-release versions route by their identifier:
+// `4.0.0-dev.N` → `dev`, `4.0.0-rc.N` → `next`, anything else → the
+// first dot-segment of the pre-release. The point is to never let a
+// pre-release version silently overwrite `latest` — that's the npm
+// footgun behind https://github.com/AvaProtocol/ava-sdk-js/pull/214
+// where `4.0.0-dev.N` could have clobbered the v2.x `latest` tag.
+function pickPublishTag(version) {
+  const dash = version.indexOf('-');
+  if (dash === -1) return null; // stable → npm default (`latest`)
+  const preRelease = version.slice(dash + 1); // e.g. "dev.4" or "rc.1"
+  const identifier = preRelease.split('.')[0];
+  if (identifier === 'rc') return 'next';
+  return identifier; // "dev", "alpha", "beta", etc.
+}
+
 // Main publish function for a single package
 async function publishPackage(packagePath, dryRun = false) {
   const packageInfo = getPackageInfo(packagePath);
-  
-  log.info(`Publishing ${packageInfo.name}@${packageInfo.version}`);
-  
+  const tag = pickPublishTag(packageInfo.version);
+  const tagSummary = tag ? `dist-tag '${tag}'` : `dist-tag 'latest' (stable)`;
+
+  log.info(`Publishing ${packageInfo.name}@${packageInfo.version} (${tagSummary})`);
+
   // Check if this version already exists
   if (checkVersionExists(packageInfo.name, packageInfo.version)) {
     log.warning(`${packageInfo.name}@${packageInfo.version} already exists on npm`);
@@ -120,12 +139,12 @@ async function publishPackage(packagePath, dryRun = false) {
       return true;
     }
   }
-  
+
   if (dryRun) {
-    log.info(`[DRY RUN] Would publish ${packageInfo.name}@${packageInfo.version}`);
+    log.info(`[DRY RUN] Would publish ${packageInfo.name}@${packageInfo.version} under ${tagSummary}`);
     return true;
   }
-  
+
   // Build the package
   log.info(`Building ${packageInfo.name}...`);
   const buildResult = runCommand('npm run build', { cwd: packagePath });
@@ -133,13 +152,17 @@ async function publishPackage(packagePath, dryRun = false) {
     log.error(`Build failed for ${packageInfo.name}`);
     return false;
   }
-  
-  // Publish the package
-  log.info(`Publishing ${packageInfo.name} to npm...`);
-  const publishResult = runCommand('npm publish --access public', { cwd: packagePath });
-  
+
+  // Publish the package — explicit --tag when pre-release so we never
+  // overwrite `latest` by accident.
+  log.info(`Publishing ${packageInfo.name} to npm under ${tagSummary}...`);
+  const publishCmd = tag
+    ? `npm publish --access public --tag ${tag}`
+    : 'npm publish --access public';
+  const publishResult = runCommand(publishCmd, { cwd: packagePath });
+
   if (publishResult.success) {
-    log.success(`Successfully published ${packageInfo.name}@${packageInfo.version}`);
+    log.success(`Successfully published ${packageInfo.name}@${packageInfo.version} under ${tagSummary}`);
     return true;
   } else {
     log.error(`Failed to publish ${packageInfo.name}`);
@@ -165,15 +188,17 @@ async function main() {
   // Preliminary checks
   checkDirectory();
   
-  // Ensure grpc_codegen is up to date and packages are built before publishing
-  log.info('Regenerating protobuf code (yarn protoc-gen)...');
-  const protocResult = runCommand('yarn protoc-gen');
-  if (!protocResult.success) {
-    log.error('Failed to run protoc-gen. Aborting.');
+  // Regenerate OpenAPI types from the vendored openapi.yaml snapshot
+  // before building. (The v2.x line ran `yarn protoc-gen` here for the
+  // gRPC code path; v4 is REST-only and uses openapi-typescript.)
+  log.info('Regenerating OpenAPI types (yarn types-gen)...');
+  const typesGenResult = runCommand('yarn types-gen');
+  if (!typesGenResult.success) {
+    log.error('Failed to run types-gen. Aborting.');
     process.exit(1);
   }
-  log.success('Protobuf code regenerated');
-  
+  log.success('OpenAPI types regenerated');
+
   log.info('Building all packages (yarn build)...');
   const buildResult = runCommand('yarn build');
   if (!buildResult.success) {

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -259,11 +259,13 @@ main_publish() {
     local types_version=$(get_package_version "packages/types")
     local sdk_name=$(get_package_name "packages/sdk-js")
     local sdk_version=$(get_package_version "packages/sdk-js")
-    
+    local types_tag=$(pick_publish_tag "$types_version")
+    local sdk_tag=$(pick_publish_tag "$sdk_version")
+
     print_status "Packages to publish:"
-    echo "  - $types_name@$types_version"
-    echo "  - $sdk_name@$sdk_version"
-    
+    echo "  - $types_name@$types_version (dist-tag '${types_tag:-latest}')"
+    echo "  - $sdk_name@$sdk_version (dist-tag '${sdk_tag:-latest}')"
+
     if [[ "$dry_run" == "true" ]]; then
         print_warning "DRY RUN MODE - No packages will actually be published"
         return 0

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -121,9 +121,28 @@ get_package_name() {
 check_version_exists() {
     local package_name=$1
     local version=$2
-    
+
     npm view "$package_name@$version" version > /dev/null 2>&1
     return $?
+}
+
+# Pick the npm dist-tag from a semver string. Stable versions (no
+# pre-release identifier, e.g. "4.0.0") return empty → npm uses its
+# `latest` default. Pre-release versions route by their identifier:
+# `4.0.0-dev.N` → `dev`, `4.0.0-rc.N` → `next`, anything else → the
+# first dot-segment. Mirrors pickPublishTag() in publish-packages.js.
+pick_publish_tag() {
+    local version=$1
+    case "$version" in
+        *-*)
+            local pre="${version#*-}"
+            local id="${pre%%.*}"
+            if [[ "$id" == "rc" ]]; then echo "next"; else echo "$id"; fi
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
 }
 
 # Function to publish a package
@@ -131,9 +150,16 @@ publish_package() {
     local package_path=$1
     local package_name=$(get_package_name "$package_path")
     local package_version=$(get_package_version "$package_path")
-    
-    print_status "Publishing $package_name@$package_version"
-    
+    local tag=$(pick_publish_tag "$package_version")
+    local tag_summary
+    if [[ -n "$tag" ]]; then
+        tag_summary="dist-tag '$tag'"
+    else
+        tag_summary="dist-tag 'latest' (stable)"
+    fi
+
+    print_status "Publishing $package_name@$package_version ($tag_summary)"
+
     # Check if this version already exists
     if check_version_exists "$package_name" "$package_version"; then
         print_warning "$package_name@$package_version already exists on npm"
@@ -144,10 +170,10 @@ publish_package() {
             return 0
         fi
     fi
-    
+
     # Change to package directory
     cd "$package_path"
-    
+
     # Run build to ensure package is ready
     print_status "Building $package_name..."
     npm run build
@@ -156,17 +182,22 @@ publish_package() {
         cd - > /dev/null
         return 1
     fi
-    
-    # Publish the package
-    print_status "Publishing $package_name to npm..."
-    npm publish --access public
+
+    # Publish the package — explicit --tag for pre-releases so we
+    # never overwrite `latest` by accident.
+    print_status "Publishing $package_name to npm under $tag_summary..."
+    if [[ -n "$tag" ]]; then
+        npm publish --access public --tag "$tag"
+    else
+        npm publish --access public
+    fi
     local publish_result=$?
     
     # Return to root directory
     cd - > /dev/null
     
     if [[ $publish_result -eq 0 ]]; then
-        print_success "Successfully published $package_name@$package_version"
+        print_success "Successfully published $package_name@$package_version under $tag_summary"
         return 0
     else
         print_error "Failed to publish $package_name"


### PR DESCRIPTION
## Summary

Two bugs in `scripts/publish-packages.js` + `.sh` that would have bitten the v4 GA cutover hard:

### 1. `npm publish` missing `--tag` — would clobber `latest`

The publish call ran:

```bash
npm publish --access public
```

with no `--tag` flag. npm defaults `--tag` to `latest`, so any version — including pre-releases like `4.0.0-dev.4` — would have been published as the new `latest`. The current `latest` is `2.17.0` (the stable v2 gRPC line); a v4 pre-release silently clobbering that would break every consumer doing `npm install @avaprotocol/sdk-js` with no pin.

The new `pickPublishTag(version)` helper inspects the semver pre-release identifier:

| Version | Picked tag |
|---|---|
| `4.0.0` (stable, no suffix) | `null` → npm default `latest` |
| `4.0.0-dev.N` | `dev` |
| `4.0.0-rc.N` | `next` |
| `4.0.0-alpha.N` / `4.0.0-beta.N` | `alpha` / `beta` verbatim |

The script passes `--tag <picked>` only for pre-releases; stable versions still use the npm default. The `.sh` equivalent mirrors the same logic.

### 2. `yarn protoc-gen` step is stale — script aborts before publishing

The pre-publish step ran `yarn protoc-gen` — a leftover from the v2.x gRPC codebase. v4 is REST-only and the script no longer exists, so the publish script aborted before reaching the publish step. Replaced with `yarn types-gen` (openapi-typescript regeneration) to match the v4 build flow.

## Verification

Dry-run output against current `4.0.0-dev.0` / `4.0.0-dev.3`:

```
[INFO] Publishing @avaprotocol/types@4.0.0-dev.0 (dist-tag 'dev')
[INFO] Publishing @avaprotocol/sdk-js@4.0.0-dev.3 (dist-tag 'dev')
```

Confirmed correct tag detection. For the upcoming `3.0.0` GA cutover, the script will fall through to npm's default `latest` because there's no pre-release suffix.

## Test plan

- [x] `node scripts/publish-packages.js --dry-run` — types-gen runs, build succeeds, version detection picks `dev` tag for pre-release versions
- [ ] Live publish of the 3.0.0 GA release (separate PR) — will validate the stable-version path (`latest` tag, no `--tag` flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
