### PR TITLE
release: 3.0.0 — restore npm semver continuity from 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Ava SDK for JavaScript/TypeScript
 
+`ava-sdk-js` is the official TypeScript SDK for Ava Protocol's AVS.
+
+> **3.0.0 is a REST-only rewrite.** The 2.x line spoke gRPC; the 3.x line speaks the aggregator gateway's `/api/v1/...` REST API. The `4.0.0-dev.X` versions on npm are pre-release iterations of this rewrite that we ultimately stabilized as `3.0.0` to keep semver continuity from 2.x — see [packages/sdk-js/CHANGELOG.md](./packages/sdk-js/CHANGELOG.md) for the full rationale. The sections below still describe the 2.x gRPC client; an updated quick-start for the 3.x REST client is tracked in a follow-up doc PR.
+
 `ava-sdk-js` is a simple, type-safe wrapper around gRPC designed to simplify integration with Ava Protocol's AVS. It enables developers to interact with Ava Protocol efficiently, whether on the client-side or server-side, and provides full TypeScript support for a seamless development experience.
 
 ## Features

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @avaprotocol/sdk-js
 
+## 3.0.0
+
+### Major Changes — REST cutover
+
+`@avaprotocol/sdk-js` is now a REST client. The gRPC client surface that powered every 2.x release has been archived; the SDK speaks the OpenAPI-described REST surface (`/api/v1/...`) of the aggregator gateway directly. This is a hard break from 2.x — there is no compat shim.
+
+**What's new in 3.0.0:**
+
+- **REST `Client`** — `import { Client } from "@avaprotocol/sdk-js"` constructs a Bearer-JWT client; resource sub-clients (`client.auth`, `client.workflows`, `client.wallets`, `client.executions`, `client.secrets`, `client.tokens`, `client.nodes`, `client.triggers`, `client.operators`, `client.health`) replace the old gRPC method surface.
+- **Position D auth** — `buildAuthMessage({ ownerAddress, chainId, version })` requires the wallet's currently-connected chainId and the gateway version (fetched from `client.health.check()`). The previous silent defaults (`Chains.EigenLayerAuth` / `"v4-sdk"`) are gone. See [studio/docs/AUTH_POSITION_D_MIGRATION.md](https://github.com/AvaProtocol/studio/blob/main/docs/AUTH_POSITION_D_MIGRATION.md) for the migration rationale.
+- **Protocol catalog** — `Protocols` re-exports from `@avaprotocol/protocols`. 14 protocols (AAVE v3, Uniswap v3, Chainlink, etc.) across mainnet, Base, Sepolia, Base Sepolia.
+- **Typed builders** — `Triggers.cron()`, `Triggers.event()`, `Triggers.block()`, `Triggers.fixedTime()`, `Nodes.contractWrite()`, `Nodes.restApi()`, etc. return discriminated-union-shaped objects so the OpenAPI types validate at compile time.
+- **Generated types** — `@avaprotocol/types@^3.0.0` ships the OpenAPI-derived TypeScript types (`components`, `paths`, `v4.*` re-exports) the SDK and consumers can import directly.
+
+**Why 3.0.0 (not 4.0.0):**
+
+The pre-release dev iterations of the REST rewrite (`4.0.0-dev.0` through `4.0.0-dev.3`) used a major version that matched the internal codebase generation tag (`src/v4/` directory). Publishing the stable release as `3.0.0` instead restores npm semver continuity from `2.17.0` — consumers see the expected major bump cadence. The `src/v4/` internal directory name is preserved as a codebase generation tag (the prior gRPC iteration was internally "v3" but published as the 2.x line, and the REST rewrite is "v4" internally regardless of its npm version).
+
+The `4.0.0-dev.X` versions remain on npm under the `dev` dist-tag for anyone who pinned them during the rewrite; they're functionally equivalent to the 3.0.0 release minus the Position D auth changes (round 1 of the breaking SDK changes).
+
 ## 2.17.0
 
 ### Minor Changes

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -1,6 +1,10 @@
 # Ava SDK for JavaScript/TypeScript
 
-`@avaprotocol/sdk-js` is a simple, type-safe wrapper around gRPC designed to simplify integration with Ava Protocol’s AVS. It enables developers to interact with Ava Protocol efficiently, whether on the client-side or server-side, and provides full TypeScript support for a seamless development experience.
+`@avaprotocol/sdk-js` is the official TypeScript SDK for Ava Protocol's AVS.
+
+> **3.0.0 is a REST-only rewrite.** The 2.x line spoke gRPC; the 3.x line speaks the aggregator gateway's `/api/v1/...` REST API. The `4.0.0-dev.X` versions on npm are pre-release iterations of this rewrite that we ultimately stabilized as `3.0.0` to keep semver continuity from 2.x — see [CHANGELOG.md](./CHANGELOG.md) for the full rationale. The README sections below still describe the 2.x gRPC client; an updated quick-start for the 3.x REST client is tracked in a follow-up doc PR.
+
+`@avaprotocol/sdk-js` is a simple, type-safe wrapper around gRPC designed to simplify integration with Ava Protocol's AVS. It enables developers to interact with Ava Protocol efficiently, whether on the client-side or server-side, and provides full TypeScript support for a seamless development experience.
 
 ## Features
 

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avaprotocol/sdk-js",
-  "version": "4.0.0-dev.3",
+  "version": "3.0.0",
   "description": "TypeScript SDK for Ava Protocol's AVS REST API (v4). Resource-grouped sub-clients, fetch transport, EIP-191 auth.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@avaprotocol/protocols": "^0.2.0",
-    "@avaprotocol/types": "4.0.0-dev.0",
+    "@avaprotocol/types": "^3.0.0",
     "dotenv": "^16.4.5",
     "ethers": "^6.13.2"
   },

--- a/packages/sdk-js/src/v4/protocols/index.ts
+++ b/packages/sdk-js/src/v4/protocols/index.ts
@@ -1,6 +1,6 @@
 // Protocol catalog re-export.
 //
-// As of 4.0.0-dev.3 the actual address/ABI/topic data lives in the
+// As of 3.0.0 the actual address/ABI/topic data lives in the
 // standalone `@avaprotocol/protocols` package — the SDK ships a thin
 // re-export so consumers don't have to install a second package and
 // the existing `import { Protocols } from "@avaprotocol/sdk-js"`

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @avaprotocol/types
 
+## 3.0.0
+
+### Major Changes — OpenAPI-derived types for the REST aggregator
+
+`@avaprotocol/types` is now the OpenAPI-derived TypeScript type surface for the aggregator's `/api/v1/...` REST API. The protobuf-derived types that powered every 2.x release are archived alongside the gRPC SDK client (see `@avaprotocol/sdk-js@3.0.0`).
+
+**What's new in 3.0.0:**
+
+- **OpenAPI schemas** — `components["schemas"]["..."]` resolves to every aggregator schema (workflows, executions, wallets, secrets, tokens, nodes, triggers, health, auth, etc.).
+- **`v4.*` namespace re-exports** — convenience aliases for the most commonly consumed shapes (`v4.Workflow`, `v4.Execution`, `v4.HealthStatus`, `v4.AuthExchangeRequest`, etc.). The `v4` prefix mirrors the internal codebase generation tag in `@avaprotocol/sdk-js`; see that package's CHANGELOG for the codebase-vs-npm versioning rationale.
+- **`HealthStatus.version` now required** — Position D auth depends on this field; the schema reflects that.
+- **New wallet routing fields** — `CreateWalletRequest.chainId` (body override) and `GetWalletNonce` `?chainId=` query param mirror the gateway's per-request chain override path.
+
+**Why 3.0.0 (not 4.0.0):**
+
+The `4.0.0-dev.0` pre-release that shipped during the REST rewrite has been superseded by `3.0.0` to keep npm semver continuous from `2.13.0`. See `@avaprotocol/sdk-js@3.0.0` for the full versioning rationale.
+
 ## 2.13.0
 
 ### Minor Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avaprotocol/types",
-  "version": "4.0.0-dev.0",
+  "version": "3.0.0",
   "description": "Type definitions for Ava Protocol's AVS REST API (v4) — generated from api/openapi.yaml.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Stable 3.0.0 release of `@avaprotocol/sdk-js` + `@avaprotocol/types`, ending the `4.0.0-dev.X` pre-release line.

| Package | Before | After |
|---|---|---|
| `@avaprotocol/sdk-js` | `4.0.0-dev.3` | `3.0.0` |
| `@avaprotocol/types` | `4.0.0-dev.0` | `3.0.0` |
| `sdk-js → types` dep | `4.0.0-dev.0` | `^3.0.0` |

## Why 3.0.0 (not 4.0.0)

The pre-release dev iterations (`4.0.0-dev.0` → `4.0.0-dev.3`) used a major version that matched the internal codebase generation tag (`src/v4/` directory). Publishing the stable as `3.0.0` instead restores npm semver continuity from `2.17.0` — consumers see the expected single-major bump rather than a skipped major.

The `src/v4/` internal directory name is preserved as a codebase generation tag — the prior gRPC iteration was internally "v3" but published as the 2.x npm line, and the REST rewrite is "v4" internally regardless of its npm version. Renaming the internal directories would be cosmetic churn with no consumer-visible benefit; the npm version is what consumers see.

The `4.0.0-dev.X` versions remain on npm under the `dev` dist-tag for anyone who pinned them during the rewrite; they're functionally equivalent to 3.0.0 minus the Position D auth changes shipped in #214.

## What's in this PR

- `packages/types/package.json`: `4.0.0-dev.0` → `3.0.0`
- `packages/sdk-js/package.json`: `4.0.0-dev.3` → `3.0.0` (+ types dep bumped to `^3.0.0`)
- CHANGELOG entries for both packages explaining the cutover, the breaking changes vs 2.x, and the npm-continuity rationale
- README "Versioning notes" callout at the top of both READMEs flagging the rewrite + pointing at CHANGELOG for the detail
- Stale `// As of 4.0.0-dev.3` code comment in `packages/sdk-js/src/v4/protocols/index.ts` updated to `3.0.0`

## What is NOT in this PR

- **README content past the version-note callout still describes the 2.x gRPC client.** Rewriting it for the 3.x REST client is a follow-up doc PR — out of scope for the version cutover.
- **No changeset markdown file.** Changesets supports `patch`/`minor`/`major` bumps *from* the current version (`4.0.0-dev.3` → `4.0.0`, `4.1.0`, or `5.0.0`). Going backwards to `3.0.0` requires manual version setting. Future releases go through changesets normally.

## Prerequisite: merge #216 first

The publish scripts on `main` are broken in two ways that [#216](https://github.com/AvaProtocol/ava-sdk-js/pull/216) (chore/publish-script-tag-detection) fixes:

1. No `--tag` flag → would publish any version as `latest` (correct for 3.0.0 stable by coincidence, but would silently clobber `latest=2.17.0` with any future pre-release).
2. Pre-publish step runs `yarn protoc-gen` (v2.x gRPC leftover), aborts the script before publish.

**Recommended sequence:**
1. Merge #216
2. Merge this PR
3. From a freshly-pulled `main`: `yarn publish` (now safe — picks `latest` automatically for stable 3.0.0)
4. Tag the release on GitHub: `gh release create v3.0.0 --title "v3.0.0" --notes-from-tag`

Or, if you want to publish manually before #216 lands:

```bash
cd packages/types && npm publish --access public
cd ../sdk-js   && npm publish --access public
```

Stable `3.0.0` has no pre-release suffix, so npm's default `latest` tag is correct — the `--tag` bug only bites pre-releases.

## Test plan

- [x] `yarn install` — lockfile clean
- [x] `yarn workspace @avaprotocol/types build` — clean
- [x] `yarn workspace @avaprotocol/sdk-js build` — clean
- [x] `yarn test tests/v4/smoke.test.ts` — 12/12 pass
- [x] `npx tsc --noEmit -p .` — no new errors (pre-existing estimateFees + smoke.test cast errors unchanged)
- [ ] After merge + `yarn publish`: verify `npm view @avaprotocol/sdk-js dist-tags` shows `latest: 3.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
