### PR TITLE
fix: EventCondition.value is a string, matching proto + REST contract

### DIFF
--- a/.changeset/event-condition-value-string.md
+++ b/.changeset/event-condition-value-string.md
@@ -1,0 +1,6 @@
+---
+"@avaprotocol/sdk-js": patch
+"@avaprotocol/types": patch
+---
+
+fix: `EventCondition.value` is now typed as `string` instead of `Record<string, unknown>`, matching the proto contract and the aggregator's REST decoder. Studio templates (e.g. Uniswap V3 stop-loss) that previously failed with `WORKFLOWS_BAD_TRIGGER: cannot unmarshal string into Go struct field EventCondition.config.queries.conditions.value` now serialize correctly. Re-syncs `packages/types/openapi/openapi.yaml` from EigenLayer-AVS staging (PR #601) and regenerates `openapi.gen.ts`.

--- a/.changeset/restapi-options-summarize.md
+++ b/.changeset/restapi-options-summarize.md
@@ -1,0 +1,5 @@
+---
+"@avaprotocol/types": patch
+---
+
+types: `RestAPINodeConfig` now exposes an optional `options` bag, with a typed `summarize?: boolean` flag. Setting `summarize: true` on a terminal SendGrid or Telegram RestAPI node opts the workflow into the aggregator's context-memory AI summarizer (which composes a subject + HTML body from execution context and injects them into the outgoing request). No-op on non-notification URLs; the deterministic summarizer remains the default. Surface added via the openapi resync from EigenLayer-AVS staging.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ export default [
     ignores: [
       "**/dist/**",           // Build output directories
       "**/grpc_codegen/**",   // Generated gRPC code
+      "**/openapi.gen.ts",    // Generated openapi-typescript output
       "**/*.d.ts",            // TypeScript declaration files
       "**/*_pb.js",           // Protocol buffer generated files
       "**/*_grpc_pb.js"       // gRPC generated files

--- a/packages/sdk-js/src/v4/builders/triggers.ts
+++ b/packages/sdk-js/src/v4/builders/triggers.ts
@@ -93,7 +93,7 @@ export const Triggers = Object.freeze({
         fieldName: string;
         operator: "eq" | "ne" | "gt" | "gte" | "lt" | "lte" | "contains";
         fieldType?: string;
-        value: Record<string, unknown>;
+        value: string;
       }>;
     }>;
     chainId?: number;

--- a/packages/types/openapi/openapi.yaml
+++ b/packages/types/openapi/openapi.yaml
@@ -448,8 +448,13 @@ components:
           type: string
           enum: [eq, ne, gt, gte, lt, lte, contains]
         value:
-          # JSON Value; type depends on field
-          additionalProperties: true
+          type: string
+          description: |
+            Value to compare against, encoded as a string. The operator
+            parses it according to `fieldType` (e.g. `int256` / `uint256`
+            → big.Int, `address` → checksummed hex, `bool` →
+            "true"/"false"). Matches the proto `EventCondition.value`,
+            which is also a string.
         fieldType: { type: string }
 
     EventMethodCall:
@@ -656,6 +661,26 @@ components:
           type: object
           additionalProperties: { type: string }
         body: { type: string }
+        options:
+          type: object
+          description: |
+            Generic options bag for backend features on terminal
+            RestAPI nodes. `summarize: true` opts a SendGrid /v3/mail/send
+            or Telegram /sendMessage node into the aggregator's
+            context-memory summarizer, which composes a subject + HTML
+            body from the workflow's execution context and injects them
+            into the outgoing request. Without this field set, the
+            aggregator falls back to the deterministic summarizer (no
+            LLM polish).
+          properties:
+            summarize:
+              type: boolean
+              description: |
+                When true on a terminal SendGrid or Telegram node,
+                ComposeSummarySmart runs at execution time and fills
+                in the empty content.value / text slot with an
+                AI-generated body. No-op on non-notification URLs.
+          additionalProperties: true
 
     CustomCodeNodeConfig:
       type: object

--- a/packages/types/src/openapi.gen.ts
+++ b/packages/types/src/openapi.gen.ts
@@ -816,9 +816,14 @@ export interface components {
             readonly fieldName: string;
             /** @enum {string} */
             readonly operator: "eq" | "ne" | "gt" | "gte" | "lt" | "lte" | "contains";
-            readonly value: {
-                readonly [key: string]: unknown;
-            };
+            /**
+             * @description Value to compare against, encoded as a string. The operator
+             *     parses it according to `fieldType` (e.g. `int256` / `uint256`
+             *     → big.Int, `address` → checksummed hex, `bool` →
+             *     "true"/"false"). Matches the proto `EventCondition.value`,
+             *     which is also a string.
+             */
+            readonly value: string;
             readonly fieldType?: string;
         };
         readonly EventMethodCall: {
@@ -955,6 +960,27 @@ export interface components {
                 readonly [key: string]: string;
             };
             readonly body?: string;
+            /**
+             * @description Generic options bag for backend features on terminal
+             *     RestAPI nodes. `summarize: true` opts a SendGrid /v3/mail/send
+             *     or Telegram /sendMessage node into the aggregator's
+             *     context-memory summarizer, which composes a subject + HTML
+             *     body from the workflow's execution context and injects them
+             *     into the outgoing request. Without this field set, the
+             *     aggregator falls back to the deterministic summarizer (no
+             *     LLM polish).
+             */
+            readonly options?: {
+                /**
+                 * @description When true on a terminal SendGrid or Telegram node,
+                 *     ComposeSummarySmart runs at execution time and fills
+                 *     in the empty content.value / text slot with an
+                 *     AI-generated body. No-op on non-notification URLs.
+                 */
+                readonly summarize?: boolean;
+            } & {
+                readonly [key: string]: unknown;
+            };
         };
         readonly CustomCodeNodeConfig: {
             readonly lang: components["schemas"]["Lang"];

--- a/tests/v4/triggers/eventTrigger.test.ts
+++ b/tests/v4/triggers/eventTrigger.test.ts
@@ -129,13 +129,12 @@ describe("EventTrigger Tests", () => {
           ],
         }),
       });
-      // Tenderly's event simulation can be flaky on chainlink price
-      // feeds depending on recent feed activity; skip cleanly if it
-      // fails for environmental reasons.
-      if (!result.success) {
-        console.log(`Skipping — Tenderly Chainlink sim failed: ${result.error}`);
-        return;
-      }
+      // CLAUDE.md forbids soft-skips; hard-assert. The
+      // WORKFLOWS_BAD_TRIGGER fix (SDK value: string) ensures this
+      // request no longer rejects at the validation layer. If Tenderly
+      // genuinely can't simulate the Chainlink feed in CI, that's a
+      // real environmental issue to address — not silently mask.
+      expect(result.success).toBe(true);
       const data = (result.output as { data: any }).data;
       expect(data.topics[0]).toBe(CHAINLINK_ANSWER_UPDATED_SIG);
       // Provide the ABI so the engine knows which field gates the

--- a/tests/v4/triggers/eventTrigger.test.ts
+++ b/tests/v4/triggers/eventTrigger.test.ts
@@ -121,7 +121,7 @@ describe("EventTrigger Tests", () => {
                   fieldName: "AnswerUpdated.current",
                   operator: "gt",
                   fieldType: "int256",
-                  value: { stringValue: "0" },
+                  value: "0",
                 },
               ],
               maxEventsPerBlock: 5,


### PR DESCRIPTION
## Summary

Studio templates (e.g. Uniswap V3 stop-loss) fail in production with:

```
APIError: trigger: decode EventTrigger: json: cannot unmarshal string
into Go struct field EventCondition.config.queries.conditions.value
of type map[string]interface {}
code: WORKFLOWS_BAD_TRIGGER
```

Root cause: schema drift. The proto, the aggregator's Go tests, and the studio template all treat `EventCondition.value` as a **string**, but the OpenAPI spec had it as `additionalProperties: true` — which `openapi-typescript` and `oapi-codegen` both translated to a map/object. The REST handler's JSON decoder then rejected the string the SDK was sending.

EigenLayer-AVS PR [#601](https://github.com/AvaProtocol/EigenLayer-AVS/pull/601) corrected the upstream spec. This PR pulls that fix into the SDK and updates the matching call sites.

## Changes

- `packages/types/openapi/openapi.yaml` — re-synced from EigenLayer-AVS staging via `yarn openapi-download`
- `packages/types/src/openapi.gen.ts` — regenerated via `yarn types-gen`; `EventCondition.value` is now `string`
- `packages/sdk-js/src/v4/builders/triggers.ts` — `Triggers.event` `conditions[].value` type changed from `Record<string, unknown>` → `string`
- `tests/v4/triggers/eventTrigger.test.ts` — fixed `value: { stringValue: "0" }` → `value: "0"` (the old shape was never valid against the proto)
- `eslint.config.mjs` — added `**/openapi.gen.ts` to ignores (the regenerated discriminated-union expansion exceeds the 256-char line cap)
- `.changeset/event-condition-value-string.md` — patch bump for `@avaprotocol/sdk-js` + `@avaprotocol/types`

## Test plan

- [x] `yarn build` clean
- [x] `npx tsc --noEmit -p tsconfig.json` clean
- [x] `yarn lint` clean
- [ ] After publish: re-apply the Uniswap V3 stop-loss template in studio and confirm the workflow saves without `WORKFLOWS_BAD_TRIGGER`

🤖 Generated with [Claude Code](https://claude.com/claude-code)