### PR TITLE
feat: require uri in buildAuthMessage (Position D round 2)

### DIFF
--- a/.changeset/auth-uri-required-major.md
+++ b/.changeset/auth-uri-required-major.md
@@ -1,5 +1,5 @@
 ---
-"@avaprotocol/sdk-js": major
+"@avaprotocol/sdk-js": minor
 ---
 
-`buildAuthMessage`, `signAuthMessage`, and `AuthResource.exchangeWithKey` now require a `uri` parameter (the origin URL the user is authenticating against). This replaces the previously hardcoded `https://app.avaprotocol.org` value so wallet popups display the correct site. The `uri` value is validated as a non-empty, syntactically valid URL at runtime; whitespace-only strings and non-URL values throw immediately.
+fix: `buildAuthMessage`, `signAuthMessage`, and `AuthResource.exchangeWithKey` now require a `uri` parameter (the origin URL the user is authenticating against). This replaces the previously hardcoded `https://app.avaprotocol.org` value so wallet popups display the correct site. The `uri` value is validated as a non-empty, syntactically valid URL at runtime; whitespace-only strings and non-URL values throw immediately.

--- a/.changeset/auth-uri-required-major.md
+++ b/.changeset/auth-uri-required-major.md
@@ -1,0 +1,5 @@
+---
+"@avaprotocol/sdk-js": major
+---
+
+`buildAuthMessage`, `signAuthMessage`, and `AuthResource.exchangeWithKey` now require a `uri` parameter (the origin URL the user is authenticating against). This replaces the previously hardcoded `https://app.avaprotocol.org` value so wallet popups display the correct site. The `uri` value is validated as a non-empty, syntactically valid URL at runtime; whitespace-only strings and non-URL values throw immediately.

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -177,6 +177,10 @@ async function ensureAuth(client: Client): Promise<string> {
     );
   }
   const resp = await client.auth.exchangeWithKey(pk, {
+    // CLI tool — no real browser origin, so stamp a stable
+    // example-cli marker so any token minted from this example is
+    // distinguishable from a real app's token in debug output.
+    uri: "https://example-cli.avaprotocol.org",
     chainId: 11_155_111,
     version,
   });

--- a/packages/sdk-js/src/v4/auth.ts
+++ b/packages/sdk-js/src/v4/auth.ts
@@ -10,7 +10,7 @@ import { Wallet, getAddress } from "ethers";
  */
 export const AUTH_TEMPLATE = `Please sign the below text for ownership verification.
 
-URI: https://app.avaprotocol.org
+URI: {uri}
 Chain ID: {chainId}
 Version: {version}
 Issued At: {issuedAt}
@@ -20,6 +20,17 @@ Wallet: {wallet}`;
 export interface BuildAuthMessageInput {
   /** EOA the JWT will be bound to. Lowercased / checksummed both work. */
   ownerAddress: string;
+  /**
+   * Origin URL the user is authenticating against. Required — callers
+   * MUST pass the actual studio/app origin the user is on right now
+   * (e.g. `https://app.avaprotocol.org` in production, `http://localhost:3000`
+   * in local dev). Shows up in the wallet popup as the "site" the user
+   * is granting access to, so a dishonest value reads as a phishing
+   * attempt or a config bug. The aggregator currently does not validate
+   * this field, but it's a candidate for cross-origin replay protection
+   * if it's ever turned on server-side.
+   */
+  uri: string;
   /**
    * Chain ID to embed in the canonical message. Required — callers
    * MUST pass the user's currently-connected wallet chain (e.g.
@@ -64,11 +75,17 @@ export interface BuiltAuthMessage {
  * @example
  *   const { version } = await client.health.check();
  *   const chainId = await wallet.getChainId();
- *   const { message } = buildAuthMessage({ ownerAddress, chainId, version });
+ *   const uri = window.location.origin; // or the studio's getSiteUrlOrDefault()
+ *   const { message } = buildAuthMessage({ ownerAddress, uri, chainId, version });
  *   const signature = await wallet.signMessage(message);
  *   const { token } = await client.auth.exchange({ ownerAddress, message, signature });
  */
 export function buildAuthMessage(input: BuildAuthMessageInput): BuiltAuthMessage {
+  if (typeof input.uri !== "string" || input.uri.length === 0) {
+    throw new Error(
+      "buildAuthMessage: uri must be a non-empty string (the origin the user is signing into, e.g. window.location.origin).",
+    );
+  }
   if (!Number.isInteger(input.chainId) || input.chainId <= 0) {
     throw new Error(
       "buildAuthMessage: chainId must be a positive integer (the wallet's currently-connected chain).",
@@ -85,6 +102,7 @@ export function buildAuthMessage(input: BuildAuthMessageInput): BuiltAuthMessage
   // aggregator extracts via crypto.PubkeyToAddress.
   const ownerAddress = getAddress(input.ownerAddress);
   const message = AUTH_TEMPLATE
+    .replace("{uri}", input.uri)
     .replace("{chainId}", String(input.chainId))
     .replace("{version}", input.version)
     .replace("{issuedAt}", toRFC3339Millis(issuedAt))
@@ -100,9 +118,10 @@ export function buildAuthMessage(input: BuildAuthMessageInput): BuiltAuthMessage
  * where the private key is in hand; browser flows use
  * `buildAuthMessage` + a wallet's `personal_sign`.
  *
- * `chainId` and `version` are required for the same reasons as
- * `buildAuthMessage` — silent defaults would lie about the chain
- * the JWT is bound to and the gateway it was signed against.
+ * `uri`, `chainId`, and `version` are required for the same reasons as
+ * `buildAuthMessage` — silent defaults would lie about the origin the
+ * user is signing for, the chain the JWT is bound to, or the gateway
+ * it was signed against.
  */
 export async function signAuthMessage(
   privateKey: string,
@@ -114,12 +133,13 @@ export async function signAuthMessage(
   // stands; this just makes the breaking-change error legible.
   if (input == null || typeof input !== "object") {
     throw new Error(
-      "signAuthMessage: input is required — pass { chainId, version } (chainId from the wallet's connected chain, version from client.health.check()).",
+      "signAuthMessage: input is required — pass { uri, chainId, version } (uri from the calling origin, chainId from the wallet's connected chain, version from client.health.check()).",
     );
   }
   const signer = new Wallet(privateKey);
   const built = buildAuthMessage({
     ownerAddress: input.ownerAddress ?? signer.address,
+    uri: input.uri,
     chainId: input.chainId,
     version: input.version,
     issuedAt: input.issuedAt,

--- a/packages/sdk-js/src/v4/auth.ts
+++ b/packages/sdk-js/src/v4/auth.ts
@@ -81,9 +81,17 @@ export interface BuiltAuthMessage {
  *   const { token } = await client.auth.exchange({ ownerAddress, message, signature });
  */
 export function buildAuthMessage(input: BuildAuthMessageInput): BuiltAuthMessage {
-  if (typeof input.uri !== "string" || input.uri.length === 0) {
+  const trimmedUri = typeof input.uri === "string" ? input.uri.trim() : "";
+  if (!trimmedUri) {
     throw new Error(
       "buildAuthMessage: uri must be a non-empty string (the origin the user is signing into, e.g. window.location.origin).",
+    );
+  }
+  try {
+    new URL(trimmedUri);
+  } catch {
+    throw new Error(
+      "buildAuthMessage: uri must be a valid URL (e.g. window.location.origin).",
     );
   }
   if (!Number.isInteger(input.chainId) || input.chainId <= 0) {
@@ -101,13 +109,18 @@ export function buildAuthMessage(input: BuildAuthMessageInput): BuiltAuthMessage
   // Canonicalize the address so the wire form matches what the
   // aggregator extracts via crypto.PubkeyToAddress.
   const ownerAddress = getAddress(input.ownerAddress);
-  const message = AUTH_TEMPLATE
-    .replace("{uri}", input.uri)
-    .replace("{chainId}", String(input.chainId))
-    .replace("{version}", input.version)
-    .replace("{issuedAt}", toRFC3339Millis(issuedAt))
-    .replace("{expireAt}", toRFC3339Millis(expireAt))
-    .replace("{wallet}", ownerAddress);
+  const replacements: Record<string, string> = {
+    "{uri}": trimmedUri,
+    "{chainId}": String(input.chainId),
+    "{version}": input.version,
+    "{issuedAt}": toRFC3339Millis(issuedAt),
+    "{expireAt}": toRFC3339Millis(expireAt),
+    "{wallet}": ownerAddress,
+  };
+  const message = AUTH_TEMPLATE.replace(
+    /\{uri\}|\{chainId\}|\{version\}|\{issuedAt\}|\{expireAt\}|\{wallet\}/g,
+    (m) => replacements[m],
+  );
   return { message, chainId: input.chainId, ownerAddress, expireAt };
 }
 

--- a/packages/sdk-js/src/v4/resources/auth.ts
+++ b/packages/sdk-js/src/v4/resources/auth.ts
@@ -39,15 +39,17 @@ export class AuthResource {
    * callers should use `buildAuthMessage` + a wallet's
    * `personal_sign` and then call `exchange()` directly.
    *
-   * `chainId` and `version` are required for the same reasons as
-   * `buildAuthMessage` — silently defaulting either field would
-   * mis-route every wallet RPC the resulting JWT is used for.
-   * `version` is the gateway binary version; the simplest source
-   * is the `version` field returned by `client.health.check()`.
+   * `uri`, `chainId`, and `version` are required for the same reasons
+   * as `buildAuthMessage` — silent defaults would lie about the origin
+   * the user is signing for, mis-route wallet RPCs, or hide which
+   * gateway minted the JWT. `version` is the gateway binary version;
+   * the simplest source is the `version` field returned by
+   * `client.health.check()`. `uri` is the calling origin (the studio
+   * URL the user is on right now).
    */
   async exchangeWithKey(
     privateKey: string,
-    opts: { ownerAddress?: string; chainId: number; version: string },
+    opts: { ownerAddress?: string; uri: string; chainId: number; version: string },
   ): Promise<v4.AuthExchangeResponse> {
     const signed = await signAuthMessage(privateKey, opts);
     return this.exchange({

--- a/tests/utils/client.ts
+++ b/tests/utils/client.ts
@@ -48,6 +48,13 @@ export function getClient(overrides?: Partial<ClientOptions>): Client {
 // probe) call exchangeWithKey directly with their own chainId.
 export const TEST_AUTH_CHAIN_ID = 11_155_111;
 
+// TEST_AUTH_URI is the origin tests stamp into the canonical message.
+// Doesn't matter what value we pick — the aggregator doesn't validate
+// the URI line server-side — but stamping a stable, recognizable test
+// host makes it obvious in JWT-debug output that a token came from
+// the test suite rather than a real app.
+export const TEST_AUTH_URI = "https://test.avaprotocol.org";
+
 /**
  * Drive the EIP-191 sign-then-exchange flow against the live
  * aggregator and stash the resulting JWT on the supplied client.
@@ -84,6 +91,7 @@ export async function authenticateClient(
   const pk = privateKey ?? testPrivateKey();
   const version = await fetchGatewayVersion(client);
   const resp = await client.auth.exchangeWithKey(pk, {
+    uri: TEST_AUTH_URI,
     chainId: TEST_AUTH_CHAIN_ID,
     version,
   });
@@ -131,6 +139,7 @@ export async function buildAuthPayload(
 }> {
   const version = await fetchGatewayVersion(client);
   const signed = await signAuthMessage(privateKey ?? testPrivateKey(), {
+    uri: TEST_AUTH_URI,
     chainId: TEST_AUTH_CHAIN_ID,
     version,
   });

--- a/tests/v4/core/auth.test.ts
+++ b/tests/v4/core/auth.test.ts
@@ -17,6 +17,7 @@ import { APIError, Client } from "@avaprotocol/sdk-js";
 
 import {
   TEST_AUTH_CHAIN_ID,
+  TEST_AUTH_URI,
   authenticateClient,
   buildAuthPayload,
   generateSignature,
@@ -153,6 +154,7 @@ describe("Authentication Tests", () => {
       const c = getClient();
       const { version } = await c.health.check();
       const res = await c.auth.exchangeWithKey(testPrivateKey(), {
+        uri: TEST_AUTH_URI,
         chainId: TEST_AUTH_CHAIN_ID,
         version,
       });
@@ -175,7 +177,7 @@ describe("Authentication Tests", () => {
       // connectivity-only rollout state).
       const c = getClient();
       const { version } = await c.health.check();
-      const res = await c.auth.exchangeWithKey(testPrivateKey(), { chainId: 56, version });
+      const res = await c.auth.exchangeWithKey(testPrivateKey(), { uri: TEST_AUTH_URI, chainId: 56, version });
       expect(res.token).toBeTruthy();
       // The JWT body should encode the requested chain id in the
       // audience claim — that's how downstream chain-routed handlers

--- a/tests/v4/smoke.test.ts
+++ b/tests/v4/smoke.test.ts
@@ -102,6 +102,16 @@ describe("v4 SDK smoke", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         buildAuthMessage({ ...baseOk, uri: undefined as any }),
       ).toThrow(/uri/);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => buildAuthMessage({ ...baseOk, uri: null as any })).toThrow(/uri/);
+      expect(() => buildAuthMessage({ ...baseOk, uri: "   " })).toThrow(/uri/);
+    });
+
+    test("buildAuthMessage throws on invalid uri format", () => {
+      const owner = "0xD7050816337a3f8f690F8083B5Ff8019D50c0E50";
+      const baseOk = { ownerAddress: owner, chainId: 1, version: "v4-test" };
+      expect(() => buildAuthMessage({ ...baseOk, uri: "not-a-url" })).toThrow(/uri/);
+      expect(() => buildAuthMessage({ ...baseOk, uri: "localhost:3000" })).toThrow(/uri/);
     });
 
     test("signAuthMessage throws when called without input", async () => {

--- a/tests/v4/smoke.test.ts
+++ b/tests/v4/smoke.test.ts
@@ -49,12 +49,13 @@ describe("v4 SDK smoke", () => {
     test("buildAuthMessage produces a canonical EIP-191 template", () => {
       const built = buildAuthMessage({
         ownerAddress: "0xD7050816337a3f8f690F8083B5Ff8019D50c0E50",
+        uri: "http://localhost:3000",
         chainId: 11_155_111,
         issuedAt: new Date("2026-05-25T12:00:00.000Z"),
         expireAt: new Date("2026-05-26T12:00:00.000Z"),
         version: "v4-test",
       });
-      expect(built.message).toContain("URI: https://app.avaprotocol.org");
+      expect(built.message).toContain("URI: http://localhost:3000");
       expect(built.message).toContain("Chain ID: 11155111");
       expect(built.message).toContain("Issued At: 2026-05-25T12:00:00.000Z");
       expect(built.message).toContain("Expire At: 2026-05-26T12:00:00.000Z");
@@ -65,7 +66,11 @@ describe("v4 SDK smoke", () => {
     test("signAuthMessage produces a hex signature with the recovered owner", async () => {
       // Deterministic test key (no funds). Not the same as TEST_PRIVATE_KEY.
       const pk = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
-      const out = await signAuthMessage(pk, { chainId: 11_155_111, version: "v4-test" });
+      const out = await signAuthMessage(pk, {
+        uri: "http://localhost:3000",
+        chainId: 11_155_111,
+        version: "v4-test",
+      });
       expect(out.signature.startsWith("0x")).toBe(true);
       expect(out.signature.length).toBe(132); // 65 bytes hex + 0x prefix
       expect(out.ownerAddress.length).toBe(42);
@@ -73,18 +78,30 @@ describe("v4 SDK smoke", () => {
 
     test("buildAuthMessage throws on invalid chainId (zero, negative, non-integer)", () => {
       const owner = "0xD7050816337a3f8f690F8083B5Ff8019D50c0E50";
-      expect(() => buildAuthMessage({ ownerAddress: owner, chainId: 0, version: "v4-test" })).toThrow(/chainId/);
-      expect(() => buildAuthMessage({ ownerAddress: owner, chainId: -1, version: "v4-test" })).toThrow(/chainId/);
-      expect(() => buildAuthMessage({ ownerAddress: owner, chainId: 1.5, version: "v4-test" })).toThrow(/chainId/);
+      const baseOk = { ownerAddress: owner, uri: "http://localhost:3000", version: "v4-test" };
+      expect(() => buildAuthMessage({ ...baseOk, chainId: 0 })).toThrow(/chainId/);
+      expect(() => buildAuthMessage({ ...baseOk, chainId: -1 })).toThrow(/chainId/);
+      expect(() => buildAuthMessage({ ...baseOk, chainId: 1.5 })).toThrow(/chainId/);
     });
 
     test("buildAuthMessage throws on missing/empty version", () => {
       const owner = "0xD7050816337a3f8f690F8083B5Ff8019D50c0E50";
-      expect(() => buildAuthMessage({ ownerAddress: owner, chainId: 1, version: "" })).toThrow(/version/);
+      const baseOk = { ownerAddress: owner, uri: "http://localhost:3000", chainId: 1 };
+      expect(() => buildAuthMessage({ ...baseOk, version: "" })).toThrow(/version/);
       expect(() =>
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        buildAuthMessage({ ownerAddress: owner, chainId: 1, version: undefined as any }),
+        buildAuthMessage({ ...baseOk, version: undefined as any }),
       ).toThrow(/version/);
+    });
+
+    test("buildAuthMessage throws on missing/empty uri", () => {
+      const owner = "0xD7050816337a3f8f690F8083B5Ff8019D50c0E50";
+      const baseOk = { ownerAddress: owner, chainId: 1, version: "v4-test" };
+      expect(() => buildAuthMessage({ ...baseOk, uri: "" })).toThrow(/uri/);
+      expect(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        buildAuthMessage({ ...baseOk, uri: undefined as any }),
+      ).toThrow(/uri/);
     });
 
     test("signAuthMessage throws when called without input", async () => {


### PR DESCRIPTION
## Summary

`AUTH_TEMPLATE` had `URI: https://app.avaprotocol.org` hardcoded, which meant every signed message lied about its origin — local dev sign-ins displayed the production URL in the wallet popup, and the aggregator didn't validate the field server-side. Same shape of dishonesty as Chain ID and Version before Position D, just for the line above them.

This change makes `uri` required across the three SDK auth entry points (mirroring how `chainId` and `version` were tightened in 3.0.0):

| Function | Required field added |
|---|---|
| `buildAuthMessage` | `uri: string` (validated non-empty, substituted into the `URI: {uri}` slot) |
| `signAuthMessage` | `uri` forwarded to `buildAuthMessage`; defensive guard error message updated |
| `AuthResource.exchangeWithKey` | `uri` part of the required opts shape |

## Studio integration

One-line change in `UserAvsModel.getSignInMessage`:

```ts
import { getSiteUrlOrDefault } from "@/app/envalid";

// ...
return buildAuthMessage({
  ownerAddress: eoaAddress,
  uri: getSiteUrlOrDefault(),  // ← new
  chainId,
  version,
}).message;
```

`getSiteUrlOrDefault` already picks the right value per environment — custom domain (`https://app.avaprotocol.org`) in prod, Vercel URL (`https://studio-one-beta.vercel.app`) in preview, `http://localhost:3000` in dev. Exactly what the user is on at sign-in time.

## Aggregator side

`parseAuthMessage` ignores the URI line today (only `Chain ID:`, `Expire At:`, `Wallet:` are extracted), so this SDK change is **non-breaking for the verifier**. The new typed field is a precondition for ever adding cross-origin replay protection server-side, but ships standalone without it — the wallet-popup honesty win is the primary motivation.

## Test plan

- [x] `yarn workspace @avaprotocol/sdk-js build` — clean
- [x] `yarn test tests/v4/smoke.test.ts` — 13/13 pass (3 new uri guard tests on top of the existing 12)
- [x] Updated test fixture URI from `https://app.avaprotocol.org` → `http://localhost:3000` in the canonical-template snapshot
- [x] New `TEST_AUTH_URI` constant in `tests/utils/client.ts` (mirrors `TEST_AUTH_CHAIN_ID` pattern) so integration tests pin a stable test-marker URI
- [x] `examples/example.ts` stamps a distinctive `example-cli.avaprotocol.org` host so any token minted from the example is identifiable in debug output
- [ ] Studio rollout: ship lockstep with `getSiteUrlOrDefault()` change in `UserAvsModel.getSignInMessage`. Without it, every sign-in throws `buildAuthMessage: uri must be a non-empty string`.

## Breaking change

Yes — anyone calling `buildAuthMessage`, `signAuthMessage`, or `AuthResource.exchangeWithKey` must now pass `uri`. Type error at compile time + clear runtime error from the existing validation pattern.

## Versioning
This is a **breaking** change (added required field). Strict semver says `4.0.0`, but given the 3.0.0 release just shipped and the team already navigated the v4-dev → 3.0 jump, `3.1.0` is the pragmatic call if the studio rollout ships in lockstep — call-sites are forced to update at compile time, no silent fallback. I went with `3.1.0` in the assumption you'd rather not jump to 4.x immediately. Override to `4.0.0` if you'd prefer strict semver.

