### PR TITLE
docs: address post-merge review of #217 (3.0.0 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 > **3.0.0 is a REST-only rewrite.** The 2.x line spoke gRPC; the 3.x line speaks the aggregator gateway's `/api/v1/...` REST API. The `4.0.0-dev.X` versions on npm are pre-release iterations of this rewrite that we ultimately stabilized as `3.0.0` to keep semver continuity from 2.x — see [packages/sdk-js/CHANGELOG.md](./packages/sdk-js/CHANGELOG.md) for the full rationale. The sections below still describe the 2.x gRPC client; an updated quick-start for the 3.x REST client is tracked in a follow-up doc PR.
 
-`ava-sdk-js` is a simple, type-safe wrapper around gRPC designed to simplify integration with Ava Protocol's AVS. It enables developers to interact with Ava Protocol efficiently, whether on the client-side or server-side, and provides full TypeScript support for a seamless development experience.
+> **[2.x — archived]** `ava-sdk-js` was a simple, type-safe wrapper around gRPC designed to simplify integration with Ava Protocol's AVS. It enabled developers to interact with Ava Protocol efficiently, whether on the client-side or server-side, and provided full TypeScript support for a seamless development experience.
+
+---
+
+## Archived 2.x documentation
+
+The sections below describe the 2.x gRPC client and are kept for users still on that line. The 3.x REST client documentation is tracked in a follow-up doc PR; in the meantime see the [packages/sdk-js/CHANGELOG.md](./packages/sdk-js/CHANGELOG.md) for what changed between 2.x and 3.x.
 
 ## Features
 

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -4,7 +4,13 @@
 
 > **3.0.0 is a REST-only rewrite.** The 2.x line spoke gRPC; the 3.x line speaks the aggregator gateway's `/api/v1/...` REST API. The `4.0.0-dev.X` versions on npm are pre-release iterations of this rewrite that we ultimately stabilized as `3.0.0` to keep semver continuity from 2.x — see [CHANGELOG.md](./CHANGELOG.md) for the full rationale. The README sections below still describe the 2.x gRPC client; an updated quick-start for the 3.x REST client is tracked in a follow-up doc PR.
 
-`@avaprotocol/sdk-js` is a simple, type-safe wrapper around gRPC designed to simplify integration with Ava Protocol's AVS. It enables developers to interact with Ava Protocol efficiently, whether on the client-side or server-side, and provides full TypeScript support for a seamless development experience.
+> **[2.x — archived]** `@avaprotocol/sdk-js` was a simple, type-safe wrapper around gRPC designed to simplify integration with Ava Protocol's AVS. It enabled developers to interact with Ava Protocol efficiently, whether on the client-side or server-side, and provided full TypeScript support for a seamless development experience.
+
+---
+
+## Archived 2.x documentation
+
+The sections below describe the 2.x gRPC client and are kept for users still on that line. The 3.x REST client documentation is tracked in a follow-up doc PR; in the meantime see the [CHANGELOG](./CHANGELOG.md) for what changed between 2.x and 3.x.
 
 ## Features
 

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@avaprotocol/sdk-js",
   "version": "3.0.0",
-  "description": "TypeScript SDK for Ava Protocol's AVS REST API (v4). Resource-grouped sub-clients, fetch transport, EIP-191 auth.",
+  "description": "TypeScript SDK for Ava Protocol's AVS REST API. Resource-grouped sub-clients, fetch transport, EIP-191 auth.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/sdk-js/src/v4/protocols/index.ts
+++ b/packages/sdk-js/src/v4/protocols/index.ts
@@ -1,10 +1,10 @@
 // Protocol catalog re-export.
 //
-// As of 3.0.0 the actual address/ABI/topic data lives in the
-// standalone `@avaprotocol/protocols` package — the SDK ships a thin
-// re-export so consumers don't have to install a second package and
-// the existing `import { Protocols } from "@avaprotocol/sdk-js"`
-// surface keeps working.
+// Address/ABI/topic data lives in the standalone
+// `@avaprotocol/protocols` package — the SDK ships a thin re-export
+// so consumers don't have to install a second package and the
+// existing `import { Protocols } from "@avaprotocol/sdk-js"` surface
+// keeps working.
 //
 // Update `@avaprotocol/protocols` (https://github.com/AvaProtocol/protocols)
 // when a new protocol address lands or a new chain comes online;


### PR DESCRIPTION
## Summary

Post-merge follow-up addressing Claude's review of [#217](https://github.com/AvaProtocol/ava-sdk-js/pull/217) (3.0.0 release). All three flagged issues are documentation / code-comment hygiene — no behavior change.

## What's fixed

### 1. README contradiction (both READMEs)

The "3.0.0 is a REST-only rewrite" callout warned readers the next sections were stale, but the immediately following paragraph still confidently asserted *"is a simple, type-safe wrapper around gRPC"*. A first-time reader skimming would hit that and reasonably conclude the callout was wrong.

Fix:
- Reword the lead paragraph from present → past tense and prefix with `[2.x — archived]`
- Insert an `## Archived 2.x documentation` section header before `## Features` so the stale-zone is unambiguous through the remaining 2.x bullets / install instructions / getting started, until the proper REST quick-start lands in a follow-up doc PR

### 2. Source-code version anchor (CLAUDE.md style guide)

`packages/sdk-js/src/v4/protocols/index.ts` had `// As of 3.0.0 the actual address/ABI/topic data lives in the standalone @avaprotocol/protocols package`. Per the convention, version anchors belong in the CHANGELOG; the source comment should explain the WHY without pegging itself to a moment in time (this one silently becomes stale at 3.0.1). Dropped the `As of 3.0.0` prefix; kept the factual description.

### 3. `package.json` description

`packages/sdk-js/package.json` `description` said `"TypeScript SDK for Ava Protocol's AVS REST API (v4). ..."`. The `(v4)` referred to the internal codebase generation tag — accurate but confusing on a `3.0.0` package listing on npm. Dropped.

## Test plan

- [x] `yarn workspace @avaprotocol/sdk-js build` — clean
- [x] `yarn test tests/v4/smoke.test.ts` — 12/12 pass
- [x] No behavior change — only docs + comments + npm description text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
