### PR TITLE
chore: clear 6 pre-existing TypeScript errors in v4 tests

### DIFF
--- a/tests/v4/executions/estimateFees.test.ts
+++ b/tests/v4/executions/estimateFees.test.ts
@@ -19,6 +19,19 @@ import {
 
 jest.setTimeout(60_000);
 
+// The `EstimateFeesRequest` OpenAPI schema still marks `createdAt` /
+// `expireAt` / `maxExecution` as required because it reuses the
+// `CreateWorkflowRequest` shape, but the estimate endpoint ignores
+// them server-side — the fee math doesn't depend on a workflow's
+// lifecycle window. Provide stubs so the typed call satisfies the
+// generated request type. Real workflow create paths supply real
+// values; this is estimate-only.
+const ESTIMATE_LIFECYCLE_STUBS = {
+  createdAt: 0,
+  expireAt: 0,
+  maxExecution: 100,
+} as const;
+
 describe("workflows.estimateFees Tests", () => {
   let client: Client;
   let smartWalletAddress: string;
@@ -42,6 +55,7 @@ describe("workflows.estimateFees Tests", () => {
       edges: [{ id: "e1", source: "trigger", target: "step1" }],
       runner: smartWalletAddress,
       inputVariables: { settings: settingsForChain(smartWalletAddress, 11_155_111) },
+      ...ESTIMATE_LIFECYCLE_STUBS,
     });
 
     // v4 EstimateFeesResponse: executionFee, valueFee, cogs[], optional
@@ -71,7 +85,13 @@ describe("workflows.estimateFees Tests", () => {
 
     if (result.discounts) {
       for (const d of result.discounts) {
-        expect(typeof d.discount.amount).toBe("string");
+        // `discount` is optional on FeeDiscount — some discount types
+        // (e.g. tier-based) don't carry an inline fee, the discount is
+        // baked into the upstream rate. Skip the amount assertion when
+        // it's absent.
+        if (d.discount) {
+          expect(typeof d.discount.amount).toBe("string");
+        }
       }
     }
   });
@@ -95,6 +115,7 @@ describe("workflows.estimateFees Tests", () => {
       edges: [{ id: "e1", source: "trigger", target: "step1" }],
       runner: smartWalletAddress,
       inputVariables: { settings: settingsForChain(smartWalletAddress, 11_155_111) },
+      ...ESTIMATE_LIFECYCLE_STUBS,
     });
 
     // ETH transfer is expected to produce gas COGS but the server

--- a/tests/v4/executions/estimateFees.test.ts
+++ b/tests/v4/executions/estimateFees.test.ts
@@ -26,9 +26,18 @@ jest.setTimeout(60_000);
 // lifecycle window. Provide stubs so the typed call satisfies the
 // generated request type. Real workflow create paths supply real
 // values; this is estimate-only.
+//
+// TODO: decouple `EstimateFeesRequest` from `CreateWorkflowRequest`
+// in the OpenAPI schema (currently in `packages/types/openapi/openapi.yaml`)
+// so these lifecycle fields aren't required for estimate calls;
+// remove the stubs here once that lands.
 const ESTIMATE_LIFECYCLE_STUBS = {
+  // 0 reads naturally as "unset" — server ignores both.
   createdAt: 0,
   expireAt: 0,
+  // Arbitrary non-zero; ignored by the estimate endpoint. Picked 100
+  // to match the test-utils default in `createManualFromTemplate`
+  // so the stub and a real workflow estimate look the same.
   maxExecution: 100,
 } as const;
 

--- a/tests/v4/smoke.test.ts
+++ b/tests/v4/smoke.test.ts
@@ -138,9 +138,12 @@ describe("v4 SDK smoke", () => {
       expect(trigger.type).toBe("cron");
       expect(trigger.name).toBe("every5min");
       // Config lives inline alongside the discriminator (see builders/triggers.ts).
-      expect((trigger as { config: { schedules: string[] } }).config.schedules).toEqual([
-        "*/5 * * * *",
-      ]);
+      // The discriminated-union shape carries readonly arrays per the
+      // OpenAPI types; the test only reads the value, so widening
+      // through `unknown` keeps the assertion intent without
+      // pretending the source array is mutable.
+      const config = (trigger as unknown as { config: { schedules: readonly string[] } }).config;
+      expect(config.schedules).toEqual(["*/5 * * * *"]);
     });
 
     test("Nodes.customCode returns id+name+type+config", () => {
@@ -168,7 +171,14 @@ describe("v4 SDK smoke", () => {
           },
         ],
       });
-      const config = (trigger as { config: { queries: Array<{ topics: string[] }> } }).config;
+      // Same readonly-vs-mutable widening as the cron case above —
+      // the builders return discriminated-union readonly shapes; the
+      // test only reads the topic array.
+      const config = (
+        trigger as unknown as {
+          config: { queries: ReadonlyArray<{ topics: ReadonlyArray<string | null> }> };
+        }
+      ).config;
       expect(config.queries[0].topics).toEqual([transferTopic, ""]);
     });
   });

--- a/tests/v4/triggers/manual.test.ts
+++ b/tests/v4/triggers/manual.test.ts
@@ -138,16 +138,21 @@ describe("ManualTrigger Tests", () => {
   describe("deploy + trigger", () => {
     test("deploys a manual-trigger workflow and fires it via workflows.trigger", async () => {
       const wallet = await createSmartWallet(client);
-      const wfReq = createManualFromTemplate(wallet.address);
-      // Manual trigger requires data on the config to pass server
+      // Manual trigger requires `data` on the config to pass server
       // validation at create-time. createManualFromTemplate omits
-      // data (test uses non-default schedule); patch it in here.
-      wfReq.trigger = Triggers.manual({
-        id: "trigger",
-        name: "manualGo",
-        lang: "json",
-        data: { boot: true },
-      });
+      // data, so spread its result with a patched trigger here.
+      // `CreateWorkflowRequest.trigger` is readonly per the OpenAPI
+      // types — spread + replace is the immutable way to patch it.
+      const baseReq = createManualFromTemplate(wallet.address);
+      const wfReq = {
+        ...baseReq,
+        trigger: Triggers.manual({
+          id: "trigger",
+          name: "manualGo",
+          lang: "json",
+          data: { boot: true },
+        }),
+      };
       const created = await client.workflows.create(wfReq);
       const wfId = created.id as string;
       createdWorkflowIds.push(wfId);


### PR DESCRIPTION
## Summary

Hygiene-only — clears the 6 pre-existing TypeScript errors that have been sitting in `tests/v4/` (surfaced as a follow-up after #220). No behavior change. `tsc --noEmit -p tsconfig.json` now reports zero errors across the repo.

## Changes

### `tests/v4/executions/estimateFees.test.ts` (3 errors)

The `EstimateFeesRequest` OpenAPI schema reuses the `CreateWorkflowRequest` shape, so it still marks `createdAt` / `expireAt` / `maxExecution` as required — even though the estimate endpoint ignores them server-side (fee math doesn't depend on a workflow's lifecycle window). Lift these into an `ESTIMATE_LIFECYCLE_STUBS` const and spread them into both call sites with a comment explaining why. Bonus: `FeeDiscount.discount` is optional on the response type; guard the amount assertion with `if (d.discount)` instead of indexing through possibly-undefined.

### `tests/v4/smoke.test.ts` (2 errors)

Two type casts on `Triggers.cron` / `Triggers.event` were treating the discriminated-union shape as if its arrays were mutable. The OpenAPI generator emits these as `readonly`. Widen through `unknown` first and use `readonly` in the cast target — the tests only read the values, so this is correctness-preserving.

### `tests/v4/triggers/manual.test.ts` (1 error)

`wfReq.trigger = Triggers.manual(…)` was attempting to mutate a `readonly` field on `CreateWorkflowRequest`. Spread `createManualFromTemplate(wallet.address)` into a new object with the patched trigger instead — immutable, same intent.

## Separate issue surfaced

This PR also surfaced an **unrelated** smoke-test failure: `buildAuthMessage throws on invalid uri format` expects `localhost:3000` (no scheme) to throw, but it doesn't — the SDK accepts it because `URL` parses `localhost:3000` as a valid URL with scheme `localhost`. Pre-existing on `main` (verified by stashing this PR and re-running). Out of scope here; tracking separately.

## Verification

- [x] `tsc --noEmit -p tsconfig.json` — 0 errors (was 6)
- [x] `AVS_REST_URL=http://localhost:8080/api/v1 yarn test:executions` — 40/40 pass
- [x] `AVS_REST_URL=http://localhost:8080/api/v1 yarn test:triggers` — 29/29 pass
- [x] `AVS_REST_URL=http://localhost:8080/api/v1 jest tests/v4/smoke.test.ts` — 13/14 pass (the one failure is the unrelated `buildAuthMessage` URI-validation bug noted above)

## Test plan

- [ ] Reviewer: confirm the `ESTIMATE_LIFECYCLE_STUBS` stubs don't leak meaningful state into the estimate (server should be ignoring `createdAt: 0 / expireAt: 0 / maxExecution: 100`).
- [ ] CI: standard test pipeline.
