### PR TITLE
feat(v4): durable execution — await node + execution signal

### DIFF
--- a/.changeset/durable-execution-await-signal.md
+++ b/.changeset/durable-execution-await-signal.md
@@ -1,0 +1,18 @@
+---
+"@avaprotocol/sdk-js": minor
+"@avaprotocol/types": minor
+---
+
+Durable execution: add the `await` pause node and execution `signal` endpoint. A workflow can now pause mid-execution and resume later, exactly-once, surviving aggregator restarts. Adopts the EigenLayer-AVS durable-execution work (SDK hand-off, PRs #643–#647) and regenerates `openapi.gen.ts` from staging.
+
+Additions (non-breaking):
+
+- **`Nodes.await(...)` builder** — a durable pause point with two mutually-exclusive flavors. External-signal (human approval): `channel: "telegram" | "api"` (+ optional `approvers` / `prompt`), resumed via `executions.signal(...)`. Chain-event (cross-chain): `chainEvent` (an `EventTriggerConfig`), resumed automatically when an operator observes the on-chain event. `timeoutSeconds` bounds the wait (0 ⇒ server default, 24h). The XOR is enforced at compile time (overloaded options) and guarded at runtime for a friendly error.
+- **`client.executions.signal(id, { workflowId, decision, payload? })`** — `POST /executions/{id}:signal`; delivers an `approve` / `reject` decision (+ optional payload) to a `WAITING` execution and returns the resumed `Execution`. Chain-event awaits are not resumed here.
+- **New `v4` type aliases:** `AwaitNode`, `AwaitNodeConfig`, `EventTriggerConfig`, `SignalExecutionRequest`.
+
+- **`ExecutionStatus` gains `"waiting"`** — the regenerated enum now carries the non-terminal `waiting` state a durable execution reports while paused at an `await` node. It surfaces consistently across `GET /executions/{id}`, `:getStatus`, `:stream`, and `:trigger` (EigenLayer-AVS #648).
+
+Behavior notes:
+
+- `executions.waitForTerminal` / `stream` treat the paused `waiting` state as non-terminal (terminal is the `success` / `failed` / `error` allow-list), so a human-approval pause keeps waiting until a `signal(...)` resumes it. Consumers that want to react to the pause can `stream(...)` and branch on `status === "waiting"`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,18 @@ locally.
 TEST_ENV=railway yarn jest tests/v4/templates/aave-health-factor-alert.test.ts
 ```
 
-**Setup**: see `.env.railway.example`. Requires `AVS_REST_URL` pointing at
-the public gateway domain + an admin JWT in `AVS_API_KEY` minted via
-`railway ssh --service gateway --environment feature/rest-api-migration "./ap create-api-key --config=config/gateway-railway.yaml --role=admin --subject=0x..."`.
+**Setup**: see `.env.railway.example`. The renovated multi-chain gateway
+authenticates via the SIWE signature exchange (`client.auth.exchangeWithKey`),
+so the suite needs **no pre-minted JWT** — just two env vars:
+
+- `AVS_REST_URL` → the public gateway base, `https://api.avaprotocol.org/api/v1`.
+- `TEST_PRIVATE_KEY` → a throwaway test EOA private key (**no funds**; used only
+  to sign the auth message — the gateway mints the JWT in return).
+
+The Railway project is `eigenlayer-avs`; there is a single environment named
+**`production`** (sourced from the `feature/rest-api-migration` branch, renamed
+in place — see `avs-infra/RAILWAY_OPERATIONS.md`). The old admin-JWT-via-`railway
+ssh ... create-api-key` path is **no longer required** for the test suite.
 
 #### Per-test log verification
 
@@ -86,9 +95,16 @@ TEST_ENV=railway yarn jest tests/v4/templates/your-template.test.ts
 #    Base Sepolia (84_532) → worker-base-sepolia, mainnet → worker-ethereum,
 #    Base → worker-base.
 cd /Users/mikasa/Code/avs-infra
-railway logs --service gateway --environment feature/rest-api-migration --deployment 2>&1 | tail -50
-railway logs --service worker-sepolia --environment feature/rest-api-migration --deployment 2>&1 | tail -50
+railway logs --service gateway --environment production --deployment 2>&1 | tail -50
+railway logs --service worker-sepolia --environment production --deployment 2>&1 | tail -50
 ```
+
+For a **local** source-built stack (the usual day-to-day setup), skip Railway
+entirely: run `make dev-stack` from `../EigenLayer-AVS` (gateway + Sepolia
+worker + Base-Sepolia worker + Sepolia operator, all from current source) and
+point the suite at it with `AVS_REST_URL=http://localhost:8080/api/v1`. Logs
+stream to `../EigenLayer-AVS/logs/{gateway,worker-sepolia,...}.log` — `grep` /
+`tail` those instead of `railway logs`.
 
 What to look for:
 
@@ -116,14 +132,20 @@ curl http://localhost:8080/up          # Gateway liveness probe
 curl http://localhost:8090/health      # Worker liveness probe
 ```
 
-The container binary in the published `avaprotocol/avs-dev:latest`
-image today is `/ava` (root path, ENTRYPOINT `["/ava"]`). The
-EigenLayer-AVS source Dockerfile has since renamed it to `/app/ap`
-(ENTRYPOINT `["./ap"]`); flip the `apikey-gen` script in
-`package.json` and the workflow's API-key step to `./ap` once a
-fresh image tag picks up that rebuild. Subcommands either way:
-`aggregator` (runs in gateway mode when the config carries a
-`chains[]` block), `worker`, `operator`, `create-api-key`.
+The binary is now **`ap`**. Built from EigenLayer-AVS source via
+`make build` → `./out/ap`; `make dev-stack` / `make gateway` invoke
+that. The published `avaprotocol/avs-dev:latest` image's older `/ava`
+entrypoint is legacy — the `apikey-gen` script in `package.json` still
+references `/ava` and only matters when running the docker-compose
+stack against that legacy image; the source `make dev-stack` path mints
+keys via `./out/ap create-api-key`. Subcommands (either binary):
+`aggregator` (runs in gateway mode when the config carries a `chains[]`
+block), `worker`, `operator`, `create-api-key`.
+
+> Note: `make dev-stack` (source) is the primary local stack today; the
+> `docker compose` flow below targets the published image and is the CI
+> shape. They're interchangeable for the v4 suite — both expose the
+> gateway REST on `:8080`.
 
 ### Release
 

--- a/packages/sdk-js/src/v4/builders/nodes.ts
+++ b/packages/sdk-js/src/v4/builders/nodes.ts
@@ -212,4 +212,69 @@ export const Nodes = Object.freeze({
       },
     } as v4.Node;
   },
+
+  /**
+   * Durable-execution pause point. The execution suspends at this node
+   * (status `WAITING`, non-terminal) and resumes exactly-once when a wake
+   * arrives. Two mutually-exclusive flavors — set **either** `channel` **or**
+   * `chainEvent`, never both:
+   *
+   * - **External-signal (human approval):** `channel: "telegram" | "api"`
+   *   (+ optional `approvers` / `prompt`). Resumes via
+   *   `client.executions.signal(...)` with an approve/reject decision; the
+   *   decision (and any `payload`) becomes this node's output, readable
+   *   downstream as `{{<name>.data...}}`.
+   * - **Chain-event (cross-chain):** `chainEvent` — a mid-workflow event
+   *   watch (same shape as an Event trigger's config). An operator covering
+   *   `chainEvent.chainId` resumes the execution when the event fires; the
+   *   matched log becomes this node's output. NOT resumed via `signal(...)`.
+   *
+   * `timeoutSeconds` is a safety bound (0 ⇒ server default, 24h; the wait is
+   * never unbounded). On timeout the execution fails.
+   *
+   * The XOR is enforced server-side too, but is guarded here for a friendly
+   * error before the round-trip. The TS overload also makes the two flavors
+   * mutually exclusive at compile time.
+   */
+  await(
+    opts: {
+      id: string;
+      name: string;
+      timeoutSeconds?: number;
+    } & (
+      | { channel: "telegram" | "api"; approvers?: string[]; prompt?: string; chainEvent?: never }
+      | { chainEvent: v4.EventTriggerConfig; channel?: never; approvers?: never; prompt?: never }
+    ),
+  ): v4.Node {
+    const hasExternal = "channel" in opts && opts.channel !== undefined;
+    const hasChainEvent = "chainEvent" in opts && opts.chainEvent !== undefined;
+    if (hasExternal && hasChainEvent) {
+      throw new Error(
+        "Nodes.await: set either `channel` (external-signal) or `chainEvent` (chain-event), not both",
+      );
+    }
+    if (!hasExternal && !hasChainEvent) {
+      throw new Error(
+        "Nodes.await: must set either `channel` (external-signal) or `chainEvent` (chain-event)",
+      );
+    }
+
+    const config: Record<string, unknown> = {
+      ...(opts.timeoutSeconds !== undefined ? { timeoutSeconds: opts.timeoutSeconds } : {}),
+    };
+    if (hasChainEvent) {
+      config.chainEvent = opts.chainEvent;
+    } else {
+      config.channel = opts.channel;
+      if (opts.approvers !== undefined) config.approvers = opts.approvers;
+      if (opts.prompt !== undefined) config.prompt = opts.prompt;
+    }
+
+    return {
+      id: opts.id,
+      name: opts.name,
+      type: "await",
+      config,
+    } as v4.Node;
+  },
 });

--- a/packages/sdk-js/src/v4/resources/executions.ts
+++ b/packages/sdk-js/src/v4/resources/executions.ts
@@ -197,6 +197,13 @@ export class ExecutionsResource {
    * from elsewhere; this helper then sees the resumed terminal status.
    * Consumers that want to *react* to the pause (e.g. prompt an
    * approver) should use `stream()` and branch on `status === "waiting"`.
+   *
+   * Caveat: if the SSE stream ends without a terminal event (network
+   * drop, proxy idle-timeout — plausible on long `waiting` pauses), this
+   * returns the last status seen, which may be non-terminal (`waiting` /
+   * `pending`). Callers that must distinguish "disconnected mid-wait"
+   * from "finished" should re-check `getStatus`/`retrieve`, or poll
+   * those directly instead of relying on a single long-lived stream.
    */
   async waitForTerminal(
     id: string,

--- a/packages/sdk-js/src/v4/resources/executions.ts
+++ b/packages/sdk-js/src/v4/resources/executions.ts
@@ -37,6 +37,21 @@ export interface StreamExecutionParams {
   signal?: AbortSignal;
 }
 
+export interface SignalExecutionParams {
+  /**
+   * Workflow the execution belongs to. Required — executions are
+   * workflow-scoped (same as `retrieve`). The caller must own it.
+   */
+  workflowId: string;
+  /** The approver's decision. */
+  decision: v4.SignalExecutionRequest["decision"];
+  /**
+   * Optional structured data delivered as the `await` node's output,
+   * readable downstream as `{{<awaitNodeName>.data...}}`.
+   */
+  payload?: Record<string, unknown>;
+}
+
 /**
  * `client.executions.*` — read-only access to past workflow runs and
  * a live SSE stream for in-flight ones. Workflow executions are
@@ -78,6 +93,29 @@ export class ExecutionsResource {
     return this.transport.request<v4.ExecutionStatusSummary>({
       path: `/executions/${encodeURIComponent(id)}:getStatus`,
       query: { workflowId: params.workflowId },
+    });
+  }
+
+  /**
+   * POST /executions/{id}:signal — resume a `WAITING` execution paused on
+   * an external-signal `await` node (human approval). Delivers an
+   * approve/reject decision (+ optional payload) that becomes the await
+   * node's output, then returns the resumed `Execution` (terminal, or still
+   * `WAITING` if the workflow hit a *second* await).
+   *
+   * Chain-event awaits are **not** resumed here — an operator fires them
+   * automatically when it observes the on-chain event; poll `retrieve` or
+   * `stream` to watch that resume instead.
+   *
+   * Errors: `400` (bad decision / no matching pending wait / already timed
+   * out), `401` (auth), `404` (workflow not owned / not found).
+   */
+  signal(id: string, params: SignalExecutionParams): Promise<v4.Execution> {
+    return this.transport.request<v4.Execution>({
+      path: `/executions/${encodeURIComponent(id)}:signal`,
+      method: "POST",
+      query: { workflowId: params.workflowId },
+      body: { decision: params.decision, payload: params.payload },
     });
   }
 
@@ -151,6 +189,14 @@ export class ExecutionsResource {
    * Poll-and-wait helper — yields the final ExecutionStatusSummary
    * once the execution reaches a terminal status. Use `stream()`
    * when you want every intermediate status update.
+   *
+   * Terminal is an allow-list (`success` / `failed` / `error`), so a
+   * durable execution paused on an `await` node keeps waiting: both the
+   * in-flight `pending` status and the `waiting` pause are treated as
+   * non-terminal. To unblock a human-approval pause, call `signal(...)`
+   * from elsewhere; this helper then sees the resumed terminal status.
+   * Consumers that want to *react* to the pause (e.g. prompt an
+   * approver) should use `stream()` and branch on `status === "waiting"`.
    */
   async waitForTerminal(
     id: string,

--- a/packages/types/openapi/openapi.yaml
+++ b/packages/types/openapi/openapi.yaml
@@ -103,8 +103,8 @@ components:
       name: chainId
       in: query
       description: |
-        Chain ID filter. Omit to use the aggregator default chain. Repeat
-        the parameter to filter by multiple chains.
+        The chain to operate on (a single value). Omit to use the aggregator
+        default (the request's JWT `aud` chain, then the gateway default).
       schema:
         type: integer
         format: int64
@@ -324,6 +324,7 @@ components:
         - filter
         - loop
         - balance
+        - await
       description: |
         Discriminator field for the Node union. Mirrors the proto
         `NodeType` enum but without the `NODE_TYPE_` prefix.
@@ -725,8 +726,9 @@ components:
       type: object
       description: |
         Iterates over an input array, running an inner Node per item. The
-        runner node is one of the chain-aware or chain-agnostic node types
-        and inherits chainId from this LoopNode if it does not specify its own.
+        runner node is one of the chain-aware or chain-agnostic node types;
+        a chain-aware runner must specify its own required `chainId` (there is
+        no inheritance from the loop or workflow).
       required: [inputVariable, runner]
       properties:
         inputVariable:
@@ -758,6 +760,49 @@ components:
           items: { $ref: '#/components/schemas/EthereumAddress' }
           description: Restrict to these tokens. Empty = fetch all.
 
+    AwaitNodeConfig:
+      type: object
+      description: |
+        Pauses the workflow until a wake arrives (durable execution). Two mutually
+        exclusive flavors: the external-signal flavor (human approval — set `channel`,
+        e.g. a Telegram approve/reject), or the chain-event flavor (cross-chain — set
+        `chainEvent` to pause until an operator observes that on-chain event, e.g. a
+        bridge arrival on another chain). Exactly one flavor must be configured.
+      properties:
+        channel:
+          type: string
+          description: 'External-signal flavor — signal channel: `telegram` or `api`.'
+        approvers:
+          type: array
+          items: { type: string }
+          description: External-signal flavor — authorized approver identities. Empty = the workflow owner.
+        prompt:
+          type: string
+          description: External-signal flavor — message shown to the approver.
+        chainEvent:
+          allOf: [{ $ref: '#/components/schemas/EventTriggerConfig' }]
+          description: |
+            Chain-event flavor — the on-chain event to wait for (a mid-workflow
+            EventTrigger). An operator covering `chainEvent.chainId` watches it and
+            resumes the execution when it fires. Mutually exclusive with `channel`.
+        timeoutSeconds:
+          type: integer
+          format: int64
+          description: Safety bound; 0 = server default (the wait is never unbounded).
+
+    SignalExecutionRequest:
+      type: object
+      required: [decision]
+      properties:
+        decision:
+          type: string
+          enum: [approve, reject]
+          description: The approver's decision.
+        payload:
+          type: object
+          additionalProperties: true
+          description: Optional structured data delivered as the await step's output.
+
     # ---- Node union ----
 
     Node:
@@ -780,6 +825,7 @@ components:
           filter:        '#/components/schemas/FilterNode'
           loop:          '#/components/schemas/LoopNode'
           balance:       '#/components/schemas/BalanceNode'
+          await:         '#/components/schemas/AwaitNode'
       oneOf:
         - $ref: '#/components/schemas/ETHTransferNode'
         - $ref: '#/components/schemas/ContractWriteNode'
@@ -791,6 +837,7 @@ components:
         - $ref: '#/components/schemas/FilterNode'
         - $ref: '#/components/schemas/LoopNode'
         - $ref: '#/components/schemas/BalanceNode'
+        - $ref: '#/components/schemas/AwaitNode'
 
     ETHTransferNode:
       allOf:
@@ -861,6 +908,13 @@ components:
           properties:
             type: { type: string, enum: [balance] }
             config: { $ref: '#/components/schemas/BalanceNodeConfig' }
+
+    AwaitNode:
+      allOf:
+        - type: object
+          properties:
+            type: { type: string, enum: [await] }
+            config: { $ref: '#/components/schemas/AwaitNodeConfig' }
 
     # ---- Workflow envelope ----
 
@@ -1061,12 +1115,17 @@ components:
       type: string
       enum:
         - pending
+        - waiting
         - success
         - failed
         - error
       description: |
-        Outcome of an execution. `pending` is in-flight; `success` is full
-        success; `failed` is logical failure (e.g., a node returned an error);
+        Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+        mid-workflow at an `await` node, durably parked until a signal arrives
+        (a human approve/reject or an operator-observed chain event) or the wait
+        times out — non-terminal, like `pending`, but distinguishable so a client
+        can show "awaiting approval"; `success` is full success; `failed` is
+        logical failure (e.g., a node returned an error, or a wait timed out);
         `error` is a system / infrastructure failure (e.g., RPC unreachable).
 
     Fee:
@@ -1658,10 +1717,10 @@ paths:
       tags: [Workflows]
       summary: Create a workflow
       description: |
-        Persist a new workflow definition. The server resolves the
-        workflow-level `chainId` (falling back to the aggregator default
-        if omitted) and ensures the smart wallet belongs to the
-        authenticated user. Returns the persisted Workflow with its
+        Persist a new workflow definition. Each chain-aware trigger and node
+        carries its own required `chainId` (there is no workflow-level chain);
+        the server validates those chains and ensures the smart wallet belongs
+        to the authenticated user. Returns the persisted Workflow with its
         server-assigned `id` and `createdAt`.
       operationId: createWorkflow
       requestBody:
@@ -2002,6 +2061,41 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ExecutionStatusSummary' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /executions/{id}:signal:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/Ulid' }
+      - name: workflowId
+        in: query
+        required: true
+        description: Workflow id the execution belongs to. See `getExecution`.
+        schema: { $ref: '#/components/schemas/Ulid' }
+    post:
+      tags: [Executions]
+      summary: Deliver an approval/external signal to a waiting execution
+      description: |
+        Resumes a WAITING execution (durable execution). The caller must own the
+        workflow; the signal only counts against an actual pending wait whose kind
+        it matches and which has not timed out. v1 is the external-signal (human
+        approval) flavor — e.g. a Telegram approve/reject for a money-moving step.
+      operationId: signalExecution
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SignalExecutionRequest' }
+      responses:
+        '200':
+          description: The resumed (terminal or still-waiting) execution.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Execution' }
+        '400': { $ref: '#/components/responses/BadRequest' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '404': { $ref: '#/components/responses/NotFound' }
 

--- a/packages/types/src/openapi.gen.ts
+++ b/packages/types/src/openapi.gen.ts
@@ -89,10 +89,10 @@ export interface paths {
         readonly put?: never;
         /**
          * Create a workflow
-         * @description Persist a new workflow definition. The server resolves the
-         *     workflow-level `chainId` (falling back to the aggregator default
-         *     if omitted) and ensures the smart wallet belongs to the
-         *     authenticated user. Returns the persisted Workflow with its
+         * @description Persist a new workflow definition. Each chain-aware trigger and node
+         *     carries its own required `chainId` (there is no workflow-level chain);
+         *     the server validates those chains and ensures the smart wallet belongs
+         *     to the authenticated user. Returns the persisted Workflow with its
          *     server-assigned `id` and `createdAt`.
          */
         readonly post: operations["createWorkflow"];
@@ -346,6 +346,34 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/executions/{id}:signal": {
+        readonly parameters: {
+            readonly query: {
+                /** @description Workflow id the execution belongs to. See `getExecution`. */
+                readonly workflowId: components["schemas"]["Ulid"];
+            };
+            readonly header?: never;
+            readonly path: {
+                readonly id: components["schemas"]["Ulid"];
+            };
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /**
+         * Deliver an approval/external signal to a waiting execution
+         * @description Resumes a WAITING execution (durable execution). The caller must own the
+         *     workflow; the signal only counts against an actual pending wait whose kind
+         *     it matches and which has not timed out. v1 is the external-signal (human
+         *     approval) flavor — e.g. a Telegram approve/reject for a money-moving step.
+         */
+        readonly post: operations["signalExecution"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/executions/{id}:stream": {
         readonly parameters: {
             readonly query: {
@@ -477,8 +505,8 @@ export interface paths {
         readonly parameters: {
             readonly query?: {
                 /**
-                 * @description Chain ID filter. Omit to use the aggregator default chain. Repeat
-                 *     the parameter to filter by multiple chains.
+                 * @description The chain to operate on (a single value). Omit to use the aggregator
+                 *     default (the request's JWT `aud` chain, then the gateway default).
                  */
                 readonly chainId?: components["parameters"]["ChainIdQuery"];
             };
@@ -743,7 +771,7 @@ export interface components {
          *     `NodeType` enum but without the `NODE_TYPE_` prefix.
          * @enum {string}
          */
-        readonly NodeType: "ethTransfer" | "contractWrite" | "contractRead" | "graphqlQuery" | "restApi" | "customCode" | "branch" | "filter" | "loop" | "balance";
+        readonly NodeType: "ethTransfer" | "contractWrite" | "contractRead" | "graphqlQuery" | "restApi" | "customCode" | "branch" | "filter" | "loop" | "balance" | "await";
         /**
          * @description Language/format of an inline payload (e.g., custom code source,
          *     manual trigger data). Mirrors the proto `Lang` enum minus the
@@ -1004,8 +1032,9 @@ export interface components {
         };
         /**
          * @description Iterates over an input array, running an inner Node per item. The
-         *     runner node is one of the chain-aware or chain-agnostic node types
-         *     and inherits chainId from this LoopNode if it does not specify its own.
+         *     runner node is one of the chain-aware or chain-agnostic node types;
+         *     a chain-aware runner must specify its own required `chainId` (there is
+         *     no inheritance from the loop or workflow).
          */
         readonly LoopNodeConfig: {
             /** @description Template path for the iterable (e.g., `{{settings.addressList}}`). */
@@ -1031,11 +1060,48 @@ export interface components {
             /** @description Restrict to these tokens. Empty = fetch all. */
             readonly tokenAddresses?: readonly components["schemas"]["EthereumAddress"][];
         };
+        /**
+         * @description Pauses the workflow until a wake arrives (durable execution). Two mutually
+         *     exclusive flavors: the external-signal flavor (human approval — set `channel`,
+         *     e.g. a Telegram approve/reject), or the chain-event flavor (cross-chain — set
+         *     `chainEvent` to pause until an operator observes that on-chain event, e.g. a
+         *     bridge arrival on another chain). Exactly one flavor must be configured.
+         */
+        readonly AwaitNodeConfig: {
+            /** @description External-signal flavor — signal channel: `telegram` or `api`. */
+            readonly channel?: string;
+            /** @description External-signal flavor — authorized approver identities. Empty = the workflow owner. */
+            readonly approvers?: readonly string[];
+            /** @description External-signal flavor — message shown to the approver. */
+            readonly prompt?: string;
+            /**
+             * @description Chain-event flavor — the on-chain event to wait for (a mid-workflow
+             *     EventTrigger). An operator covering `chainEvent.chainId` watches it and
+             *     resumes the execution when it fires. Mutually exclusive with `channel`.
+             */
+            readonly chainEvent?: components["schemas"]["EventTriggerConfig"];
+            /**
+             * Format: int64
+             * @description Safety bound; 0 = server default (the wait is never unbounded).
+             */
+            readonly timeoutSeconds?: number;
+        };
+        readonly SignalExecutionRequest: {
+            /**
+             * @description The approver's decision.
+             * @enum {string}
+             */
+            readonly decision: "approve" | "reject";
+            /** @description Optional structured data delivered as the await step's output. */
+            readonly payload?: {
+                readonly [key: string]: unknown;
+            };
+        };
         readonly Node: {
             readonly id: string;
             readonly name?: string;
             readonly type: components["schemas"]["NodeType"];
-        } & (components["schemas"]["ETHTransferNode"] | components["schemas"]["ContractWriteNode"] | components["schemas"]["ContractReadNode"] | components["schemas"]["GraphQLQueryNode"] | components["schemas"]["RestAPINode"] | components["schemas"]["CustomCodeNode"] | components["schemas"]["BranchNode"] | components["schemas"]["FilterNode"] | components["schemas"]["LoopNode"] | components["schemas"]["BalanceNode"]);
+        } & (components["schemas"]["ETHTransferNode"] | components["schemas"]["ContractWriteNode"] | components["schemas"]["ContractReadNode"] | components["schemas"]["GraphQLQueryNode"] | components["schemas"]["RestAPINode"] | components["schemas"]["CustomCodeNode"] | components["schemas"]["BranchNode"] | components["schemas"]["FilterNode"] | components["schemas"]["LoopNode"] | components["schemas"]["BalanceNode"] | components["schemas"]["AwaitNode"]);
         readonly ETHTransferNode: {
             /** @enum {string} */
             readonly type?: "ethTransfer";
@@ -1145,6 +1211,17 @@ export interface components {
              * @enum {string}
              */
             readonly type: "balance";
+        };
+        readonly AwaitNode: {
+            /** @enum {string} */
+            readonly type?: "await";
+            readonly config?: components["schemas"]["AwaitNodeConfig"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            readonly type: "await";
         };
         readonly Edge: {
             readonly id: string;
@@ -1285,12 +1362,16 @@ export interface components {
             readonly pricingModel?: string;
         };
         /**
-         * @description Outcome of an execution. `pending` is in-flight; `success` is full
-         *     success; `failed` is logical failure (e.g., a node returned an error);
+         * @description Outcome of an execution. `pending` is in-flight; `waiting` is suspended
+         *     mid-workflow at an `await` node, durably parked until a signal arrives
+         *     (a human approve/reject or an operator-observed chain event) or the wait
+         *     times out — non-terminal, like `pending`, but distinguishable so a client
+         *     can show "awaiting approval"; `success` is full success; `failed` is
+         *     logical failure (e.g., a node returned an error, or a wait timed out);
          *     `error` is a system / infrastructure failure (e.g., RPC unreachable).
          * @enum {string}
          */
-        readonly ExecutionStatus: "pending" | "success" | "failed" | "error";
+        readonly ExecutionStatus: "pending" | "waiting" | "success" | "failed" | "error";
         readonly Fee: {
             /** @description Decimal numeric value, encoded as a string for big-int safety. */
             readonly amount: string;
@@ -1686,8 +1767,8 @@ export interface components {
         /** @description Max items to return. Default 20; server-enforced ceiling applies. */
         readonly PageLimit: number;
         /**
-         * @description Chain ID filter. Omit to use the aggregator default chain. Repeat
-         *     the parameter to filter by multiple chains.
+         * @description The chain to operate on (a single value). Omit to use the aggregator
+         *     default (the request's JWT `aud` chain, then the gateway default).
          */
         readonly ChainIdQuery: number;
     };
@@ -2143,6 +2224,38 @@ export interface operations {
             readonly 404: components["responses"]["NotFound"];
         };
     };
+    readonly signalExecution: {
+        readonly parameters: {
+            readonly query: {
+                /** @description Workflow id the execution belongs to. See `getExecution`. */
+                readonly workflowId: components["schemas"]["Ulid"];
+            };
+            readonly header?: never;
+            readonly path: {
+                readonly id: components["schemas"]["Ulid"];
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["SignalExecutionRequest"];
+            };
+        };
+        readonly responses: {
+            /** @description The resumed (terminal or still-waiting) execution. */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["Execution"];
+                };
+            };
+            readonly 400: components["responses"]["BadRequest"];
+            readonly 401: components["responses"]["Unauthorized"];
+            readonly 404: components["responses"]["NotFound"];
+        };
+    };
     readonly streamExecution: {
         readonly parameters: {
             readonly query: {
@@ -2343,8 +2456,8 @@ export interface operations {
         readonly parameters: {
             readonly query?: {
                 /**
-                 * @description Chain ID filter. Omit to use the aggregator default chain. Repeat
-                 *     the parameter to filter by multiple chains.
+                 * @description The chain to operate on (a single value). Omit to use the aggregator
+                 *     default (the request's JWT `aud` chain, then the gateway default).
                  */
                 readonly chainId?: components["parameters"]["ChainIdQuery"];
             };
@@ -2461,8 +2574,8 @@ export interface operations {
         readonly parameters: {
             readonly query?: {
                 /**
-                 * @description Chain ID filter. Omit to use the aggregator default chain. Repeat
-                 *     the parameter to filter by multiple chains.
+                 * @description The chain to operate on (a single value). Omit to use the aggregator
+                 *     default (the request's JWT `aud` chain, then the gateway default).
                  */
                 readonly chainId?: components["parameters"]["ChainIdQuery"];
             };

--- a/packages/types/src/v4.ts
+++ b/packages/types/src/v4.ts
@@ -44,6 +44,8 @@ export type FixedTimeTrigger = components["schemas"]["FixedTimeTrigger"];
 export type EventTrigger = components["schemas"]["EventTrigger"];
 export type ManualTrigger = components["schemas"]["ManualTrigger"];
 
+export type EventTriggerConfig = components["schemas"]["EventTriggerConfig"];
+
 export type Node = components["schemas"]["Node"];
 export type NodeType = components["schemas"]["NodeType"];
 export type ETHTransferNode = components["schemas"]["ETHTransferNode"];
@@ -56,6 +58,9 @@ export type FilterNode = components["schemas"]["FilterNode"];
 export type LoopNode = components["schemas"]["LoopNode"];
 export type CustomCodeNode = components["schemas"]["CustomCodeNode"];
 export type BalanceNode = components["schemas"]["BalanceNode"];
+// Durable-execution pause node (human approval / cross-chain wait).
+export type AwaitNode = components["schemas"]["AwaitNode"];
+export type AwaitNodeConfig = components["schemas"]["AwaitNodeConfig"];
 
 export type Edge = components["schemas"]["Edge"];
 export type InputVariables = components["schemas"]["InputVariables"];
@@ -72,6 +77,7 @@ export type ExecutionStep = components["schemas"]["ExecutionStep"];
 export type ExecutionStatusSummary = components["schemas"]["ExecutionStatusSummary"];
 export type ExecutionCount = components["schemas"]["ExecutionCount"];
 export type ExecutionStats = components["schemas"]["ExecutionStats"];
+export type SignalExecutionRequest = components["schemas"]["SignalExecutionRequest"];
 
 // ---------------------------------------------------------------------
 // Wallets

--- a/tests/v4/executions/awaitSignal.test.ts
+++ b/tests/v4/executions/awaitSignal.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Durable-execution e2e: the external-signal `await` node + the
+ * `executions.signal` resume endpoint, end-to-end against a live
+ * gateway with durable execution merged (EigenLayer-AVS #643–#648).
+ *
+ * Flow under test (human-approval gate):
+ *   manualTrigger → await(channel:"api") → customCode (the gated step)
+ *
+ * 1. Trigger the workflow non-blocking → an execution is created and
+ *    suspends at the await node.
+ * 2. Poll `getStatus` → it reports the new non-terminal `"waiting"`
+ *    state (the whole point of the #648 observability fix). The gated
+ *    customCode has NOT run yet.
+ * 3. `executions.signal(execId, { decision: "approve", payload })`
+ *    resumes the execution; the decision becomes the await node's
+ *    output and the gated step runs.
+ * 4. The returned execution is terminal (`"success"`) and carries the
+ *    downstream step.
+ *
+ * GATED: this exercises brand-new server behaviour and live timing, so
+ * it only runs when `DURABLE_E2E=1` is set (e.g. `TEST_ENV=railway
+ * DURABLE_E2E=1 yarn jest tests/v4/executions/awaitSignal.test.ts`).
+ * Left off by default until the target gateway image is confirmed to
+ * carry the durable-execution engine — otherwise it would fail against
+ * an older `avs-dev` image that doesn't suspend on `await`.
+ */
+
+import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
+
+import {
+  authenticateClient,
+  getClient,
+  createSmartWallet,
+  removeCreatedWorkflows,
+} from "../../utils/client";
+
+jest.setTimeout(180_000);
+
+const DURABLE_E2E = process.env.DURABLE_E2E === "1";
+// Use describe.skip when the opt-in flag is absent so the suite is a
+// no-op in default CI rather than authenticating + failing.
+const describeMaybe = DURABLE_E2E ? describe : describe.skip;
+
+/** Poll getStatus until `predicate` is true or the deadline passes. */
+async function waitForStatus(
+  client: Client,
+  execId: string,
+  workflowId: string,
+  predicate: (status: string) => boolean,
+  { timeoutMs = 60_000, intervalMs = 1_500 } = {},
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let last = "";
+  while (Date.now() < deadline) {
+    const summary = await client.executions.getStatus(execId, { workflowId });
+    last = summary.status;
+    if (predicate(last)) return last;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`execution ${execId} never reached the expected status (last: "${last}")`);
+}
+
+describeMaybe("durable execution — await(channel:'api') + executions.signal", () => {
+  let client: Client;
+  const createdWorkflowIds: string[] = [];
+
+  beforeAll(async () => {
+    client = getClient();
+    await authenticateClient(client);
+  });
+
+  afterEach(async () => {
+    await removeCreatedWorkflows(client, createdWorkflowIds.splice(0));
+  });
+
+  test("pauses at WAITING, resumes on approve, runs the gated step", async () => {
+    const wallet = await createSmartWallet(client);
+
+    const created = await client.workflows.create({
+      smartWalletAddress: wallet.address,
+      trigger: Triggers.manual({ id: "trigger", name: "manualTrigger" }),
+      nodes: [
+        Nodes.await({
+          id: "gate",
+          name: "approval",
+          channel: "api",
+          prompt: "Approve the gated step?",
+          timeoutSeconds: 120,
+        }),
+        Nodes.customCode({
+          id: "gated",
+          name: "gatedStep",
+          source: "return { ran: true, decision: approval.data.decision };",
+        }),
+      ],
+      edges: [
+        { id: "e1", source: "trigger", target: "gate" },
+        { id: "e2", source: "gate", target: "gated" },
+      ],
+    });
+    const wfId = created.id as string;
+    createdWorkflowIds.push(wfId);
+
+    // Non-blocking trigger — the execution will suspend at the await,
+    // so a blocking trigger would just hang until the await timeout.
+    const trig = await client.workflows.trigger(wfId, {
+      triggerType: "manual",
+      triggerOutput: {},
+      isBlocking: false,
+    });
+    const execId = trig.executionId;
+
+    // 1) It parks at the non-terminal WAITING state.
+    const paused = await waitForStatus(client, execId, wfId, (s) => s === "waiting");
+    expect(paused).toBe("waiting");
+
+    // 2) Still parked — the gated step has not run and the execution
+    //    is not terminal.
+    const midExec = await client.executions.retrieve(execId, { workflowId: wfId });
+    expect(midExec.status).toBe("waiting");
+    const gatedBefore = midExec.steps?.find((s) => s.name === "gatedStep");
+    expect(gatedBefore).toBeUndefined();
+
+    // 3) Approve — resumes the execution; payload becomes the await
+    //    node's output.
+    const resumed = await client.executions.signal(execId, {
+      workflowId: wfId,
+      decision: "approve",
+      payload: { decision: "approve" },
+    });
+
+    // 4) Terminal success, and the gated step ran post-resume.
+    const finalStatus =
+      resumed.status === "waiting"
+        ? await waitForStatus(client, execId, wfId, (s) => s !== "waiting" && s !== "pending")
+        : resumed.status;
+    expect(finalStatus).toBe("success");
+
+    const finalExec = await client.executions.retrieve(execId, { workflowId: wfId });
+    const gatedAfter = finalExec.steps?.find((s) => s.name === "gatedStep");
+    expect(gatedAfter?.success).toBe(true);
+  });
+
+  test("reject routes the execution down the reject path (gated step skipped)", async () => {
+    const wallet = await createSmartWallet(client);
+
+    const created = await client.workflows.create({
+      smartWalletAddress: wallet.address,
+      trigger: Triggers.manual({ id: "trigger", name: "manualTrigger" }),
+      nodes: [
+        Nodes.await({
+          id: "gate",
+          name: "approval",
+          channel: "api",
+          timeoutSeconds: 120,
+        }),
+        Nodes.customCode({
+          id: "gated",
+          name: "gatedStep",
+          source: "return { ran: true };",
+        }),
+      ],
+      edges: [
+        { id: "e1", source: "trigger", target: "gate" },
+        { id: "e2", source: "gate", target: "gated" },
+      ],
+    });
+    const wfId = created.id as string;
+    createdWorkflowIds.push(wfId);
+
+    const trig = await client.workflows.trigger(wfId, {
+      triggerType: "manual",
+      triggerOutput: {},
+      isBlocking: false,
+    });
+    const execId = trig.executionId;
+
+    await waitForStatus(client, execId, wfId, (s) => s === "waiting");
+
+    const resumed = await client.executions.signal(execId, {
+      workflowId: wfId,
+      decision: "reject",
+    });
+
+    const finalStatus =
+      resumed.status === "waiting" || resumed.status === "pending"
+        ? await waitForStatus(client, execId, wfId, (s) => s !== "waiting" && s !== "pending")
+        : resumed.status;
+    // Reject is a clean decision, not a failure — the execution
+    // completes; the gated step on the approve branch never fires.
+    expect(["success", "failed"]).toContain(finalStatus);
+  });
+});

--- a/tests/v4/executions/awaitSignal.test.ts
+++ b/tests/v4/executions/awaitSignal.test.ts
@@ -18,11 +18,24 @@
  *    downstream step.
  *
  * GATED: this exercises brand-new server behaviour and live timing, so
- * it only runs when `DURABLE_E2E=1` is set (e.g. `TEST_ENV=railway
- * DURABLE_E2E=1 yarn jest tests/v4/executions/awaitSignal.test.ts`).
- * Left off by default until the target gateway image is confirmed to
- * carry the durable-execution engine — otherwise it would fail against
- * an older `avs-dev` image that doesn't suspend on `await`.
+ * it only runs when `DURABLE_E2E=1` is set (e.g.
+ * `AVS_REST_URL=http://localhost:8080/api/v1 DURABLE_E2E=1 \
+ *   yarn jest tests/v4/executions/awaitSignal.test.ts`).
+ * Left off by default until the target gateway is confirmed to carry
+ * the durable-execution engine.
+ *
+ * KNOWN SERVER BLOCKER (as of 2026-06-28, verified against a local
+ * `make dev-stack` on EigenLayer-AVS staging): the WAITING half works
+ * end-to-end — the execution suspends at `await` and `getStatus` /
+ * `retrieve` report `"waiting"` — but `POST /executions/{id}:signal`
+ * 404s at the gateway router. The generated echo route
+ * `/executions/:id:signal` is unmatchable: the GET colon-method routes
+ * (`:getStatus`, `:stream`) only resolve because `GetExecution`
+ * registers a bare `/executions/:id` that anchors echo's param+suffix
+ * split; POST has no such sibling, so `:signal` never matches (probe:
+ * POST → 404 generic, GET `:getStatus` → 401). The SDK sends the
+ * correct URI. This test will pass once the gateway routing is fixed;
+ * until then the signal step fails. Tracked for EigenLayer-AVS.
  */
 
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
@@ -78,6 +91,7 @@ describeMaybe("durable execution — await(channel:'api') + executions.signal", 
 
     const created = await client.workflows.create({
       smartWalletAddress: wallet.address,
+      name: "durable-await-approve",
       trigger: Triggers.manual({ id: "trigger", name: "manualTrigger" }),
       nodes: [
         Nodes.await({
@@ -97,6 +111,9 @@ describeMaybe("durable execution — await(channel:'api') + executions.signal", 
         { id: "e1", source: "trigger", target: "gate" },
         { id: "e2", source: "gate", target: "gated" },
       ],
+      inputVariables: {
+        settings: { name: "durable-await-approve", runner: wallet.address },
+      },
     });
     const wfId = created.id as string;
     createdWorkflowIds.push(wfId);
@@ -146,6 +163,7 @@ describeMaybe("durable execution — await(channel:'api') + executions.signal", 
 
     const created = await client.workflows.create({
       smartWalletAddress: wallet.address,
+      name: "durable-await-reject",
       trigger: Triggers.manual({ id: "trigger", name: "manualTrigger" }),
       nodes: [
         Nodes.await({
@@ -164,6 +182,9 @@ describeMaybe("durable execution — await(channel:'api') + executions.signal", 
         { id: "e1", source: "trigger", target: "gate" },
         { id: "e2", source: "gate", target: "gated" },
       ],
+      inputVariables: {
+        settings: { name: "durable-await-reject", runner: wallet.address },
+      },
     });
     const wfId = created.id as string;
     createdWorkflowIds.push(wfId);

--- a/tests/v4/executions/awaitSignal.test.ts
+++ b/tests/v4/executions/awaitSignal.test.ts
@@ -24,18 +24,14 @@
  * Left off by default until the target gateway is confirmed to carry
  * the durable-execution engine.
  *
- * KNOWN SERVER BLOCKER (as of 2026-06-28, verified against a local
- * `make dev-stack` on EigenLayer-AVS staging): the WAITING half works
- * end-to-end — the execution suspends at `await` and `getStatus` /
- * `retrieve` report `"waiting"` — but `POST /executions/{id}:signal`
- * 404s at the gateway router. The generated echo route
- * `/executions/:id:signal` is unmatchable: the GET colon-method routes
- * (`:getStatus`, `:stream`) only resolve because `GetExecution`
- * registers a bare `/executions/:id` that anchors echo's param+suffix
- * split; POST has no such sibling, so `:signal` never matches (probe:
- * POST → 404 generic, GET `:getStatus` → 401). The SDK sends the
- * correct URI. This test will pass once the gateway routing is fixed;
- * until then the signal step fails. Tracked for EigenLayer-AVS.
+ * Verified passing 2026-06-28 against a local `make dev-stack`
+ * (EigenLayer-AVS staging). Gateway logs for the run show the full
+ * lifecycle: `execution suspended (durable) resume_node: gate` →
+ * `POST /executions/{id}:signal -> 200` → `execution resumed to
+ * terminal status: EXECUTION_STATUS_SUCCESS`. (An earlier gateway
+ * build 404'd the POST `:signal` route — the generated echo route
+ * `/executions/:id:signal` was unmatchable for POST; fixed server-side
+ * before this run.)
  */
 
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";

--- a/tests/v4/executions/awaitSignal.test.ts
+++ b/tests/v4/executions/awaitSignal.test.ts
@@ -143,8 +143,10 @@ describeMaybe("durable execution — await(channel:'api') + executions.signal", 
     });
 
     // 4) Terminal success, and the gated step ran post-resume.
+    //    signal(...) can return before the engine finishes transitioning
+    //    through "pending", so treat "pending" as keep-polling too.
     const finalStatus =
-      resumed.status === "waiting"
+      resumed.status === "waiting" || resumed.status === "pending"
         ? await waitForStatus(client, execId, wfId, (s) => s !== "waiting" && s !== "pending")
         : resumed.status;
     expect(finalStatus).toBe("success");
@@ -154,7 +156,7 @@ describeMaybe("durable execution — await(channel:'api') + executions.signal", 
     expect(gatedAfter?.success).toBe(true);
   });
 
-  test("reject routes the execution down the reject path (gated step skipped)", async () => {
+  test("reject resumes the execution to a clean terminal success", async () => {
     const wallet = await createSmartWallet(client);
 
     const created = await client.workflows.create({
@@ -203,8 +205,10 @@ describeMaybe("durable execution — await(channel:'api') + executions.signal", 
       resumed.status === "waiting" || resumed.status === "pending"
         ? await waitForStatus(client, execId, wfId, (s) => s !== "waiting" && s !== "pending")
         : resumed.status;
-    // Reject is a clean decision, not a failure — the execution
-    // completes; the gated step on the approve branch never fires.
-    expect(["success", "failed"]).toContain(finalStatus);
+    // Reject is a clean decision, not a failure: the execution resumes
+    // and completes successfully. (This linear workflow has no Branch,
+    // so reject doesn't skip a downstream step — routing-on-decision is
+    // a separate Branch concern; this asserts the resume itself.)
+    expect(finalStatus).toBe("success");
   });
 });

--- a/tests/v4/smoke.test.ts
+++ b/tests/v4/smoke.test.ts
@@ -167,6 +167,73 @@ describe("v4 SDK smoke", () => {
       expect(config.lang).toBe("javascript");
     });
 
+    test("Nodes.await (external-signal) carries channel/approvers/prompt + timeout", () => {
+      const node = Nodes.await({
+        id: "approve",
+        name: "approve",
+        channel: "telegram",
+        approvers: ["0xabc"],
+        prompt: "Approve this transfer?",
+        timeoutSeconds: 3600,
+      });
+      expect(node.id).toBe("approve");
+      expect(node.type).toBe("await");
+      const config = (
+        node as {
+          config: {
+            channel: string;
+            approvers: readonly string[];
+            prompt: string;
+            timeoutSeconds: number;
+            chainEvent?: unknown;
+          };
+        }
+      ).config;
+      expect(config.channel).toBe("telegram");
+      expect(config.approvers).toEqual(["0xabc"]);
+      expect(config.prompt).toBe("Approve this transfer?");
+      expect(config.timeoutSeconds).toBe(3600);
+      expect(config.chainEvent).toBeUndefined();
+    });
+
+    test("Nodes.await (chain-event) carries chainEvent and no signal fields", () => {
+      const node = Nodes.await({
+        id: "bridge",
+        name: "bridge",
+        chainEvent: {
+          chainId: 8453,
+          queries: [{ addresses: ["0x0000000000000000000000000000000000000001"], topics: [""] }],
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+      });
+      expect(node.type).toBe("await");
+      const config = (
+        node as { config: { chainEvent?: { chainId: number }; channel?: string } }
+      ).config;
+      expect(config.chainEvent?.chainId).toBe(8453);
+      expect(config.channel).toBeUndefined();
+    });
+
+    test("Nodes.await throws when both flavors are set", () => {
+      expect(() =>
+        Nodes.await({
+          id: "x",
+          name: "x",
+          // Force the runtime guard (bypass the compile-time XOR) the way a
+          // JS consumer could.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ...({ channel: "api", chainEvent: { chainId: 1, queries: [] } } as any),
+        }),
+      ).toThrow(/not both/);
+    });
+
+    test("Nodes.await throws when neither flavor is set", () => {
+      expect(() =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        Nodes.await({ id: "x", name: "x" } as any),
+      ).toThrow(/either/);
+    });
+
     test("Triggers.event preserves topic wildcards as empty strings", () => {
       const transferTopic = Protocols.erc20.eventTopics.Transfer;
       const trigger = Triggers.event({
@@ -188,6 +255,70 @@ describe("v4 SDK smoke", () => {
         }
       ).config;
       expect(config.queries[0].topics).toEqual([transferTopic, ""]);
+    });
+  });
+
+  describe("executions.signal", () => {
+    test("POSTs decision+payload to /executions/{id}:signal?workflowId=...", async () => {
+      let captured: { url: string; method?: string; body?: string } | undefined;
+      const fakeFetch: typeof fetch = async (input, init) => {
+        captured = {
+          url: String(input),
+          method: init?.method,
+          body: init?.body as string | undefined,
+        };
+        return new Response(JSON.stringify({ id: "exec1", status: "success" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      };
+      const client = new Client({ baseUrl: "http://example.test/api/v1", fetchImpl: fakeFetch });
+      const exec = await client.executions.signal("exec1", {
+        workflowId: "wf1",
+        decision: "approve",
+        payload: { note: "ok" },
+      });
+
+      expect(captured?.method).toBe("POST");
+      const url = new URL(captured!.url);
+      expect(url.pathname).toBe("/api/v1/executions/exec1:signal");
+      expect(url.searchParams.get("workflowId")).toBe("wf1");
+      expect(JSON.parse(captured!.body!)).toEqual({
+        decision: "approve",
+        payload: { note: "ok" },
+      });
+      expect(exec.status).toBe("success");
+    });
+  });
+
+  describe("executions.waitForTerminal — durable-execution WAITING", () => {
+    test("treats 'waiting' as non-terminal and resolves on the terminal status", async () => {
+      // Fake SSE stream: pending -> waiting (paused on an await node) ->
+      // success (resumed). waitForTerminal must skip pending+waiting and
+      // only resolve on success.
+      const frames = [
+        { id: "e1", status: "pending" },
+        { id: "e1", status: "waiting" },
+        { id: "e1", status: "success" },
+      ].map((s) => `data: ${JSON.stringify(s)}\n\n`);
+
+      const fakeFetch: typeof fetch = async () => {
+        const enc = new TextEncoder();
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            for (const f of frames) controller.enqueue(enc.encode(f));
+            controller.close();
+          },
+        });
+        return new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      };
+
+      const client = new Client({ baseUrl: "http://example.test/api/v1", fetchImpl: fakeFetch });
+      const final = await client.executions.waitForTerminal("e1", { workflowId: "wf1" });
+      expect(final.status).toBe("success");
     });
   });
 


### PR DESCRIPTION
## Durable execution — `await` node + execution `signal` (SDK consumer surface)

Adds the SDK side of durable execution (pause mid-workflow, resume exactly-once), matching the EigenLayer-AVS engine merged to staging (#643–#648). Types regenerated from the staging OpenAPI — not hand-transcribed.

### What's included
- **`Nodes.await(...)` builder** — a durable pause point with two mutually-exclusive flavors:
  - *external-signal (human approval):* `channel: "telegram" | "api"` (+ optional `approvers` / `prompt`), resumed via `executions.signal(...)`.
  - *chain-event (cross-chain):* `chainEvent: EventTriggerConfig`, resumed automatically when an operator observes the on-chain event.
  - XOR enforced at compile time (overloaded options) **and** guarded at runtime for a friendly error.
- **`client.executions.signal(id, { workflowId, decision, payload? })`** — `POST /executions/{id}:signal`; resumes a `WAITING` execution with an `approve`/`reject` decision, returns the resumed `Execution`.
- **`ExecutionStatus` gains `"waiting"`** — the non-terminal paused state, now surfaced consistently across `GET /executions/{id}`, `:getStatus`, `:stream`, `:trigger`. `waitForTerminal` / `stream` treat it as keep-waiting via the `success`/`failed`/`error` allow-list.
- **New `v4` aliases:** `AwaitNode`, `AwaitNodeConfig`, `EventTriggerConfig`, `SignalExecutionRequest`.
- **Changeset:** `minor` for `@avaprotocol/sdk-js` + `@avaprotocol/types`.

### Tests
- **Unit (smoke, offline):** await builder both flavors + XOR errors; `signal` request shaping; `waitForTerminal` treating a `"waiting"` SSE frame as non-terminal. 20/20 pass.
- **E2E (`tests/v4/executions/awaitSignal.test.ts`, gated behind `DURABLE_E2E=1`):** full human-approval round-trip — suspend at `await` → `getStatus` reports `"waiting"` → `signal(approve|reject)` → resumed to terminal. **Verified passing** against a local `make dev-stack` (EigenLayer-AVS staging). Gateway logs for the run:
  ```
  execution suspended (durable)  resume_node: gate
  POST /api/v1/executions/{id}:signal -> 200
  execution resumed to terminal  status: EXECUTION_STATUS_SUCCESS
  ```

### Notes / context
- Review of the hand-off surfaced two server gaps that were fixed upstream before this landed: WAITING was masked as `"pending"` across 3 duplicate REST status mappers (EigenLayer-AVS #648), and the `POST /executions/{id}:signal` echo route was unmatchable (fixed server-side; now 200).
- `CLAUDE.md` refreshed: Railway suite uses SIWE (`exchangeWithKey`) — no admin JWT — env renamed to `production`; documented the local `make dev-stack` (`./out/ap`, REST `:8080`).

### Commits
- `feat(v4)`: durable execution — await node + execution signal
- `test(v4)`: e2e scaffold + verified-passing record
- `docs`: Railway/local-stack guidance refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)
