### PR TITLE
feat(v4)!: require explicit per-part chainId; remove workflow-level chain

### DIFF
--- a/.env.railway.example
+++ b/.env.railway.example
@@ -3,7 +3,7 @@
 # Usage:
 #   cp .env.railway.example .env.railway
 #   # fill in the placeholders below
-#   TEST_ENV=railway yarn test:v4
+#   TEST_ENV=railway yarn test
 #
 # The renovated multi-chain gateway routes per-part chains itself, so a
 # single endpoint serves every supported chain — no per-chain env files.

--- a/.env.railway.example
+++ b/.env.railway.example
@@ -1,33 +1,21 @@
-# Targets the Railway-hosted gateway in the `feature/rest-api-migration`
-# environment of the `eigenlayer-avs` project.
+# Targets the deployed Railway/production gateway for the v4 REST suite.
 #
 # Usage:
 #   cp .env.railway.example .env.railway
 #   # fill in the placeholders below
 #   TEST_ENV=railway yarn test:v4
 #
-# This is the mainnet-family gateway (registers against Ethereum
-# mainnet AVS, routes to worker-ethereum + worker-base). For the
-# testnet family, point AVS_REST_URL at the `gateway` service's
-# domain instead and re-mint the API key against gateway-railway.yaml.
+# The renovated multi-chain gateway routes per-part chains itself, so a
+# single endpoint serves every supported chain — no per-chain env files.
 
-# Public REST endpoint exposed by the gateway-ethereum service.
-# Get from Railway dashboard → gateway-ethereum → Settings → Networking
-# → "your-domain.up.railway.app". Use the full /api/v1 base path.
-AVS_REST_URL=https://<REPLACE-WITH-GATEWAY-DOMAIN>/api/v1
+# Public REST endpoint (production gateway). Full /api/v1 base path.
+AVS_REST_URL=https://api.avaprotocol.org/api/v1
 
-# Admin JWT minted against the gateway's JWT secret. Generate with:
-#   ./ap create-api-key --config=config/gateway-ethereum-railway.yaml \
-#     --role=admin --subject=<test EOA address>
-# (run on the gateway-ethereum service via Railway dashboard SSH, or
-# locally with the same JWT secret env var set)
-AVS_API_KEY=<REPLACE-WITH-JWT>
-
-# Test EOA private key (no funds needed — used only for the EIP-191
-# signature flow). The address derived from this key is the subject
-# in the API key above.
-TEST_PRIVATE_KEY=0xf8aacc32254941a02596fa8164c834ce7a2d398827915513968832e05db2add7
+# Test EOA private key — no funds needed; used only for the EIP-191
+# signature auth flow (client.auth.exchangeWithKey). This is the only
+# auth the suite uses; no pre-minted API key is required.
+TEST_PRIVATE_KEY=<REPLACE-WITH-TEST-EOA-PRIVATE-KEY>
 
 # Chain RPC for block-trigger tests (executions/getExecution.test.ts).
-# Use the same Ethereum mainnet or Sepolia endpoint the workers use.
-CHAIN_ENDPOINT=https://api-ethereum-mainnet.n.dwellir.com/<KEY>
+# Use the Sepolia endpoint the gateway's workers use.
+CHAIN_ENDPOINT=<REPLACE-WITH-CHAIN-RPC-URL>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,7 @@ v3 gRPC tests are archived under `tests-v3-archive/`. Each suite maps
 to a subdirectory and is sharded as its own CI matrix job:
 
 ```bash
-yarn test                              # Run every jest spec (full suite)
-yarn test:v4                           # Everything under tests/v4
+yarn test                              # Run the full v4 suite (everything under tests/v4)
 yarn test:core                         # tests/v4/core      — auth, wallet, secrets, getToken, withdraw
 yarn test:workflows                    # tests/v4/workflows — CRUD + trigger/enable/cancel
 yarn test:executions                   # tests/v4/executions — simulate, runNodeWithInputs, gas, fees

--- a/docs/changes/chain-decoupling-sdk-tracking.md
+++ b/docs/changes/chain-decoupling-sdk-tracking.md
@@ -5,12 +5,16 @@ gateway built from `staging` for end-to-end runtime verification + the release
 changeset. **Date:** 2026-06-26.
 **Upstream:** `EigenLayer-AVS/PLAN_CHAIN_DECOUPLING.md` (backend leads, bottom-up).
 
-> **#634 is merged to `staging`.** Types regenerated; builders + resources +
-> tests + example updated; `yarn build` clean, `tsc -p tsconfig.json` = 0 errors,
-> smoke suite green. The local docker gateway is still the pre-renovation
-> `avs-dev:latest` image (create() still rejects per-node `chainId` with the
-> int64 error), so the `PER_NODE_CHAIN_READY` tests stay gated until a gateway
-> built from `staging` (#631/#633) is deployed.
+> **#634 merged + #639 fixed and VERIFIED (2026-06-26).** Types regenerated;
+> builders + resources + tests + example updated. Against the local v4.0.0
+> gateway (`:8080`, start.sh, with the #639 fix): the multichain create→retrieve
+> round-trip **passes**, and the **full `yarn test:v4` suite is 283 passed / 1
+> skipped / 285**, with **0 int64 errors**. The one remaining failure
+> (`eventTrigger.test.ts › condition-based filtering`) is **unrelated** to
+> chain-decoupling: the event is fetched correctly on Sepolia, but the gateway
+> evaluates `AnswerUpdated.current > 0` as "Conditions not met" (no ABI in the
+> query) — pre-existing condition-eval behavior, flagged for a separate look.
+> `yarn build` clean, `tsc -p tsconfig.json` = 0.
 
 The backend is making `chainId` a property of the **parts that touch a chain**
 (event/block triggers; contract-read/-write and ETH-transfer nodes) and

--- a/docs/changes/chain-decoupling-sdk-tracking.md
+++ b/docs/changes/chain-decoupling-sdk-tracking.md
@@ -1,0 +1,245 @@
+# SDK chain-decoupling renovation — tracking & inventory
+
+**Status:** Track A + Track B **source implemented** (2026-06-26); awaiting a
+gateway built from `staging` for end-to-end runtime verification + the release
+changeset. **Date:** 2026-06-26.
+**Upstream:** `EigenLayer-AVS/PLAN_CHAIN_DECOUPLING.md` (backend leads, bottom-up).
+
+> **#634 is merged to `staging`.** Types regenerated; builders + resources +
+> tests + example updated; `yarn build` clean, `tsc -p tsconfig.json` = 0 errors,
+> smoke suite green. The local docker gateway is still the pre-renovation
+> `avs-dev:latest` image (create() still rejects per-node `chainId` with the
+> int64 error), so the `PER_NODE_CHAIN_READY` tests stay gated until a gateway
+> built from `staging` (#631/#633) is deployed.
+
+The backend is making `chainId` a property of the **parts that touch a chain**
+(event/block triggers; contract-read/-write and ETH-transfer nodes) and
+**removing the workflow-level chain entirely** (G5 / Decision 1): no
+`Task.chain_id`, no `CreateTaskReq.chain_id`, chain-agnostic task storage,
+`chainId` **required** (`>0`, configured) on every chain-aware part, `0`/unset
+rejected. The 4 cleared chains: Ethereum, Base, Sepolia, Base Sepolia.
+
+Our type layer is **generated** from the backend spec
+(`yarn openapi-download` pulls `EigenLayer-AVS/staging/api/openapi.yaml`, then
+`yarn types-gen` → `packages/types/src/openapi.gen.ts`). So the breaking type
+changes are mechanical and **gated on the backend spec merging to `staging`**.
+
+**Gating item is DONE (unmerged):** the renovated `openapi.yaml` is in
+**EigenLayer-AVS PR #634** (targets `staging`); the backend stopped reading the
+workflow-level fields in **#631** (no further Go changes needed). Once #634 merges
+to `staging`, `yarn openapi-download && yarn types-gen` produces the new types and
+Track B is unblocked. Verified contents of #634:
+
+- **Removed:** `Workflow.chainId` (response) and `CreateWorkflowRequest.chainId`;
+  `chainId` query param on listWorkflows / countWorkflows / listExecutions /
+  countExecutions / executionStats.
+- **Kept:** per-part `config.chainId` — now in each config's **required** list
+  (5/5), so regenerated TS makes it **non-optional**; request-level `chainId` on
+  simulate / estimateFees / runNode / createWallet / withdraw / getToken.
+
+This splits the SDK work into two tracks.
+
+---
+
+## Track A — no-regret, do now (safe under both the current and the G5 contract)
+
+Explicit per-part chains already work end-to-end (backend Phases 1–2 are
+IMPLEMENTED; SDK builders already accept `chainId`). Writing explicit chains is
+forward-compatible: it works today **and** is what G5 makes mandatory.
+
+- [x] **Multi-chain template test** — `tests/v4/templates/multichain-per-part-chain.test.ts`.
+  Locks the wire contract: explicit per-part `chainId` round-trips through
+  create → retrieve. Tier 1 (single-chain, every part names Sepolia explicitly);
+  Tier 2 (genuine watch-Sepolia / act-Base-Sepolia). Both gated behind
+  `PER_NODE_CHAIN_READY=1` (Tier 2 additionally on `MULTICHAIN_TEST=1` /
+  `TEST_ENV=railway`) because the **deployed server does not yet honor a per-node
+  `chainId` on the persisted `create()` path** — see the upstream finding below.
+  Typechecks clean; default-skips so CI stays green until the backend lands.
+  Flip the gate on once the renovated backend (G3) is deployed to the target stack.
+- [x] **Convert template/builder call sites to explicit per-part chains.** Done as
+  part of Track B (required `chainId` forced every chain-aware part to carry its
+  own). Every chain-aware builder call now passes `chainId: 11_155_111`; the dead
+  workflow-level `chainId` was removed from the `buildWorkflow` objects below:
+  - `tests/v4/templates/aave-health-factor-alert.test.ts:119`
+  - `tests/v4/templates/batch-recurring-payment-with-email.test.ts:47`
+  - `tests/v4/templates/exported-workflow-consistency.test.ts:51` (manual trigger + off-chain nodes — chain-agnostic; just drop the top-level `chainId`)
+  - `tests/v4/templates/workflow-usdc-read-write-customcode.test.ts:50`
+  - `tests/v4/templates/uniswapv3_stoploss.test.ts:53`
+  - `tests/v4/templates/recurring-payment-with-report.test.ts:53`
+  - (`tests/v4/smoke.test.ts:61,79` and the `auth.test.ts` / `client.ts` `chainId`
+    are the **auth-flow** chain — JWT `aud`, kept by design. Do **not** touch.)
+- [ ] **Rework the `settingsForChain` / `settingsFor` test helpers**
+  (`tests/utils/client.ts:225-235`). They inject `inputVariables.settings.chain_id`,
+  which today feeds the `body.chainId → settings.chain_id → aud → default`
+  fallback (backend audit class **A**, removed by G5). Keep `settings.name` +
+  `settings.runner` (still required by the context-memory summarizer); stop
+  treating `settings.chain_id` as a task-default execution chain. Move execution
+  chain onto the parts.
+
+## Track B — IMPLEMENTED (source) against #634 on `staging`
+
+#634 merged to `staging`, so the gating regen was real, not hypothetical. All
+source items below are done; `yarn build` clean, `tsc -p tsconfig.json` = 0,
+smoke green. What remains is **runtime** verification against a deployed
+renovated gateway and the release changeset (see "Remaining" at the end).
+
+- [x] **Regenerated types** — `yarn openapi-download && yarn types-gen`. Confirmed
+  diffs in `packages/types/src/openapi.gen.ts`:
+  - `Workflow.chainId` (response) — **removed**. No SDK/test read it (verified), safe.
+  - `CreateWorkflowRequest.chainId` — **removed**.
+  - `SimulateWorkflowRequest.chainId` / `EstimateFeesRequest.chainId` — **KEPT** (unchanged).
+  - Per-part `config.chainId` (event/block trigger, contractRead/Write, ethTransfer)
+    — now **required / non-optional** (verified `chainId?` → `chainId` on all 5).
+  - `"0 = inherit"` notes dropped; `ChainIdQuery` removed from list/count/executions ops.
+- [x] **Builders' `chainId` now required** — `builders/nodes.ts`
+  (`ethTransfer`/`contractWrite`/`contractRead`) and `builders/triggers.ts`
+  (`block`/`event`): `chainId?: number` → `chainId: number`, emitted
+  unconditionally. **Breaking for SDK consumers** (must now pass `chainId`).
+- [x] **Workflow-level `chainId` dropped from create** — falls out of the
+  regenerated `CreateWorkflowRequest`; removed the dead top-level `chainId` from
+  the 6 template `buildWorkflow` objects and the example demo. `simulate` /
+  `estimateFees` keep their request-level `chainId`.
+- [x] **Removed list/count chainId params** — `ListWorkflowsParams`,
+  `CountWorkflowsParams`, `ListExecutionsParams`, `CountExecutionsParams`,
+  `ExecutionStatsParams` no longer carry `chainId`. (Optional future: a helper to
+  derive the per-chain set from a workflow's parts — not built yet.)
+- [x] **Fixed stale chain-coupling docs** — `resources/nodes.ts` rewritten to
+  "explicit-or-error; request `chainId` or node `config.chainId`, stamped via
+  `stampNodeChainIfUnset`"; `resources/executions.ts` `RetrieveExecutionParams`
+  comment updated to chain-agnostic storage.
+- [x] **All test/example call sites updated** — 73 TS errors → 0; every
+  chain-aware builder call in tests now passes `chainId: 11_155_111` (Sepolia dev
+  stack); `examples/example.ts` `--chain-id` flag removed.
+- [ ] **Flip inherit-asserting tests to expect rejection** — none existed (the
+  suite never asserted `0`-inherit), so nothing to flip. The `PER_NODE_CHAIN_READY`
+  multichain test asserts the positive round-trip; verify it green on a renovated
+  gateway, then consider adding an explicit "missing chain → InvalidArgument" case.
+
+## Untouched by design (do NOT change)
+
+- Auth flow: `chains.ts` (`Chains.EigenLayerAuth`), `auth.ts`
+  (`buildAuthMessage`/`signAuthMessage`), `resources/auth.ts`. The JWT `aud`
+  chain stays — it is **API-auth scope**, not a task chain (plan answer #1).
+- `resources/tokens.ts` `retrieve(address, { chainId })` — `GetTokenMetadataReq`,
+  explicitly "unchanged". Keep.
+- `resources/wallets.ts` `withdraw(address, req)` — `WithdrawFundsReq`, explicitly
+  "unchanged" (takes its own `chain_id`). Keep.
+- `TriggerWorkflowRequest` — has no `chainId` today, and the backend ignores
+  `TriggerTaskReq.chain_id` anyway ("a task has no chain to override"). Nothing to do.
+- `Nodes.balance({ chain })` — Balance node uses a `chain` **string** (name or id),
+  NOT `chain_id`; it is not in the chain-aware set. Keep as-is.
+
+(Builders are NOT in this list — their `chainId` goes from optional to required;
+see the Track B "Make the builders' `chainId` required" item.)
+
+---
+
+## Remaining (not source — verification + release)
+
+1. **Runtime verification** — deploy a gateway built from `staging` (#631/#633),
+   then run `PER_NODE_CHAIN_READY=1 yarn jest tests/v4/templates/multichain-per-part-chain.test.ts`
+   (and the full suite) and flip the gate default on once green. The local docker
+   `avs-dev:latest` image is pre-renovation, so it still fails today.
+   `settings.chain_id` in the `settingsFor*` helpers is now vestigial (backend
+   ignores it) but harmless — optional cleanup, left in place.
+2. **Changeset + release** — `yarn changeset` for the **breaking** SDK change
+   (builders' `chainId` now required; workflow-level + list/count `chainId`
+   removed). Bump `@avaprotocol/sdk-js` + `@avaprotocol/types` major. Land in the
+   release window for the renovated gateway.
+3. **Two stale backend OpenAPI prose descriptions** (cosmetic, don't affect
+   generated types — flag to AVS): `api/openapi.yaml` createWorkflow description
+   (~:1662) still says "the server resolves the workflow-level `chainId` (falling
+   back to the aggregator default)"; the LoopNode description (~:729) still says
+   it "inherits chainId from this LoopNode." Both contradict the shipped contract.
+
+## Upstream finding to report to the AVS backend (2026-06-26)
+
+Running the new test against the local `avaprotocol/avs-dev:latest` gateway,
+`client.workflows.create()` with an explicit per-node `chainId` on a
+`contractRead` node is **rejected in every representation**:
+
+| node `config.chainId` sent | result |
+|---|---|
+| `11155111` (number, type-correct per `ChainId: number`) | `unmarshal config into Go struct: json: cannot unmarshal string into Go struct field ContractReadNodeConfig.chainId of type int64` |
+| `"11155111"` (string) | `node read: decode ContractReadNode: json: cannot unmarshal string into Go struct field ContractReadNodeConfig.config.chainId of type int64` |
+| omitted | OK — created, retrieved `chainId` undefined (legacy `0`-inherit) |
+
+**UPDATE 2026-06-26 (verified against the new v4.0.0 gateway on :8080, health
+200, no docker):** the failure is **isolated to the persisted `create()` path**.
+The *identical* `Nodes.contractRead({ chainId: 11155111 })` node — a JSON
+**number** on the wire (verified: SDK builder emits `"chainId":11155111`; the
+transport does a plain `JSON.stringify`, no transform) — behaves as:
+
+| endpoint | same node + per-node `chainId` (number) | result |
+|---|---|---|
+| `POST /workflows:simulate` | ✅ | status=success |
+| `POST /nodes:run` | ✅ | success=true |
+| `POST /workflows:create` | ❌ | `cannot unmarshal string into ... ContractReadNodeConfig.chainId of type int64` |
+
+Two of three gateway endpoints decode the per-node chain correctly from the same
+bytes, so the SDK request shape is correct. Only `create()` fails — and it fails
+for a **number and a string** alike (the string case fails deeper, at
+`...config.chainId`), so there is no client representation that gets through.
+
+Diagnosis: a step **unique to the create()/persist path** marshals the node
+config via **protojson** (proto `int64` → quoted JSON string) and then
+`encoding/json`-decodes it into a Go struct whose `chainId` is `int64` without a
+`,string` tag → the quoted value is rejected. Same class as the
+`EventCondition.value` string fix (#224). **#633 (`TestNodeRoundTrip_PerNodeChainId`)
+exercises `OpenAPIToProtoNode` from an already-decoded Go `generated.Node`, not
+the HTTP create() body→persist round-trip**, so it stays green while the live
+create() path still fails.
+
+This is **not an SDK bug** (simulate + runNode prove the wire format). **Filed as
+[AvaProtocol/EigenLayer-AVS#639](https://github.com/AvaProtocol/EigenLayer-AVS/issues/639)**
+with the full root cause: `protoRetargetJSON` (`aggregator/rest/mapping/node.go:339`)
+does `protojson.Marshal` (proto `int64` → quoted string) → `encoding/json` into
+`generated.ChainId = int64` (`json:"chainId"`, no `,string`) on the
+proto→OpenAPI render path (`ProtoToOpenAPINode`, hit by create/get/list, not by
+simulate/runNode). `#633` only covers the inbound `OpenAPIToProtoNode` direction.
+Repro: `PER_NODE_CHAIN_READY=1 yarn jest
+tests/v4/templates/multichain-per-part-chain.test.ts` against `:8080`. SDK needs
+no further change once #639 lands.
+
+## Open questions — RESOLVED by the plan's "Client contract (after #632)" section
+
+1. **List/count filtering.** ✅ Query param **removed** — list/get/cancel/pause/
+   setEnabled are chain-agnostic; "workflows on chain Y" is derived **client-side**
+   from the parts. (Note: client-side, not server-side as first assumed.)
+2. **Single-node `runNodeWithInputs` chain source.** ✅ `RunNodeWithInputsReq.chain_id`
+   **stays** (or the node's own `chainId`); backend stamps request→node via
+   `stampNodeChainIfUnset`. The `settings.chain_id`/`aud`/default fallback is removed.
+3. **Simulate / EstimateFees chainId.** ✅ Both **kept** — simulate takes per-part
+   chains *or* a request `chainId`; `EstimateFeesReq` is explicitly unchanged.
+   (Earlier guess that they'd be removed was wrong — corrected above.)
+
+**Still open:**
+
+4. **Create()-path int64 decode** — confirm #631 (backend read-stop) fixes the
+   persisted `create()` `ContractReadNodeConfig`/`ContractWriteNodeConfig` int64
+   decode (the upstream finding above), not just simulate/runNode. The contract
+   says to send per-part chains on CreateWorkflow, which implies the fix; verify
+   on deploy with `PER_NODE_CHAIN_READY=1`.
+5. **#634 release coordination.** Target date for #634 merge to `staging`, so the
+   Track B changeset (regen + builder/edit) lands in the same window.
+
+---
+
+## How to run the multi-chain test
+
+Both tiers default-skip until `PER_NODE_CHAIN_READY=1` (server honors per-node
+`chainId` on the persisted create path — backend G3 deployed):
+
+```bash
+# Tier 1 (single-chain round-trip; any stack once G3 is deployed):
+PER_NODE_CHAIN_READY=1 yarn jest tests/v4/templates/multichain-per-part-chain.test.ts
+
+# Tier 2 (genuine cross-chain — needs worker-sepolia + worker-base-sepolia):
+PER_NODE_CHAIN_READY=1 MULTICHAIN_TEST=1 TEST_ENV=railway \
+  yarn jest tests/v4/templates/multichain-per-part-chain.test.ts
+```
+
+Per CLAUDE.md, run one test at a time against Railway and tail the gateway +
+worker-sepolia / worker-base-sepolia logs for the execution window to confirm
+the per-part chain actually routed (gateway accepts the explicit chains; no
+"unconfigured chain" rejection on Base Sepolia).

--- a/docs/changes/chain-decoupling-sdk-tracking.md
+++ b/docs/changes/chain-decoupling-sdk-tracking.md
@@ -8,7 +8,7 @@ changeset. **Date:** 2026-06-26.
 > **#634 merged + #639 fixed and VERIFIED (2026-06-26).** Types regenerated;
 > builders + resources + tests + example updated. Against the local v4.0.0
 > gateway (`:8080`, start.sh, with the #639 fix): the multichain create→retrieve
-> round-trip **passes**, and the **full `yarn test:v4` suite is 283 passed / 1
+> round-trip **passes**, and the **full `yarn test` suite is 283 passed / 1
 > skipped / 285**, with **0 int64 errors**. The one remaining failure
 > (`eventTrigger.test.ts › condition-based filtering`) is **unrelated** to
 > chain-decoupling: the event is fetched correctly on Sepolia, but the gateway

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -52,7 +52,6 @@ interface CliFlags {
   pretty: boolean;
   blocking: boolean;
   limit?: number;
-  chainId?: number;
   workflowId?: string;
   owner?: string;
   factory?: string;
@@ -89,9 +88,6 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
         break;
       case "limit":
         flags.limit = Number(argv[++i]);
-        break;
-      case "chain-id":
-        flags.chainId = Number(argv[++i]);
         break;
       case "workflow-id":
         flags.workflowId = argv[++i];
@@ -227,16 +223,11 @@ const commands: Record<string, { description: string; usage: string; run: Comman
 
   "workflows:create": {
     description: "Create a workflow from a JSON definition file",
-    usage: "workflows:create <file.json> [--chain-id N]",
-    run: async (client, [file], flags) => {
+    usage: "workflows:create <file.json>",
+    run: async (client, [file], _flags) => {
       if (!file) fail(EXIT_USER_ERROR, "WORKFLOWS_BAD_ARGS", "Usage: workflows:create <file.json>");
       await ensureAuth(client);
-      // openapi-typescript marks generated schema fields readonly, so
-      // we build a fresh request that merges the file payload with
-      // the optional --chain-id flag rather than mutating in place.
-      const file_body = readJsonFile<v4.CreateWorkflowRequest>(file);
-      const body: v4.CreateWorkflowRequest =
-        flags.chainId !== undefined ? { ...file_body, chainId: flags.chainId } : file_body;
+      const body = readJsonFile<v4.CreateWorkflowRequest>(file);
       return client.workflows.create(body);
     },
   },
@@ -473,7 +464,6 @@ const commands: Record<string, { description: string; usage: string; run: Comman
         // --- 4. create workflow -------------------------------------
         const create = {
           smartWalletAddress,
-          chainId: flags.chainId,
           trigger: Triggers.cron({
             name: "verify-cron",
             schedule: ["*/10 * * * *"],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "build": "yarn workspaces run build",
     "clean": "rm -rf node_modules yarn.lock && yarn workspaces run clean",
     "test": "jest --config jest.config.cjs --detectOpenHandles --runInBand",
-    "test:v4": "jest --config jest.config.cjs --detectOpenHandles --runInBand tests/v4",
     "test:core": "jest --config jest.config.cjs --detectOpenHandles --runInBand tests/v4/core",
     "test:workflows": "jest --config jest.config.cjs --detectOpenHandles --runInBand tests/v4/workflows",
     "test:executions": "jest --config jest.config.cjs --detectOpenHandles --runInBand tests/v4/executions",

--- a/packages/sdk-js/src/v4/builders/nodes.ts
+++ b/packages/sdk-js/src/v4/builders/nodes.ts
@@ -16,7 +16,7 @@ export const Nodes = Object.freeze({
     name: string;
     destination: string;
     amountWei: string;
-    chainId?: number;
+    chainId: number;
   }): v4.Node {
     return {
       id: opts.id,
@@ -25,7 +25,7 @@ export const Nodes = Object.freeze({
       config: {
         destination: opts.destination,
         amount: opts.amountWei,
-        ...(opts.chainId ? { chainId: opts.chainId } : {}),
+        chainId: opts.chainId,
       },
     } as v4.Node;
   },
@@ -45,7 +45,7 @@ export const Nodes = Object.freeze({
     isSimulated?: boolean;
     valueWei?: string;
     gasLimit?: string;
-    chainId?: number;
+    chainId: number;
   }): v4.Node {
     return {
       id: opts.id,
@@ -59,7 +59,7 @@ export const Nodes = Object.freeze({
         ...(opts.isSimulated !== undefined ? { isSimulated: opts.isSimulated } : {}),
         ...(opts.valueWei ? { value: opts.valueWei } : {}),
         ...(opts.gasLimit ? { gasLimit: opts.gasLimit } : {}),
-        ...(opts.chainId ? { chainId: opts.chainId } : {}),
+        chainId: opts.chainId,
       },
     } as v4.Node;
   },
@@ -75,7 +75,7 @@ export const Nodes = Object.freeze({
       callData?: string;
       applyToFields?: string[];
     }>;
-    chainId?: number;
+    chainId: number;
   }): v4.Node {
     return {
       id: opts.id,
@@ -85,7 +85,7 @@ export const Nodes = Object.freeze({
         contractAddress: opts.contractAddress,
         ...(opts.contractAbi ? { contractAbi: opts.contractAbi } : {}),
         ...(opts.methodCalls ? { methodCalls: opts.methodCalls } : {}),
-        ...(opts.chainId ? { chainId: opts.chainId } : {}),
+        chainId: opts.chainId,
       },
     } as v4.Node;
   },

--- a/packages/sdk-js/src/v4/builders/triggers.ts
+++ b/packages/sdk-js/src/v4/builders/triggers.ts
@@ -16,7 +16,7 @@ import type { v4 } from "@avaprotocol/types";
  * SDK callers use the builder or hand-assemble the object.
  */
 export const Triggers = Object.freeze({
-  block(opts: { name: string; id?: string; interval: number; chainId?: number }): v4.Trigger {
+  block(opts: { name: string; id?: string; interval: number; chainId: number }): v4.Trigger {
     return {
       type: "block",
       name: opts.name,
@@ -26,7 +26,7 @@ export const Triggers = Object.freeze({
       // alongside the discriminator. Both forms (`{type, config}` and
       // the `BlockTrigger.type` enum) survive the wire-level merge
       // oapi-codegen's serializer performs.
-      config: { interval: opts.interval, ...(opts.chainId ? { chainId: opts.chainId } : {}) },
+      config: { interval: opts.interval, chainId: opts.chainId },
     } as v4.Trigger;
   },
 
@@ -96,7 +96,7 @@ export const Triggers = Object.freeze({
         value: string;
       }>;
     }>;
-    chainId?: number;
+    chainId: number;
     cooldownSeconds?: number;
   }): v4.Trigger {
     return {
@@ -105,7 +105,7 @@ export const Triggers = Object.freeze({
       ...(opts.id ? { id: opts.id } : {}),
       config: {
         queries: opts.queries,
-        ...(opts.chainId ? { chainId: opts.chainId } : {}),
+        chainId: opts.chainId,
         ...(opts.cooldownSeconds !== undefined ? { cooldownSeconds: opts.cooldownSeconds } : {}),
       },
     } as v4.Trigger;

--- a/packages/sdk-js/src/v4/builders/triggers.ts
+++ b/packages/sdk-js/src/v4/builders/triggers.ts
@@ -89,11 +89,24 @@ export const Triggers = Object.freeze({
       /** Topic filters; empty string ("") matches any topic at that index. */
       topics?: string[];
       maxEventsPerBlock?: number;
+      /**
+       * Contract ABI (JSON entries) for decoding the event. REQUIRED for
+       * `conditions` that reference a decoded field (e.g. `AnswerUpdated.current`):
+       * without it the engine can't resolve the field and the condition fails.
+       */
+      contractAbi?: ReadonlyArray<Record<string, unknown>>;
       conditions?: Array<{
         fieldName: string;
         operator: "eq" | "ne" | "gt" | "gte" | "lt" | "lte" | "contains";
         fieldType?: string;
         value: string;
+      }>;
+      /** Method calls that enrich decoded event data (e.g. `decimals`). */
+      methodCalls?: Array<{
+        methodName: string;
+        callData?: string;
+        applyToFields?: string[];
+        methodParams?: string[];
       }>;
     }>;
     chainId: number;

--- a/packages/sdk-js/src/v4/resources/executions.ts
+++ b/packages/sdk-js/src/v4/resources/executions.ts
@@ -5,7 +5,6 @@ import { Transport } from "../internal/transport";
 export interface ListExecutionsParams {
   /** Required for the flat list endpoint; pass one or more workflowIds. */
   workflowId?: string[];
-  chainId?: number;
   before?: string;
   after?: string;
   limit?: number;
@@ -13,19 +12,19 @@ export interface ListExecutionsParams {
 
 export interface CountExecutionsParams {
   workflowId?: string[];
-  chainId?: number;
 }
 
 export interface ExecutionStatsParams {
   workflowId?: string[];
-  chainId?: number;
 }
 
 export interface RetrieveExecutionParams {
   /**
    * Workflow id the execution belongs to. Required because executions
-   * are stored under their parent workflow's chain-scoped prefix in
-   * BadgerDB — there is no global execution index.
+   * are indexed under their parent workflow — there is no global
+   * execution index. (Storage is chain-agnostic since the chain
+   * decoupling: chain lives on the workflow's parts, not on the
+   * execution key.)
    */
   workflowId: string;
 }

--- a/packages/sdk-js/src/v4/resources/nodes.ts
+++ b/packages/sdk-js/src/v4/resources/nodes.ts
@@ -20,11 +20,13 @@ export class NodesResource {
    * delegation, no persistence) and returns the raw output keyed by
    * node type — `{ success, output: { <nodeType>: {...} } }`.
    *
-   * Chain context: the gateway resolves the target chain in this order:
-   * `body.chainId` → `inputVariables.settings.chain_id` → the JWT's
-   * `aud` claim → the gateway's default chain. Specify `chainId`
-   * explicitly when calling a contract that lives on a non-default
-   * chain (e.g. a sepolia oracle when the gateway defaults to mainnet).
+   * Chain context: the chain is **explicit-or-error** since the chain
+   * decoupling — there is no `settings.chain_id` / JWT-`aud` / default
+   * fallback. For a chain-aware node, set either the request-level
+   * `chainId` or the node's own `config.chainId`; the gateway stamps the
+   * request chain onto the node when the node leaves it unset
+   * (`stampNodeChainIfUnset`). The chain must be one of the configured
+   * set (Ethereum, Base, Sepolia, Base Sepolia) or the call is rejected.
    */
   run(req: v4.RunNodeRequest): Promise<v4.RunNodeResponse> {
     return this.transport.request<v4.RunNodeResponse>({

--- a/packages/sdk-js/src/v4/resources/workflows.ts
+++ b/packages/sdk-js/src/v4/resources/workflows.ts
@@ -16,7 +16,6 @@ export interface ListWorkflowsParams {
   smartWalletAddress?: string[];
   /** Filter by status. Repeat to OR multiple statuses. */
   status?: v4.WorkflowStatus[];
-  chainId?: number;
   before?: string;
   after?: string;
   limit?: number;
@@ -25,7 +24,6 @@ export interface ListWorkflowsParams {
 export interface CountWorkflowsParams {
   smartWalletAddress?: string[];
   status?: v4.WorkflowStatus[];
-  chainId?: number;
 }
 
 /**

--- a/packages/types/openapi/openapi.yaml
+++ b/packages/types/openapi/openapi.yaml
@@ -118,9 +118,9 @@ components:
       type: integer
       format: int64
       description: |
-        Numeric chain ID. `0` or omitted means "use the aggregator's default
-        chain" — typically only useful in single-chain deployments or for
-        chain-agnostic operations.
+        Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+        chain-aware trigger/node configs this is required and must be a
+        configured chain; on query/filter params it is optional.
       example: 11155111
 
     EthereumAddress:
@@ -392,7 +392,7 @@ components:
     BlockTriggerConfig:
       type: object
       description: Fires every N blocks on the target chain.
-      required: [interval]
+      required: [interval, chainId]
       properties:
         interval:
           type: integer
@@ -401,7 +401,7 @@ components:
           description: Fire every N blocks.
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to watch blocks on. 0 = inherit workflow chainId.
+          description: Chain to watch blocks on. Required — a workflow carries no chain to inherit.
 
     EventTriggerQuery:
       type: object
@@ -476,7 +476,7 @@ components:
     EventTriggerConfig:
       type: object
       description: Fires when matching on-chain events are observed.
-      required: [queries]
+      required: [queries, chainId]
       properties:
         queries:
           type: array
@@ -491,7 +491,7 @@ components:
             trigger again. Default 300. 0 disables cooldown.
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to watch events on. 0 = inherit workflow chainId.
+          description: Chain to watch events on. Required — a workflow carries no chain to inherit.
 
     # ---- Trigger union ----
 
@@ -583,7 +583,7 @@ components:
 
     ETHTransferNodeConfig:
       type: object
-      required: [destination, amount]
+      required: [destination, amount, chainId]
       properties:
         destination: { $ref: '#/components/schemas/EthereumAddress' }
         amount:
@@ -591,11 +591,11 @@ components:
           description: Amount in wei (decimal string for big-int safety). Special value `max` withdraws the entire balance.
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to execute on. 0 = inherit workflow chainId.
+          description: Chain to execute on. Required — a workflow carries no chain to inherit.
 
     ContractWriteNodeConfig:
       type: object
-      required: [contractAddress]
+      required: [contractAddress, chainId]
       properties:
         contractAddress: { $ref: '#/components/schemas/EthereumAddress' }
         callData: { $ref: '#/components/schemas/Hex' }
@@ -617,11 +617,11 @@ components:
           description: Custom gas limit (decimal string).
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to execute on. 0 = inherit workflow chainId.
+          description: Chain to execute on. Required — a workflow carries no chain to inherit.
 
     ContractReadNodeConfig:
       type: object
-      required: [contractAddress]
+      required: [contractAddress, chainId]
       properties:
         contractAddress: { $ref: '#/components/schemas/EthereumAddress' }
         contractAbi:
@@ -633,7 +633,7 @@ components:
           items: { $ref: '#/components/schemas/MethodCall' }
         chainId:
           $ref: '#/components/schemas/ChainId'
-          description: Chain to read from. 0 = inherit workflow chainId.
+          description: Chain to read from. Required — a workflow carries no chain to inherit.
 
     GraphQLQueryNodeConfig:
       type: object
@@ -894,9 +894,6 @@ components:
         name: { type: string }
         owner: { $ref: '#/components/schemas/EthereumAddress' }
         smartWalletAddress: { $ref: '#/components/schemas/EthereumAddress' }
-        chainId:
-          $ref: '#/components/schemas/ChainId'
-          description: Workflow-level default chain. Triggers and nodes may override.
         trigger: { $ref: '#/components/schemas/Trigger' }
         nodes:
           type: array
@@ -939,9 +936,6 @@ components:
       properties:
         name: { type: string }
         smartWalletAddress: { $ref: '#/components/schemas/EthereumAddress' }
-        chainId:
-          $ref: '#/components/schemas/ChainId'
-          description: Default chain. Triggers and nodes may override.
         trigger: { $ref: '#/components/schemas/Trigger' }
         nodes:
           type: array
@@ -1427,6 +1421,46 @@ components:
         node: { $ref: '#/components/schemas/Node' }
         inputVariables: { $ref: '#/components/schemas/InputVariables' }
         chainId: { $ref: '#/components/schemas/ChainId' }
+        erc20Overrides:
+          type: array
+          description: >
+            Optional ERC20 balance/allowance state overrides applied only during
+            this isolated node simulation. Lets callers seed token balances and
+            approvals so contract-write simulations (e.g. Uniswap swaps) don't
+            revert with "transfer amount exceeds allowance/balance" before the
+            approval/funding transactions have been run. Simulation-only: a
+            real-execution request (isSimulated=false) that sets these is rejected
+            with an error, never silently ignored.
+          items: { $ref: '#/components/schemas/ERC20StateOverride' }
+
+    ERC20StateOverride:
+      type: object
+      required: [tokenAddress, ownerAddress]
+      description: >
+        Seeds a token's balanceOf / allowance storage slots for a single
+        simulation. balanceOf[owner] lives at keccak256(abi.encode(owner,
+        balanceSlot)); allowance[owner][spender] at keccak256(abi.encode(spender,
+        keccak256(abi.encode(owner, allowanceSlot)))).
+      properties:
+        tokenAddress: { $ref: '#/components/schemas/EthereumAddress' }
+        ownerAddress: { $ref: '#/components/schemas/EthereumAddress' }
+        spenderAddress: { $ref: '#/components/schemas/EthereumAddress' }
+        balance:
+          type: string
+          description: Balance override (hex 0x… or decimal string).
+        allowance:
+          type: string
+          description: Allowance override (hex 0x… or decimal string).
+        balanceSlot:
+          type: integer
+          format: int64
+          minimum: 0
+          description: 'Storage slot for the balanceOf mapping. Required when balance is set; ERC20 storage layout varies per token (OpenZeppelin 0, USDC FiatToken 9).'
+        allowanceSlot:
+          type: integer
+          format: int64
+          minimum: 0
+          description: 'Storage slot for the allowance mapping. Required when allowance is set; ERC20 storage layout varies per token (OpenZeppelin 1, USDC FiatToken 10).'
 
     RunNodeResponse:
       type: object
@@ -1662,7 +1696,6 @@ paths:
           schema:
             type: array
             items: { $ref: '#/components/schemas/WorkflowStatus' }
-        - $ref: '#/components/parameters/ChainIdQuery'
         - $ref: '#/components/parameters/PageBefore'
         - $ref: '#/components/parameters/PageAfter'
         - $ref: '#/components/parameters/PageLimit'
@@ -1860,7 +1893,6 @@ paths:
           schema:
             type: array
             items: { $ref: '#/components/schemas/WorkflowStatus' }
-        - $ref: '#/components/parameters/ChainIdQuery'
       responses:
         '200':
           description: Workflow count for the filter set.
@@ -1885,7 +1917,6 @@ paths:
           schema:
             type: array
             items: { $ref: '#/components/schemas/Ulid' }
-        - $ref: '#/components/parameters/ChainIdQuery'
         - $ref: '#/components/parameters/PageBefore'
         - $ref: '#/components/parameters/PageAfter'
         - $ref: '#/components/parameters/PageLimit'
@@ -2023,7 +2054,6 @@ paths:
           schema:
             type: array
             items: { $ref: '#/components/schemas/Ulid' }
-        - $ref: '#/components/parameters/ChainIdQuery'
       responses:
         '200':
           description: Execution count.
@@ -2043,7 +2073,6 @@ paths:
           schema:
             type: array
             items: { $ref: '#/components/schemas/Ulid' }
-        - $ref: '#/components/parameters/ChainIdQuery'
       responses:
         '200':
           description: Execution stats.

--- a/packages/types/src/openapi.gen.ts
+++ b/packages/types/src/openapi.gen.ts
@@ -621,9 +621,9 @@ export interface components {
     schemas: {
         /**
          * Format: int64
-         * @description Numeric chain ID. `0` or omitted means "use the aggregator's default
-         *     chain" — typically only useful in single-chain deployments or for
-         *     chain-agnostic operations.
+         * @description Numeric chain ID (e.g. 11155111 for Sepolia, 8453 for Base). On
+         *     chain-aware trigger/node configs this is required and must be a
+         *     configured chain; on query/filter params it is optional.
          * @example 11155111
          */
         readonly ChainId: number;
@@ -784,8 +784,8 @@ export interface components {
              * @description Fire every N blocks.
              */
             readonly interval: number;
-            /** @description Chain to watch blocks on. 0 = inherit workflow chainId. */
-            readonly chainId?: components["schemas"]["ChainId"];
+            /** @description Chain to watch blocks on. Required — a workflow carries no chain to inherit. */
+            readonly chainId: components["schemas"]["ChainId"];
         };
         /** @description Single ethereum.FilterQuery — one subscription per query. */
         readonly EventTriggerQuery: {
@@ -841,8 +841,8 @@ export interface components {
              *     trigger again. Default 300. 0 disables cooldown.
              */
             readonly cooldownSeconds?: number;
-            /** @description Chain to watch events on. 0 = inherit workflow chainId. */
-            readonly chainId?: components["schemas"]["ChainId"];
+            /** @description Chain to watch events on. Required — a workflow carries no chain to inherit. */
+            readonly chainId: components["schemas"]["ChainId"];
         };
         readonly Trigger: {
             readonly id?: string;
@@ -915,8 +915,8 @@ export interface components {
             readonly destination: components["schemas"]["EthereumAddress"];
             /** @description Amount in wei (decimal string for big-int safety). Special value `max` withdraws the entire balance. */
             readonly amount: string;
-            /** @description Chain to execute on. 0 = inherit workflow chainId. */
-            readonly chainId?: components["schemas"]["ChainId"];
+            /** @description Chain to execute on. Required — a workflow carries no chain to inherit. */
+            readonly chainId: components["schemas"]["ChainId"];
         };
         readonly ContractWriteNodeConfig: {
             readonly contractAddress: components["schemas"]["EthereumAddress"];
@@ -931,8 +931,8 @@ export interface components {
             readonly value?: string;
             /** @description Custom gas limit (decimal string). */
             readonly gasLimit?: string;
-            /** @description Chain to execute on. 0 = inherit workflow chainId. */
-            readonly chainId?: components["schemas"]["ChainId"];
+            /** @description Chain to execute on. Required — a workflow carries no chain to inherit. */
+            readonly chainId: components["schemas"]["ChainId"];
         };
         readonly ContractReadNodeConfig: {
             readonly contractAddress: components["schemas"]["EthereumAddress"];
@@ -940,8 +940,8 @@ export interface components {
                 readonly [key: string]: unknown;
             }[];
             readonly methodCalls?: readonly components["schemas"]["MethodCall"][];
-            /** @description Chain to read from. 0 = inherit workflow chainId. */
-            readonly chainId?: components["schemas"]["ChainId"];
+            /** @description Chain to read from. Required — a workflow carries no chain to inherit. */
+            readonly chainId: components["schemas"]["ChainId"];
         };
         readonly GraphQLQueryNodeConfig: {
             /** Format: uri */
@@ -1168,8 +1168,6 @@ export interface components {
             readonly name?: string;
             readonly owner: components["schemas"]["EthereumAddress"];
             readonly smartWalletAddress: components["schemas"]["EthereumAddress"];
-            /** @description Workflow-level default chain. Triggers and nodes may override. */
-            readonly chainId?: components["schemas"]["ChainId"];
             readonly trigger: components["schemas"]["Trigger"];
             readonly nodes: readonly components["schemas"]["Node"][];
             readonly edges?: readonly components["schemas"]["Edge"][];
@@ -1209,8 +1207,6 @@ export interface components {
         readonly CreateWorkflowRequest: {
             readonly name?: string;
             readonly smartWalletAddress: components["schemas"]["EthereumAddress"];
-            /** @description Default chain. Triggers and nodes may override. */
-            readonly chainId?: components["schemas"]["ChainId"];
             readonly trigger: components["schemas"]["Trigger"];
             readonly nodes: readonly components["schemas"]["Node"][];
             readonly edges?: readonly components["schemas"]["Edge"][];
@@ -1547,6 +1543,28 @@ export interface components {
             readonly node: components["schemas"]["Node"];
             readonly inputVariables?: components["schemas"]["InputVariables"];
             readonly chainId?: components["schemas"]["ChainId"];
+            /** @description Optional ERC20 balance/allowance state overrides applied only during this isolated node simulation. Lets callers seed token balances and approvals so contract-write simulations (e.g. Uniswap swaps) don't revert with "transfer amount exceeds allowance/balance" before the approval/funding transactions have been run. Simulation-only: a real-execution request (isSimulated=false) that sets these is rejected with an error, never silently ignored. */
+            readonly erc20Overrides?: readonly components["schemas"]["ERC20StateOverride"][];
+        };
+        /** @description Seeds a token's balanceOf / allowance storage slots for a single simulation. balanceOf[owner] lives at keccak256(abi.encode(owner, balanceSlot)); allowance[owner][spender] at keccak256(abi.encode(spender, keccak256(abi.encode(owner, allowanceSlot)))). */
+        readonly ERC20StateOverride: {
+            readonly tokenAddress: components["schemas"]["EthereumAddress"];
+            readonly ownerAddress: components["schemas"]["EthereumAddress"];
+            readonly spenderAddress?: components["schemas"]["EthereumAddress"];
+            /** @description Balance override (hex 0x… or decimal string). */
+            readonly balance?: string;
+            /** @description Allowance override (hex 0x… or decimal string). */
+            readonly allowance?: string;
+            /**
+             * Format: int64
+             * @description Storage slot for the balanceOf mapping. Required when balance is set; ERC20 storage layout varies per token (OpenZeppelin 0, USDC FiatToken 9).
+             */
+            readonly balanceSlot?: number;
+            /**
+             * Format: int64
+             * @description Storage slot for the allowance mapping. Required when allowance is set; ERC20 storage layout varies per token (OpenZeppelin 1, USDC FiatToken 10).
+             */
+            readonly allowanceSlot?: number;
         };
         readonly RunNodeResponse: {
             readonly success: boolean;
@@ -1713,11 +1731,6 @@ export interface operations {
                 readonly smartWalletAddress?: readonly components["schemas"]["EthereumAddress"][];
                 /** @description Filter by status. Repeat to OR multiple statuses. */
                 readonly status?: readonly components["schemas"]["WorkflowStatus"][];
-                /**
-                 * @description Chain ID filter. Omit to use the aggregator default chain. Repeat
-                 *     the parameter to filter by multiple chains.
-                 */
-                readonly chainId?: components["parameters"]["ChainIdQuery"];
                 /** @description Cursor — return items immediately before this position (backward pagination). */
                 readonly before?: components["parameters"]["PageBefore"];
                 /** @description Cursor — return items immediately after this position (forward pagination). */
@@ -1990,11 +2003,6 @@ export interface operations {
             readonly query?: {
                 readonly smartWalletAddress?: readonly components["schemas"]["EthereumAddress"][];
                 readonly status?: readonly components["schemas"]["WorkflowStatus"][];
-                /**
-                 * @description Chain ID filter. Omit to use the aggregator default chain. Repeat
-                 *     the parameter to filter by multiple chains.
-                 */
-                readonly chainId?: components["parameters"]["ChainIdQuery"];
             };
             readonly header?: never;
             readonly path?: never;
@@ -2019,11 +2027,6 @@ export interface operations {
             readonly query?: {
                 /** @description Filter by workflow ID. Repeat to OR multiple workflows. */
                 readonly workflowId?: readonly components["schemas"]["Ulid"][];
-                /**
-                 * @description Chain ID filter. Omit to use the aggregator default chain. Repeat
-                 *     the parameter to filter by multiple chains.
-                 */
-                readonly chainId?: components["parameters"]["ChainIdQuery"];
                 /** @description Cursor — return items immediately before this position (backward pagination). */
                 readonly before?: components["parameters"]["PageBefore"];
                 /** @description Cursor — return items immediately after this position (forward pagination). */
@@ -2172,11 +2175,6 @@ export interface operations {
         readonly parameters: {
             readonly query?: {
                 readonly workflowId?: readonly components["schemas"]["Ulid"][];
-                /**
-                 * @description Chain ID filter. Omit to use the aggregator default chain. Repeat
-                 *     the parameter to filter by multiple chains.
-                 */
-                readonly chainId?: components["parameters"]["ChainIdQuery"];
             };
             readonly header?: never;
             readonly path?: never;
@@ -2200,11 +2198,6 @@ export interface operations {
         readonly parameters: {
             readonly query?: {
                 readonly workflowId?: readonly components["schemas"]["Ulid"][];
-                /**
-                 * @description Chain ID filter. Omit to use the aggregator default chain. Repeat
-                 *     the parameter to filter by multiple chains.
-                 */
-                readonly chainId?: components["parameters"]["ChainIdQuery"];
             };
             readonly header?: never;
             readonly path?: never;

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ the root of this repo and point `AVS_REST_URL` at the gateway.
 ```bash
 export AVS_REST_URL=http://localhost:8080/api/v1
 export TEST_PRIVATE_KEY=0x...                       # EOA for auth flow
-yarn test:v4
+yarn test
 ```
 
 `tests-v3-archive/` holds the legacy gRPC test suite (44 files). They

--- a/tests/utils/client.ts
+++ b/tests/utils/client.ts
@@ -223,13 +223,18 @@ export async function removeCreatedWorkflows(
  * Mirrors v3's `getSettings()` — keeps the per-test boilerplate down.
  */
 export function settingsFor(runner: string, name = "Test Simulation") {
-  // chain_id (snake_case to match the engine's expectation) is
-  // mandatory for contractWrite simulation through Tenderly. Default
-  // to Sepolia since the dev stack runs there; callers running on a
-  // different chain can override via `settingsForChain` below.
+  // `settings.chain_id` is VESTIGIAL since the chain decoupling: the engine
+  // resolves the execution chain from each chain-aware part's own `chainId`,
+  // not from settings (the old "audit class A" fallback was removed by G5).
+  // Verified: simulate succeeds with or without it. Kept only so the helper's
+  // shape doesn't churn callers; the engine ignores it. `name` is still read
+  // by the context-memory summarizer. Safe to drop in a follow-up.
   return { name, runner, chain_id: 11_155_111 };
 }
 
+// Retained for back-compat with callers that pass an explicit chain. Like
+// `settingsFor`, the `chain_id` it emits is vestigial — the per-part `chainId`
+// on each node/trigger is authoritative.
 export function settingsForChain(runner: string, chainId: number, name = "Test Simulation") {
   return { name, runner, chain_id: chainId };
 }

--- a/tests/v4/core/secret.test.ts
+++ b/tests/v4/core/secret.test.ts
@@ -101,6 +101,7 @@ describe("secret Tests", () => {
         trigger: Triggers.block({
           id: "trigger",
           name: "blockTrigger",
+          chainId: 11_155_111,
           interval: 5,
         }),
         nodes: [

--- a/tests/v4/core/wallet.test.ts
+++ b/tests/v4/core/wallet.test.ts
@@ -74,6 +74,7 @@ describe("Wallet Management Tests", () => {
           trigger: Triggers.block({
             id: "trigger",
             name: "blockTrigger",
+            chainId: 11_155_111,
             interval: 102,
           }),
         };

--- a/tests/v4/executions/errorCodeConsistency.test.ts
+++ b/tests/v4/executions/errorCodeConsistency.test.ts
@@ -44,7 +44,7 @@ describe("Error code consistency between nodes.run and workflows.simulate", () =
 
     // workflows.simulate path.
     const sim = await client.workflows.simulate({
-      trigger: Triggers.block({ id: "trigger", name: "timeTrigger", interval: 7200 }),
+      trigger: Triggers.block({ id: "trigger", name: "timeTrigger", chainId: 11_155_111, interval: 7200 }),
       nodes: [emptyCustomCode],
       edges: [{ id: "e1", source: "trigger", target: "step1" }],
       inputVariables: { settings: settingsFor(wallet.address) },
@@ -62,7 +62,7 @@ describe("Error code consistency between nodes.run and workflows.simulate", () =
   test("successful step has no errorCode (or an UNSPECIFIED sentinel)", async () => {
     const wallet = await createSmartWallet(client);
     const sim = await client.workflows.simulate({
-      trigger: Triggers.block({ id: "trigger", name: "timeTrigger", interval: 7200 }),
+      trigger: Triggers.block({ id: "trigger", name: "timeTrigger", chainId: 11_155_111, interval: 7200 }),
       nodes: [
         Nodes.customCode({ id: "step1", name: "code1", source: "return {result: 'ok'};" }),
       ],

--- a/tests/v4/executions/estimateFees.test.ts
+++ b/tests/v4/executions/estimateFees.test.ts
@@ -117,6 +117,7 @@ describe("workflows.estimateFees Tests", () => {
         Nodes.ethTransfer({
           id: "step1",
           name: "ethTransfer",
+          chainId: 11_155_111,
           destination: smartWalletAddress,
           amountWei: "1000000000000000",
         }),

--- a/tests/v4/executions/execution.test.ts
+++ b/tests/v4/executions/execution.test.ts
@@ -48,7 +48,7 @@ describe("Execution Management Tests", () => {
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
       maxExecution: 0,
-      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval: 5 }),
+      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
     });
     const wfId = created.id as string;
     createdWorkflowIds.push(wfId);
@@ -99,7 +99,7 @@ describe("Execution Management Tests", () => {
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
       maxExecution: 0,
-      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval: 5 }),
+      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
     });
     const wfId = created.id as string;
     createdWorkflowIds.push(wfId);

--- a/tests/v4/executions/gasTracking.test.ts
+++ b/tests/v4/executions/gasTracking.test.ts
@@ -59,6 +59,7 @@ describe("Gas tracking", () => {
       node: Nodes.ethTransfer({
         id: "transfer",
         name: "transfer",
+        chainId: 11_155_111,
         destination: eoaAddress,
         amountWei: "1000000000000000",
       }),
@@ -93,11 +94,12 @@ describe("Gas tracking", () => {
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
       maxExecution: 1,
-      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval: 5 }),
+      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
       nodes: [
         Nodes.ethTransfer({
           id: "transfer",
           name: "transfer",
+          chainId: 11_155_111,
           destination: eoaAddress,
           amountWei: "100000000000000",
         }),
@@ -142,6 +144,7 @@ describe("Gas tracking", () => {
         Nodes.ethTransfer({
           id: "transfer",
           name: "transfer",
+          chainId: 11_155_111,
           destination: eoaAddress,
           amountWei: "1",
         }),

--- a/tests/v4/executions/getExecution.test.ts
+++ b/tests/v4/executions/getExecution.test.ts
@@ -52,7 +52,7 @@ describe("executions.retrieve Tests", () => {
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
       maxExecution: 3,
-      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval }),
+      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval }),
     });
     const wfId = created.id as string;
     createdWorkflowIds.push(wfId);
@@ -136,7 +136,7 @@ describe("executions.retrieve Tests", () => {
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
       maxExecution: 1,
-      trigger: Triggers.block({ id: "trigger", name: "blockGetExecs", interval: 5 }),
+      trigger: Triggers.block({ id: "trigger", name: "blockGetExecs", chainId: 11_155_111, interval: 5 }),
       nodes: [Nodes.customCode({ id: "step1", name: "step1", source: "return {ok: true};" })],
       edges: [{ id: "e1", source: "trigger", target: "step1" }],
     });

--- a/tests/v4/executions/getExecutions.test.ts
+++ b/tests/v4/executions/getExecutions.test.ts
@@ -33,7 +33,7 @@ async function createAndFireWorkflow(
   const created = await client.workflows.create({
     ...createFromTemplate(walletAddress),
     maxExecution: 1,
-    trigger: Triggers.block({ id: "trigger", name: triggerName, interval: 5 }),
+    trigger: Triggers.block({ id: "trigger", name: triggerName, chainId: 11_155_111, interval: 5 }),
   });
   const wfId = created.id as string;
   await client.workflows.trigger(wfId, {

--- a/tests/v4/executions/partialSuccess.test.ts
+++ b/tests/v4/executions/partialSuccess.test.ts
@@ -44,7 +44,7 @@ describe("Execution Status — partial / mixed step outcomes", () => {
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
       maxExecution: 1,
-      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval: 5 }),
+      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
       nodes: [
         Nodes.customCode({ id: "good", name: "successfulNode", source: "return {result: 'success'};" }),
         Nodes.customCode({
@@ -87,7 +87,7 @@ describe("Execution Status — partial / mixed step outcomes", () => {
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
       maxExecution: 1,
-      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval: 5 }),
+      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
       nodes: [
         Nodes.customCode({ id: "step1", name: "step1", source: "return {ok: 1};" }),
         Nodes.customCode({ id: "step2", name: "step2", source: "return {ok: 2};" }),
@@ -121,7 +121,7 @@ describe("Execution Status — partial / mixed step outcomes", () => {
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
       maxExecution: 1,
-      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval: 5 }),
+      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
       nodes: [
         Nodes.customCode({ id: "step1", name: "step1", source: "throw new Error('boom1');" }),
       ],

--- a/tests/v4/executions/runNodeWithInputs.test.ts
+++ b/tests/v4/executions/runNodeWithInputs.test.ts
@@ -63,6 +63,7 @@ describe("nodes.run (provider routing)", () => {
       node: Nodes.contractWrite({
         id: "w",
         name: "approve",
+        chainId: 11_155_111,
         contractAddress: USDC_SEPOLIA,
         contractAbi: APPROVE_ABI,
         methodCalls: [{ methodName: "approve", methodParams: [eoaAddress, "1000000"] }],

--- a/tests/v4/nodes/branchNode.test.ts
+++ b/tests/v4/nodes/branchNode.test.ts
@@ -151,7 +151,7 @@ describe("BranchNode Tests", () => {
 
         const wfReq = {
           ...createFromTemplate(wallet.address),
-          trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval: 3 }),
+          trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 3 }),
           nodes: [branch, nodeA, nodeB],
           edges: [
             { id: "e1", source: "trigger", target: "branch" },

--- a/tests/v4/nodes/contractRead.test.ts
+++ b/tests/v4/nodes/contractRead.test.ts
@@ -74,6 +74,7 @@ describe("ContractRead Node Tests", () => {
         node: Nodes.contractRead({
           id: "r",
           name: "r",
+          chainId: 11_155_111,
           contractAddress: ORACLE_ADDRESS,
           contractAbi: ORACLE_ABI,
           methodCalls: [{ methodName: "latestRoundData", methodParams: [] }],
@@ -97,6 +98,7 @@ describe("ContractRead Node Tests", () => {
         node: Nodes.contractRead({
           id: "r",
           name: "r",
+          chainId: 11_155_111,
           contractAddress: ORACLE_ADDRESS,
           contractAbi: ORACLE_ABI,
           methodCalls: [
@@ -119,6 +121,7 @@ describe("ContractRead Node Tests", () => {
         node: Nodes.contractRead({
           id: "r",
           name: "r",
+          chainId: 11_155_111,
           contractAddress: ORACLE_ADDRESS,
           contractAbi: ORACLE_ABI,
           methodCalls: [{ methodName: "description", methodParams: [] }],
@@ -141,6 +144,7 @@ describe("ContractRead Node Tests", () => {
         node: Nodes.contractRead({
           id: "r",
           name: "r",
+          chainId: 11_155_111,
           contractAddress: "0x1234567890123456789012345678901234567890",
           contractAbi: [
             {
@@ -165,6 +169,7 @@ describe("ContractRead Node Tests", () => {
         node: Nodes.contractRead({
           id: "r",
           name: "r",
+          chainId: 11_155_111,
           contractAddress: ORACLE_ADDRESS,
           contractAbi: ORACLE_ABI,
           methodCalls: [
@@ -203,6 +208,7 @@ describe("ContractRead Node Tests", () => {
           Nodes.contractRead({
             id: "r",
             name: "r",
+            chainId: 11_155_111,
             contractAddress: ORACLE_ADDRESS,
             contractAbi: ORACLE_ABI,
             methodCalls: [{ methodName: "latestRoundData", methodParams: [] }],

--- a/tests/v4/nodes/contractWrite.test.ts
+++ b/tests/v4/nodes/contractWrite.test.ts
@@ -60,6 +60,7 @@ describe("ContractWrite Node Tests", () => {
         node: Nodes.contractWrite({
           id: "w",
           name: "w",
+          chainId: 11_155_111,
           contractAddress: USDC_SEPOLIA,
           contractAbi: ERC20_ABI,
           methodCalls: [{ methodName: "approve", methodParams: [eoaAddress, "0"] }],
@@ -80,6 +81,7 @@ describe("ContractWrite Node Tests", () => {
         node: Nodes.contractWrite({
           id: "w",
           name: "w",
+          chainId: 11_155_111,
           contractAddress: USDC_SEPOLIA,
           contractAbi: ERC20_ABI,
           methodCalls: [{ methodName: "transfer", methodParams: [eoaAddress, "1"] }],
@@ -101,6 +103,7 @@ describe("ContractWrite Node Tests", () => {
         node: Nodes.contractWrite({
           id: "w",
           name: "w",
+          chainId: 11_155_111,
           contractAddress: USDC_SEPOLIA,
           contractAbi: ERC20_ABI,
           methodCalls: [
@@ -123,6 +126,7 @@ describe("ContractWrite Node Tests", () => {
         node: Nodes.contractWrite({
           id: "w",
           name: "w",
+          chainId: 11_155_111,
           contractAddress: USDC_SEPOLIA,
           contractAbi: ERC20_ABI,
           methodCalls: [{ methodName: "nonexistent", methodParams: [] }],
@@ -143,6 +147,7 @@ describe("ContractWrite Node Tests", () => {
           Nodes.contractWrite({
             id: "w",
             name: "w",
+            chainId: 11_155_111,
             contractAddress: USDC_SEPOLIA,
             contractAbi: ERC20_ABI,
             methodCalls: [{ methodName: "approve", methodParams: [eoaAddress, "0"] }],
@@ -172,12 +177,14 @@ describe("ContractWrite Node Tests", () => {
         trigger: Triggers.block({
           id: "trigger",
           name: "blockTrigger",
+          chainId: 11_155_111,
           interval: 5,
         }),
         nodes: [
           Nodes.contractWrite({
             id: "w",
             name: "w",
+            chainId: 11_155_111,
             contractAddress: USDC_SEPOLIA,
             contractAbi: ERC20_ABI,
             methodCalls: [{ methodName: "approve", methodParams: [eoaAddress, "0"] }],

--- a/tests/v4/nodes/customCode.test.ts
+++ b/tests/v4/nodes/customCode.test.ts
@@ -321,6 +321,7 @@ describe("CustomCode Node Tests", () => {
         trigger: Triggers.block({
           id: "trigger",
           name: "blockTrigger",
+          chainId: 11_155_111,
           interval: triggerInterval,
         }),
         nodes: [node],

--- a/tests/v4/nodes/ethTransfer.test.ts
+++ b/tests/v4/nodes/ethTransfer.test.ts
@@ -59,6 +59,7 @@ describe("ETHTransfer Node Tests", () => {
         node: Nodes.ethTransfer({
           id: "n1",
           name: "n1",
+          chainId: 11_155_111,
           destination: eoaAddress,
           amountWei,
         }),
@@ -95,6 +96,7 @@ describe("ETHTransfer Node Tests", () => {
         node: Nodes.ethTransfer({
           id: "n1",
           name: "n1",
+          chainId: 11_155_111,
           destination: "",
           amountWei: "1",
         }),
@@ -116,6 +118,7 @@ describe("ETHTransfer Node Tests", () => {
         node: Nodes.ethTransfer({
           id: "n1",
           name: "n1",
+          chainId: 11_155_111,
           destination: eoaAddress,
           amountWei: "0",
         }),
@@ -138,6 +141,7 @@ describe("ETHTransfer Node Tests", () => {
           Nodes.ethTransfer({
             id: "transfer",
             name: "transfer",
+            chainId: 11_155_111,
             destination: eoaAddress,
             amountWei,
           }),
@@ -177,12 +181,14 @@ describe("ETHTransfer Node Tests", () => {
         trigger: Triggers.block({
           id: "trigger",
           name: "blockTrigger",
+          chainId: 11_155_111,
           interval: triggerInterval,
         }),
         nodes: [
           Nodes.ethTransfer({
             id: "transfer",
             name: "transfer",
+            chainId: 11_155_111,
             destination: eoaAddress,
             amountWei: "100000000000000",
           }),

--- a/tests/v4/nodes/filterNode.test.ts
+++ b/tests/v4/nodes/filterNode.test.ts
@@ -169,7 +169,7 @@ describe("FilterNode Tests", () => {
 
       const wfReq = {
         ...createFromTemplate(wallet.address),
-        trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval: 5 }),
+        trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
         nodes: [dataNode, filter],
         edges: [
           { id: "e1", source: "trigger", target: "data" },

--- a/tests/v4/smoke.test.ts
+++ b/tests/v4/smoke.test.ts
@@ -171,6 +171,7 @@ describe("v4 SDK smoke", () => {
       const transferTopic = Protocols.erc20.eventTopics.Transfer;
       const trigger = Triggers.event({
         name: "transfer",
+        chainId: 11_155_111,
         queries: [
           {
             addresses: ["0x0000000000000000000000000000000000000001"],

--- a/tests/v4/templates/aave-health-factor-alert.test.ts
+++ b/tests/v4/templates/aave-health-factor-alert.test.ts
@@ -116,10 +116,10 @@ describe("Template: AAVE health factor alert", () => {
     return {
       smartWalletAddress,
       name: "AAVE Health Factor Top-up",
-      chainId: 11_155_111,
       trigger: Triggers.event({
         id: "trigger",
         name: "aaveBorrow",
+        chainId: 11_155_111,
         queries: [
           {
             addresses: [AAVE_V3_POOL_SEPOLIA],
@@ -134,6 +134,7 @@ describe("Template: AAVE health factor alert", () => {
         Nodes.contractRead({
           id: "read",
           name: "aaveRead",
+          chainId: 11_155_111,
           contractAddress: AAVE_V3_POOL_SEPOLIA,
           contractAbi: Protocols.aaveV3.poolMethodsAbi,
           // Read the HF of the smart wallet (the runner) — the account
@@ -182,6 +183,7 @@ describe("Template: AAVE health factor alert", () => {
         Nodes.contractWrite({
           id: "approve",
           name: "approveLink",
+          chainId: 11_155_111,
           contractAddress: AAVE_LINK_SEPOLIA,
           contractAbi: Protocols.erc20.approveAbi,
           methodCalls: [
@@ -198,6 +200,7 @@ describe("Template: AAVE health factor alert", () => {
         Nodes.contractWrite({
           id: "supply",
           name: "topUpCollateral",
+          chainId: 11_155_111,
           contractAddress: AAVE_V3_POOL_SEPOLIA,
           contractAbi: Protocols.aaveV3.poolMethodsAbi,
           methodCalls: [
@@ -376,6 +379,7 @@ describe("Template: AAVE health factor alert", () => {
       Nodes.contractRead({
         id: "read",
         name: "aaveRead",
+        chainId: 11_155_111,
         contractAddress: AAVE_V3_POOL_SEPOLIA,
         contractAbi: Protocols.aaveV3.poolMethodsAbi,
         methodCalls: [
@@ -471,6 +475,7 @@ describe("Template: AAVE health factor alert", () => {
       Nodes.contractRead({
         id: "read",
         name: "aaveRead",
+        chainId: 11_155_111,
         contractAddress: AAVE_V3_POOL_SEPOLIA,
         contractAbi: Protocols.aaveV3.poolMethodsAbi,
         methodCalls: [
@@ -480,6 +485,7 @@ describe("Template: AAVE health factor alert", () => {
       Nodes.contractWrite({
         id: "approve",
         name: "approveLink",
+        chainId: 11_155_111,
         contractAddress: AAVE_LINK_SEPOLIA,
         contractAbi: Protocols.erc20.approveAbi,
         methodCalls: [
@@ -492,6 +498,7 @@ describe("Template: AAVE health factor alert", () => {
       Nodes.contractWrite({
         id: "supply",
         name: "topUpCollateral",
+        chainId: 11_155_111,
         contractAddress: AAVE_V3_POOL_SEPOLIA,
         contractAbi: Protocols.aaveV3.poolMethodsAbi,
         methodCalls: [

--- a/tests/v4/templates/approve-with-simulation.test.ts
+++ b/tests/v4/templates/approve-with-simulation.test.ts
@@ -49,6 +49,7 @@ describe("Template: single approve with Tenderly simulation", () => {
         Nodes.contractWrite({
           id: "approve",
           name: "approve",
+          chainId: 11_155_111,
           contractAddress: USDC_SEPOLIA,
           contractAbi: APPROVE_ABI,
           methodCalls: [{ methodName: "approve", methodParams: [UNISWAP_ROUTER02, "10000"] }],

--- a/tests/v4/templates/batch-recurring-payment-with-email.test.ts
+++ b/tests/v4/templates/batch-recurring-payment-with-email.test.ts
@@ -44,7 +44,6 @@ describe("Template: batch recurring payment with email", () => {
     return {
       smartWalletAddress,
       name: "Batch recurring payment with email",
-      chainId: 11_155_111,
       trigger: Triggers.cron({
         id: "trigger",
         name: "cron",

--- a/tests/v4/templates/exported-workflow-consistency.test.ts
+++ b/tests/v4/templates/exported-workflow-consistency.test.ts
@@ -48,7 +48,6 @@ describe("Template: exported workflow consistency", () => {
     return {
       smartWalletAddress,
       name: "Exported workflow consistency",
-      chainId: 11_155_111,
       trigger: Triggers.manual({
         id: "trigger",
         name: "manualTrigger",

--- a/tests/v4/templates/multichain-per-part-chain.test.ts
+++ b/tests/v4/templates/multichain-per-part-chain.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Per-part multi-chain wire-contract test.
+ *
+ * Locks the contract defined in EigenLayer-AVS PLAN_CHAIN_DECOUPLING.md:
+ * chainId is a property of the *parts that touch a chain* (event/block
+ * triggers, contract/transfer nodes), NOT of the workflow. A workflow
+ * can watch chain X and act on chain Y; each chain-aware part carries
+ * its own explicit chainId, and that value must survive the REST →
+ * proto → REST round-trip intact (the protojson round-trip the backend
+ * already supports — plan "What already works", G1/G3).
+ *
+ * Two tiers:
+ *   1. Single-stack (runs everywhere, incl. the Sepolia-only CI stack):
+ *      every chain-aware part names its chain *explicitly* (no reliance
+ *      on workflow-level `chainId` inheritance). Asserts the explicit
+ *      chain round-trips through create → retrieve. This is the forward-
+ *      compatible shape G5 will make mandatory — writing it now is
+ *      no-regret.
+ *   2. Cross-chain (gated on a multi-chain stack — Railway, or
+ *      MULTICHAIN_TEST=1): trigger on Sepolia, contract read on Base
+ *      Sepolia, in ONE workflow. Proves the two-axis model (watch X /
+ *      act Y) survives the wire. A Sepolia-only stack rejects the Base
+ *      Sepolia part (backend G4 — unconfigured explicit chain), so this
+ *      case only runs where both chains are configured.
+ *
+ * NOTE (intentional, per the renovation plan): this suite sets an
+ * explicit `chainId` on every chain-aware part and sends NO
+ * workflow-level `chainId` (removed from CreateWorkflowRequest in
+ * EigenLayer-AVS #634). This is the post-renovation shape — it stays
+ * type-clean after `yarn types-gen` regenerates against #634's spec.
+ */
+
+import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
+
+import {
+  authenticateClient,
+  getClient,
+  createSmartWallet,
+  removeCreatedWorkflows,
+  settingsForChain,
+} from "../../utils/client";
+
+jest.setTimeout(60_000);
+
+// READINESS GATE — the deployed server must honor an explicit per-node
+// `chainId` on the *persisted* create() path (backend G3). The current
+// `avs-dev:latest` image does NOT: a per-node `chainId` on contractRead
+// is rejected at create() in every representation —
+//   `cannot unmarshal string into ... ContractReadNodeConfig.chainId of
+//    type int64`
+// — because the node-config decode mixes protojson (int64 → quoted
+// string) with plain encoding/json (rejects the quotes). Verified
+// 2026-06-26; see docs/changes/chain-decoupling-sdk-tracking.md. Set
+// PER_NODE_CHAIN_READY=1 once the renovated backend (G3, incl. the
+// persisted create() path) is deployed to the target stack — then these
+// assertions lock the wire contract for real.
+const PER_NODE_CHAIN_READY = process.env.PER_NODE_CHAIN_READY === "1";
+
+// A multi-chain stack (Railway deploys worker-sepolia + worker-base-
+// sepolia + mainnet/base) is required for the genuine cross-chain case;
+// the local CI compose wires Sepolia only. Gate on an explicit opt-in.
+const MULTICHAIN_STACK =
+  process.env.MULTICHAIN_TEST === "1" || process.env.TEST_ENV === "railway";
+
+const contractTest = PER_NODE_CHAIN_READY ? test : test.skip;
+const crossChainTest = PER_NODE_CHAIN_READY && MULTICHAIN_STACK ? test : test.skip;
+
+const USDC_SEPOLIA = Tokens.USDC[Chains.Sepolia]!.address;
+const USDC_BASE_SEPOLIA = Tokens.USDC[Chains.BaseSepolia]!.address;
+const SYMBOL_ABI = Protocols.erc20.symbolAbi;
+
+// A non-anonymous ERC-20 Transfer signature for the event trigger's
+// topic filter — value is irrelevant to the round-trip assertion, we
+// only need a well-formed event query so create() accepts it.
+const TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+/** Read a part's `config.chainId` off a retrieved workflow (union cast). */
+function partChainId(part: unknown): number | undefined {
+  return (part as { config?: { chainId?: number } } | undefined)?.config?.chainId;
+}
+
+describe("Template: per-part multi-chain wire contract", () => {
+  let client: Client;
+  const createdWorkflowIds: string[] = [];
+
+  beforeAll(async () => {
+    client = getClient();
+    await authenticateClient(client);
+  });
+
+  afterEach(async () => {
+    await removeCreatedWorkflows(client, createdWorkflowIds.splice(0));
+  });
+
+  contractTest("explicit per-part chainId round-trips through create → retrieve", async () => {
+    const wallet = await createSmartWallet(client);
+
+    const created = await client.workflows.create({
+      smartWalletAddress: wallet.address,
+      name: "Per-part chain round-trip",
+      // No workflow-level chainId — removed from CreateWorkflowRequest in
+      // EigenLayer-AVS #634. The chain lives only on the parts below.
+      trigger: Triggers.event({
+        id: "evt",
+        name: "evt",
+        chainId: Chains.Sepolia,
+        queries: [{ addresses: [USDC_SEPOLIA], topics: [TRANSFER_TOPIC] }],
+      }),
+      nodes: [
+        Nodes.contractRead({
+          id: "read",
+          name: "read",
+          chainId: Chains.Sepolia,
+          contractAddress: USDC_SEPOLIA,
+          contractAbi: SYMBOL_ABI,
+          methodCalls: [{ methodName: "symbol", methodParams: [] }],
+        }),
+      ],
+      edges: [{ id: "e1", source: "evt", target: "read" }],
+      inputVariables: { settings: settingsForChain(wallet.address, Chains.Sepolia) },
+    });
+    expect(typeof created.id).toBe("string");
+    createdWorkflowIds.push(created.id);
+
+    const retrieved = await client.workflows.retrieve(created.id);
+    expect(retrieved.id).toBe(created.id);
+    // The wire contract: each chain-aware part keeps its explicit chain.
+    expect(partChainId(retrieved.trigger)).toBe(Chains.Sepolia);
+    const readNode = retrieved.nodes?.find((n) => n.id === "read");
+    expect(partChainId(readNode)).toBe(Chains.Sepolia);
+  });
+
+  crossChainTest(
+    "watches an event on Sepolia and reads a contract on Base Sepolia (per-part chains)",
+    async () => {
+      const wallet = await createSmartWallet(client);
+
+      const created = await client.workflows.create({
+        smartWalletAddress: wallet.address,
+        name: "Cross-chain watch Sepolia / act Base Sepolia",
+        trigger: Triggers.event({
+          id: "evt",
+          name: "evt",
+          chainId: Chains.Sepolia,
+          queries: [{ addresses: [USDC_SEPOLIA], topics: [TRANSFER_TOPIC] }],
+        }),
+        nodes: [
+          Nodes.contractRead({
+            id: "read",
+            name: "read",
+            // The act-on chain differs from the watch chain — the whole
+            // point of the decoupling.
+            chainId: Chains.BaseSepolia,
+            contractAddress: USDC_BASE_SEPOLIA,
+            contractAbi: SYMBOL_ABI,
+            methodCalls: [{ methodName: "symbol", methodParams: [] }],
+          }),
+        ],
+        edges: [{ id: "e1", source: "evt", target: "read" }],
+        inputVariables: { settings: settingsForChain(wallet.address, Chains.Sepolia) },
+      });
+      createdWorkflowIds.push(created.id);
+
+      const retrieved = await client.workflows.retrieve(created.id);
+      expect(partChainId(retrieved.trigger)).toBe(Chains.Sepolia);
+      const readNode = retrieved.nodes?.find((n) => n.id === "read");
+      expect(partChainId(readNode)).toBe(Chains.BaseSepolia);
+    },
+  );
+});

--- a/tests/v4/templates/multichain-per-part-chain.test.ts
+++ b/tests/v4/templates/multichain-per-part-chain.test.ts
@@ -30,7 +30,7 @@
  * type-clean after `yarn types-gen` regenerates against #634's spec.
  */
 
-import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
+import { APIError, Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   authenticateClient,
@@ -129,6 +129,49 @@ describe("Template: per-part multi-chain wire contract", () => {
     expect(partChainId(retrieved.trigger)).toBe(Chains.Sepolia);
     const readNode = retrieved.nodes?.find((n) => n.id === "read");
     expect(partChainId(readNode)).toBe(Chains.Sepolia);
+  });
+
+  contractTest("rejects a chain-aware node that omits chainId (400)", async () => {
+    const wallet = await createSmartWallet(client);
+
+    // The builder requires `chainId` (TS-enforced), so strip it post-build to
+    // emulate a client that omits the now-required per-part chain. G5 makes
+    // this a hard create-time rejection — explicit-or-error, never flattened
+    // to a task default (there is no task default anymore).
+    const read = Nodes.contractRead({
+      id: "read",
+      name: "read",
+      chainId: Chains.Sepolia,
+      contractAddress: USDC_SEPOLIA,
+      contractAbi: SYMBOL_ABI,
+      methodCalls: [{ methodName: "symbol", methodParams: [] }],
+    });
+    delete (read as { config: { chainId?: number } }).config.chainId;
+
+    let error: unknown;
+    try {
+      const created = await client.workflows.create({
+        smartWalletAddress: wallet.address,
+        name: "Missing per-part chain",
+        trigger: Triggers.event({
+          id: "evt",
+          name: "evt",
+          chainId: Chains.Sepolia,
+          queries: [{ addresses: [USDC_SEPOLIA], topics: [TRANSFER_TOPIC] }],
+        }),
+        nodes: [read],
+        edges: [{ id: "e1", source: "evt", target: "read" }],
+        inputVariables: { settings: settingsForChain(wallet.address, Chains.Sepolia) },
+      });
+      // Should not reach here; register for cleanup if the server ever flattens.
+      createdWorkflowIds.push(created.id);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(APIError);
+    expect((error as APIError).status).toBe(400);
+    expect((error as APIError).message).toMatch(/chain_id/i);
   });
 
   crossChainTest(

--- a/tests/v4/templates/recurring-payment-with-report.test.ts
+++ b/tests/v4/templates/recurring-payment-with-report.test.ts
@@ -50,7 +50,6 @@ describe("Template: recurring payment with report", () => {
     return {
       smartWalletAddress,
       name: "Recurring payment with report",
-      chainId: 11_155_111,
       trigger: Triggers.manual({
         id: "trigger",
         name: "manualTrigger",

--- a/tests/v4/templates/telegram-alert-on-transfer.test.ts
+++ b/tests/v4/templates/telegram-alert-on-transfer.test.ts
@@ -55,6 +55,7 @@ describe("Template: Telegram alert on transfer", () => {
       trigger: Triggers.event({
         id: "trigger",
         name: "transferMonitor",
+        chainId: 11_155_111,
         queries: [
           // Outgoing: wallet === from
           {
@@ -98,6 +99,7 @@ describe("Template: Telegram alert on transfer", () => {
       trigger: Triggers.event({
         id: "trigger",
         name: "transferMonitor",
+        chainId: 11_155_111,
         queries: [
           {
             addresses: [USDC_SEPOLIA],

--- a/tests/v4/templates/uniswapv3_stoploss.test.ts
+++ b/tests/v4/templates/uniswapv3_stoploss.test.ts
@@ -50,7 +50,6 @@ describe("Template: Uniswap V3 stop-loss", () => {
     return {
       smartWalletAddress,
       name: "Uniswap V3 stop-loss",
-      chainId: 11_155_111,
       trigger: Triggers.cron({
         id: "trigger",
         name: "cron",
@@ -60,6 +59,7 @@ describe("Template: Uniswap V3 stop-loss", () => {
         Nodes.contractRead({
           id: "price",
           name: "price",
+          chainId: 11_155_111,
           contractAddress: CHAINLINK_ETH_USD_SEPOLIA,
           contractAbi: Protocols.chainlink.aggregatorV3Abi,
           methodCalls: [{ methodName: "latestRoundData", methodParams: [] }],
@@ -80,6 +80,7 @@ describe("Template: Uniswap V3 stop-loss", () => {
         Nodes.contractWrite({
           id: "swap",
           name: "swap",
+          chainId: 11_155_111,
           contractAddress: UNISWAP_SWAP_ROUTER02_SEPOLIA,
           contractAbi: Protocols.uniswapV3.swapRouter02Abi,
           methodCalls: [

--- a/tests/v4/templates/workflow-usdc-read-write-customcode.test.ts
+++ b/tests/v4/templates/workflow-usdc-read-write-customcode.test.ts
@@ -47,7 +47,6 @@ describe("Template: USDC read+write+customCode", () => {
     return {
       smartWalletAddress,
       name: "USDC read+write+customCode",
-      chainId: 11_155_111,
       trigger: Triggers.cron({
         id: "timeTrigger",
         name: "timeTrigger",
@@ -57,6 +56,7 @@ describe("Template: USDC read+write+customCode", () => {
         Nodes.contractRead({
           id: "contractRead1",
           name: "contractRead1",
+          chainId: 11_155_111,
           contractAddress: USDC_SEPOLIA,
           contractAbi: SYMBOL_ABI,
           methodCalls: [{ methodName: "symbol", methodParams: [] }],
@@ -64,6 +64,7 @@ describe("Template: USDC read+write+customCode", () => {
         Nodes.contractRead({
           id: "contractRead2",
           name: "contractRead2",
+          chainId: 11_155_111,
           contractAddress: USDC_SEPOLIA,
           contractAbi: DECIMALS_ABI,
           methodCalls: [{ methodName: "decimals", methodParams: [] }],
@@ -71,6 +72,7 @@ describe("Template: USDC read+write+customCode", () => {
         Nodes.contractWrite({
           id: "contractWrite1",
           name: "contractWrite1",
+          chainId: 11_155_111,
           contractAddress: USDC_SEPOLIA,
           contractAbi: TRANSFER_ABI,
           methodCalls: [{ methodName: "transfer", methodParams: [eoaAddress, "100000"] }],

--- a/tests/v4/triggers/block.test.ts
+++ b/tests/v4/triggers/block.test.ts
@@ -62,7 +62,7 @@ describe("BlockTrigger Tests", () => {
       ["single block", 1],
     ])("returns the latest block for %s", async (_label, interval) => {
       const result = await client.triggers.run({
-        trigger: Triggers.block({ id: "t", name: "blockTrigger", interval }),
+        trigger: Triggers.block({ id: "t", name: "blockTrigger", chainId: 11_155_111, interval }),
       });
       expect(result.success).toBe(true);
       const data = (result.output as { data: BlockTriggerOutput }).data;
@@ -77,7 +77,7 @@ describe("BlockTrigger Tests", () => {
     test("simulates a workflow with a block trigger", async () => {
       const wallet = await createSmartWallet(client);
       const sim = await client.workflows.simulate({
-        trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval: 10 }),
+        trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 10 }),
         nodes: [Nodes.customCode({ id: "step1", name: "step1", source: "return {ok: true};" })],
         edges: [{ id: "e1", source: "trigger", target: "step1" }],
         inputVariables: { settings: settingsFor(wallet.address) },
@@ -100,7 +100,7 @@ describe("BlockTrigger Tests", () => {
 
       const wfReq = {
         ...createFromTemplate(wallet.address),
-        trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval }),
+        trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval }),
       };
       const created = await client.workflows.create(wfReq);
       const wfId = created.id as string;

--- a/tests/v4/triggers/eventTrigger.test.ts
+++ b/tests/v4/triggers/eventTrigger.test.ts
@@ -54,6 +54,7 @@ describe("EventTrigger Tests", () => {
         trigger: Triggers.event({
           id: "t",
           name: "ev",
+          chainId: 11_155_111,
           queries: [
             {
               addresses: [USDC_SEPOLIA],
@@ -75,6 +76,7 @@ describe("EventTrigger Tests", () => {
         trigger: Triggers.event({
           id: "t",
           name: "ev",
+          chainId: 11_155_111,
           queries: [
             {
               addresses: [USDC_SEPOLIA],
@@ -96,6 +98,7 @@ describe("EventTrigger Tests", () => {
         trigger: Triggers.event({
           id: "t",
           name: "ev",
+          chainId: 11_155_111,
           queries: [
             { addresses: [USDC_SEPOLIA], topics: [TRANSFER_SIG, padTopic(eoaAddress), ""] },
             { addresses: [USDC_SEPOLIA], topics: [TRANSFER_SIG, "", padTopic(eoaAddress)] },
@@ -112,6 +115,7 @@ describe("EventTrigger Tests", () => {
         trigger: Triggers.event({
           id: "t",
           name: "ev",
+          chainId: 11_155_111,
           queries: [
             {
               addresses: [CHAINLINK_ETH_USD_SEPOLIA],
@@ -146,6 +150,7 @@ describe("EventTrigger Tests", () => {
       const trigger = Triggers.event({
         id: "t",
         name: "ev",
+        chainId: 11_155_111,
         queries: [
           {
             addresses: [USDC_SEPOLIA],
@@ -164,7 +169,7 @@ describe("EventTrigger Tests", () => {
 
     test("rejects empty queries with success=false", async () => {
       const result = await client.triggers.run({
-        trigger: Triggers.event({ id: "t", name: "ev", queries: [] }),
+        trigger: Triggers.event({ id: "t", name: "ev", chainId: 11_155_111, queries: [] }),
       });
       expect(result.success).toBe(false);
       expect(typeof result.error).toBe("string");
@@ -175,6 +180,7 @@ describe("EventTrigger Tests", () => {
         trigger: Triggers.event({
           id: "t",
           name: "ev",
+          chainId: 11_155_111,
           queries: [{ addresses: [USDC_SEPOLIA], topics: [TRANSFER_SIG] }],
         }),
       });

--- a/tests/v4/triggers/eventTrigger.test.ts
+++ b/tests/v4/triggers/eventTrigger.test.ts
@@ -120,6 +120,10 @@ describe("EventTrigger Tests", () => {
             {
               addresses: [CHAINLINK_ETH_USD_SEPOLIA],
               topics: [CHAINLINK_ANSWER_UPDATED_SIG],
+              // The ABI is required for the condition below to resolve
+              // `AnswerUpdated.current`; without it the engine can't decode
+              // the indexed field and returns "Conditions not met".
+              contractAbi: CHAINLINK_ABI,
               conditions: [
                 {
                   fieldName: "AnswerUpdated.current",
@@ -139,11 +143,12 @@ describe("EventTrigger Tests", () => {
       // genuinely can't simulate the Chainlink feed in CI, that's a
       // real environmental issue to address — not silently mask.
       expect(result.success).toBe(true);
+      // With the ABI provided, a matched event is returned decoded and keyed
+      // by event name (not as a raw topics[] log). The condition (current > 0)
+      // is satisfied, so the decoded `current` price is present and positive.
       const data = (result.output as { data: any }).data;
-      expect(data.topics[0]).toBe(CHAINLINK_ANSWER_UPDATED_SIG);
-      // Provide the ABI so the engine knows which field gates the
-      // condition; without ABI the condition is silently ignored.
-      void CHAINLINK_ABI;
+      expect(data.AnswerUpdated).toBeDefined();
+      expect(Number(data.AnswerUpdated.current)).toBeGreaterThan(0);
     });
 
     test("honors cooldownSeconds (no second fire within window)", async () => {

--- a/tests/v4/workflows/createWorkflow.test.ts
+++ b/tests/v4/workflows/createWorkflow.test.ts
@@ -50,7 +50,7 @@ describe("createWorkflow Tests", () => {
     const wallet = await createSmartWallet(client);
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
-      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval: 5 }),
+      trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
     });
     expect(typeof created.id).toBe("string");
     expect((created.id as string).length).toBe(26);
@@ -122,6 +122,7 @@ describe("createWorkflow Tests", () => {
       trigger: Triggers.event({
         id: "trigger",
         name: "eventTrigger",
+        chainId: 11_155_111,
         queries: [
           {
             addresses: [WETH, USDC],
@@ -151,6 +152,7 @@ describe("createWorkflow Tests", () => {
       trigger: Triggers.block({
         id: "trigger",
         name: "blockTrigger",
+        chainId: 11_155_111,
         interval: 102,
       }),
     });

--- a/tests/v4/workflows/triggerWorkflow.test.ts
+++ b/tests/v4/workflows/triggerWorkflow.test.ts
@@ -56,7 +56,7 @@ describe("workflows.trigger Tests", () => {
 
       const created = await client.workflows.create({
         ...createFromTemplate(wallet.address),
-        trigger: Triggers.block({ id: "trigger", name: "blockTrigger", interval }),
+        trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval }),
       });
       const wfId = created.id as string;
       createdWorkflowIds.push(wfId);
@@ -128,6 +128,7 @@ describe("workflows.trigger Tests", () => {
         trigger: Triggers.event({
           id: "trigger",
           name: "eventTrigger",
+          chainId: 11_155_111,
           queries: [
             {
               addresses: [],


### PR DESCRIPTION
## What

Aligns the v4 SDK with the EigenLayer-AVS **chain-decoupling renovation** (backend [#634](https://github.com/AvaProtocol/EigenLayer-AVS/pull/634), merged to `staging`). `chainId` is now a property of each **chain-aware part** — event/block triggers, `contractRead`/`contractWrite`/`ethTransfer` nodes — not of the workflow. A workflow can watch chain X and act on chain Y.

## Changes (⚠️ breaking for SDK consumers)

- **Regenerated types** from the renovated `openapi.yaml`: `Workflow.chainId` + `CreateWorkflowRequest.chainId` removed; per-part `config.chainId` is now **required**; `chainId` query param dropped from list/count/executions.
- **Builders require `chainId`** — `Nodes.contractRead/contractWrite/ethTransfer` and `Triggers.block/event` now take a required `chainId` and always emit it.
- **Resources**: dropped `chainId` from list/count/stats params; rewrote stale chain-resolution docs in `resources/nodes.ts` (explicit-or-error) and `resources/executions.ts` (chain-agnostic storage).
- **Tests/example**: every chain-aware builder call now passes an explicit per-part `chainId` (Sepolia); removed the obsolete `--chain-id` flag from `examples/example.ts`. 73 TS errors → 0.
- **New test** `tests/v4/templates/multichain-per-part-chain.test.ts` — locks the per-part wire contract (create→retrieve round-trip + cross-chain). Gated behind `PER_NODE_CHAIN_READY` (see below).
- **`.env.railway.example`**: redacted a committed test private key, pointed `AVS_REST_URL` at the prod gateway (`https://api.avaprotocol.org/api/v1`), dropped the dead `AVS_API_KEY` (suite uses signature auth).
- **Docs**: `docs/changes/chain-decoupling-sdk-tracking.md` tracks the full effort.

## Verification

Against the live v4.0.0 gateway (`:8080`, health 200):

| Endpoint | per-node `chainId` | result |
|---|---|---|
| `workflows:simulate` | ✅ | success |
| `nodes:run` | ✅ | success |
| `workflows:create` | ❌ | blocked — see below |

`tsc -p tsconfig.json` = 0 errors · `yarn build` clean · smoke 14/14.

## Known blocker (server-side, not this PR)

`POST /workflows:create` (and `retrieve`/`list`) currently reject a per-node `chainId` with `unmarshal config into Go struct: cannot unmarshal string into ...ChainId of type int64`. Root-caused to `protoRetargetJSON` in the gateway (protojson marshals `int64` as a quoted string → `encoding/json` into a plain `int64` field). Filed as **[AvaProtocol/EigenLayer-AVS#639](https://github.com/AvaProtocol/EigenLayer-AVS/issues/639)**. The new round-trip test is gated behind `PER_NODE_CHAIN_READY` so CI stays green; it goes green once #639 lands — **no further SDK change needed**.

## Release note

This is a breaking change, but no changeset is included yet: hold the major bump until #639 ships so we don't release an SDK whose `create()` path is server-blocked. Add the changeset in the release window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

> ⚠️ **DRAFT — CI expected red until [EigenLayer-AVS#639] lands.** The E2E suite runs the full integration tests against a `docker compose` gateway; any test that `create()`s or `retrieve()`s a workflow with a chain-aware part now sends a per-node `chainId`, which the #639 gateway bug rejects (`protoRetargetJSON` int64). Mark ready once #639 is fixed **and** a rebuilt `avaprotocol/avs-dev:latest` is published. Alternative: gate the create()-based chain-aware tests behind `PER_NODE_CHAIN_READY` (like the new multichain test) to make CI green now — say the word and I will.
