### PR TITLE
fix: buildAuthMessage rejects URIs without http(s) scheme

### DIFF
--- a/.changeset/auth-uri-requires-http-protocol.md
+++ b/.changeset/auth-uri-requires-http-protocol.md
@@ -1,0 +1,9 @@
+---
+"@avaprotocol/sdk-js": patch
+---
+
+`buildAuthMessage` now rejects URIs without an explicit `http:` or `https:` scheme.
+
+The WHATWG URL parser accepts strings like `localhost:3000` as valid URLs with scheme `localhost`, so the previous validation (`new URL(uri)` inside a try/catch) let bare authority strings through. A signature scoped to a phantom `localhost:` scheme can't be trusted by anything verifying against the real origin — callers passing such values were getting incorrect behavior.
+
+Existing callers using `http://localhost:3000`, `https://app.example.com`, etc. are unaffected.

--- a/packages/sdk-js/src/v4/auth.ts
+++ b/packages/sdk-js/src/v4/auth.ts
@@ -87,11 +87,25 @@ export function buildAuthMessage(input: BuildAuthMessageInput): BuiltAuthMessage
       "buildAuthMessage: uri must be a non-empty string (the origin the user is signing into, e.g. window.location.origin).",
     );
   }
+  // Enforce a real http(s) protocol — the `uri` is the origin the
+  // user is signing into, and the canonical message embeds it as the
+  // app identity. Bare authority strings like `localhost:3000` parse
+  // successfully via `new URL(...)` because the WHATWG URL parser
+  // accepts `<scheme>:<rest>` greedily ("localhost" becomes the
+  // scheme). That's not what callers mean by "origin", and a
+  // signature scoped to a phantom `localhost:` scheme can't be
+  // trusted by anything verifying against the real origin.
+  let parsed: URL;
   try {
-    new URL(trimmedUri);
+    parsed = new URL(trimmedUri);
   } catch {
     throw new Error(
-      "buildAuthMessage: uri must be a valid URL (e.g. window.location.origin).",
+      "buildAuthMessage: uri must be a valid URL with an http or https scheme (e.g. window.location.origin).",
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(
+      "buildAuthMessage: uri must be a valid URL with an http or https scheme (e.g. window.location.origin).",
     );
   }
   if (!Number.isInteger(input.chainId) || input.chainId <= 0) {

--- a/packages/sdk-js/src/v4/auth.ts
+++ b/packages/sdk-js/src/v4/auth.ts
@@ -87,25 +87,23 @@ export function buildAuthMessage(input: BuildAuthMessageInput): BuiltAuthMessage
       "buildAuthMessage: uri must be a non-empty string (the origin the user is signing into, e.g. window.location.origin).",
     );
   }
-  // Enforce a real http(s) protocol — the `uri` is the origin the
-  // user is signing into, and the canonical message embeds it as the
-  // app identity. Bare authority strings like `localhost:3000` parse
-  // successfully via `new URL(...)` because the WHATWG URL parser
-  // accepts `<scheme>:<rest>` greedily ("localhost" becomes the
-  // scheme). That's not what callers mean by "origin", and a
-  // signature scoped to a phantom `localhost:` scheme can't be
-  // trusted by anything verifying against the real origin.
+  // WHATWG URL treats `localhost:3000` as scheme `localhost:` — require an http(s) origin with a host.
   let parsed: URL;
   try {
     parsed = new URL(trimmedUri);
   } catch {
     throw new Error(
-      "buildAuthMessage: uri must be a valid URL with an http or https scheme (e.g. window.location.origin).",
+      `buildAuthMessage: uri must be a valid URL (got ${JSON.stringify(trimmedUri)}); use the http(s) origin the user is signing into.`,
     );
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error(
-      "buildAuthMessage: uri must be a valid URL with an http or https scheme (e.g. window.location.origin).",
+      `buildAuthMessage: uri scheme must be http or https (got ${parsed.protocol}); use the origin the user is signing into.`,
+    );
+  }
+  if (!parsed.hostname) {
+    throw new Error(
+      `buildAuthMessage: uri must include a host (got ${JSON.stringify(trimmedUri)}); use the origin the user is signing into.`,
     );
   }
   if (!Number.isInteger(input.chainId) || input.chainId <= 0) {

--- a/tests/v4/smoke.test.ts
+++ b/tests/v4/smoke.test.ts
@@ -118,8 +118,17 @@ describe("v4 SDK smoke", () => {
     test("buildAuthMessage throws on invalid uri format", () => {
       const owner = "0xD7050816337a3f8f690F8083B5Ff8019D50c0E50";
       const baseOk = { ownerAddress: owner, chainId: 1, version: "v4-test" };
+      // Not a URL at all — URL constructor throws.
       expect(() => buildAuthMessage({ ...baseOk, uri: "not-a-url" })).toThrow(/uri/);
+      // Bare authority: WHATWG URL accepts this as `<scheme>:<rest>`
+      // with scheme `localhost`, so the protocol check is what
+      // actually rejects it. Without that check, signatures would be
+      // scoped to a phantom `localhost:` scheme.
       expect(() => buildAuthMessage({ ...baseOk, uri: "localhost:3000" })).toThrow(/uri/);
+      // Non-http(s) schemes that parse successfully but aren't valid
+      // origins for an auth message.
+      expect(() => buildAuthMessage({ ...baseOk, uri: "ftp://example.com" })).toThrow(/uri/);
+      expect(() => buildAuthMessage({ ...baseOk, uri: "javascript:void(0)" })).toThrow(/uri/);
     });
 
     test("signAuthMessage throws when called without input", async () => {

--- a/tests/v4/smoke.test.ts
+++ b/tests/v4/smoke.test.ts
@@ -118,17 +118,15 @@ describe("v4 SDK smoke", () => {
     test("buildAuthMessage throws on invalid uri format", () => {
       const owner = "0xD7050816337a3f8f690F8083B5Ff8019D50c0E50";
       const baseOk = { ownerAddress: owner, chainId: 1, version: "v4-test" };
-      // Not a URL at all — URL constructor throws.
+      // Negative cases — each line documents one rejection mode.
       expect(() => buildAuthMessage({ ...baseOk, uri: "not-a-url" })).toThrow(/uri/);
-      // Bare authority: WHATWG URL accepts this as `<scheme>:<rest>`
-      // with scheme `localhost`, so the protocol check is what
-      // actually rejects it. Without that check, signatures would be
-      // scoped to a phantom `localhost:` scheme.
-      expect(() => buildAuthMessage({ ...baseOk, uri: "localhost:3000" })).toThrow(/uri/);
-      // Non-http(s) schemes that parse successfully but aren't valid
-      // origins for an auth message.
-      expect(() => buildAuthMessage({ ...baseOk, uri: "ftp://example.com" })).toThrow(/uri/);
-      expect(() => buildAuthMessage({ ...baseOk, uri: "javascript:void(0)" })).toThrow(/uri/);
+      expect(() => buildAuthMessage({ ...baseOk, uri: "localhost:3000" })).toThrow(/scheme/);
+      expect(() => buildAuthMessage({ ...baseOk, uri: "ftp://example.com" })).toThrow(/scheme/);
+      expect(() => buildAuthMessage({ ...baseOk, uri: "javascript:void(0)" })).toThrow(/scheme/);
+      // Positive cases — guard against future over-aggressive validation.
+      expect(() => buildAuthMessage({ ...baseOk, uri: "http://localhost:3000" })).not.toThrow();
+      expect(() => buildAuthMessage({ ...baseOk, uri: "https://app.example.com" })).not.toThrow();
+      expect(() => buildAuthMessage({ ...baseOk, uri: "https://app.example.com:8443/path" })).not.toThrow();
     });
 
     test("signAuthMessage throws when called without input", async () => {


### PR DESCRIPTION
## Summary

Tightens `buildAuthMessage` URI validation to require an explicit `http:` or `https:` scheme. Pre-existing valid URIs are unaffected; bare authority strings like `localhost:3000` (which previously slipped through as scheme `localhost`) now throw.

This is the auth bug surfaced as a side discovery during #221.

## What's wrong

The WHATWG URL parser is permissive — `new URL("localhost:3000")` succeeds with `protocol === "localhost:"` and `pathname === "3000"`. The previous validation:

```ts
try {
  new URL(trimmedUri);
} catch {
  throw new Error(...);
}
```

…only checks that the parser doesn't throw, so bare authority strings pass through. A signature scoped to a phantom `localhost:` scheme can't be trusted by anything verifying against the real origin — callers passing such strings were silently getting wrong behavior.

## What this fixes

Captures the parsed URL and checks `parsed.protocol` against `http:` and `https:`. The error message also gets sharper:

```ts
let parsed: URL;
try {
  parsed = new URL(trimmedUri);
} catch {
  throw new Error("buildAuthMessage: uri must be a valid URL with an http or https scheme (e.g. window.location.origin).");
}
if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
  throw new Error("buildAuthMessage: uri must be a valid URL with an http or https scheme (e.g. window.location.origin).");
}
```

The pre-existing `buildAuthMessage throws on invalid uri format` smoke test (which was failing on `main` — flagged in #221) now passes. Extended with `ftp://` and `javascript:` cases so the protocol filter has explicit regression coverage.

## Why patch, not minor

Any caller passing scheme-less URIs was getting incorrect behavior before; tightening the validation is correctness, not a breaking change. All real callers in the repo (`https://test.avaprotocol.org` in test fixtures, `http://localhost:3000` in smoke tests, `window.location.origin` in the documented browser pattern) are unaffected.

## Verification

- [x] `yarn workspace @avaprotocol/sdk-js build` — clean (30.45 KB, +0.26 KB for the extra check)
- [x] `tsc --noEmit -p tsconfig.json` — clean
- [x] `AVS_REST_URL=http://localhost:8080/api/v1 jest tests/v4/smoke.test.ts tests/v4/core/auth.test.ts` — 32/32 pass (was 31/32, the `buildAuthMessage throws on invalid uri format` test was the failing one)

## Test plan

- [ ] Reviewer: confirm no real consumers pass `ftp:` / `javascript:` / scheme-less URIs to the auth flow (search studio, AVS, third-party integrators if known).
- [ ] CI: standard pipeline.
