### PR TITLE
feat(v4): add ClientOptions.headers for non-Bearer credentials

### DIFF
--- a/packages/sdk-js/src/v4/client.ts
+++ b/packages/sdk-js/src/v4/client.ts
@@ -27,6 +27,15 @@ export interface ClientOptions {
   defaultTimeoutMs?: number;
   /** Override the fetch impl. Useful for tests and non-Node runtimes. */
   fetchImpl?: typeof fetch;
+  /**
+   * Default headers sent on every request. Use this to carry a non-Bearer
+   * credential — notably a partner assertion in `X-Partner-Assertion` for the
+   * no-fund simulate / wallet-derivation flow, where the end user has no
+   * wallet signature. Construct a dedicated client for that flow (no `token`)
+   * and put the short-lived assertion here. Fund-moving calls still require a
+   * Bearer token from `auth.exchange()`.
+   */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -62,6 +71,7 @@ export class Client {
       token: opts.token,
       defaultTimeoutMs: opts.defaultTimeoutMs,
       fetchImpl: opts.fetchImpl,
+      headers: opts.headers,
     };
     this.transport = new Transport(transportOpts);
 
@@ -85,5 +95,13 @@ export class Client {
   /** Current Bearer token. Returns undefined when anonymous. */
   get token(): string | undefined {
     return this.transport.getToken();
+  }
+
+  /**
+   * Replace the default headers (e.g. refresh a short-lived
+   * `X-Partner-Assertion`) without reconstructing the client.
+   */
+  setHeaders(headers: Record<string, string> | undefined): void {
+    this.transport.setDefaultHeaders(headers);
   }
 }

--- a/packages/sdk-js/src/v4/internal/transport.ts
+++ b/packages/sdk-js/src/v4/internal/transport.ts
@@ -20,6 +20,12 @@ export interface TransportOptions {
   defaultTimeoutMs?: number;
   /** Optional fetch implementation override (tests / non-Node runtimes). */
   fetchImpl?: typeof fetch;
+  /**
+   * Default headers applied to every request, below per-request headers
+   * and below the Bearer Authorization header. Used to carry non-Bearer
+   * credentials such as a partner assertion (`X-Partner-Assertion`).
+   */
+  headers?: Record<string, string>;
 }
 
 export interface RequestOptions {
@@ -49,12 +55,14 @@ export class Transport {
   private readonly defaultTimeoutMs: number;
   private readonly fetchImpl: typeof fetch;
   private bearerToken?: string;
+  private defaultHeaders: Record<string, string>;
 
   constructor(opts: TransportOptions) {
     this.baseUrl = opts.baseUrl.replace(/\/$/, "");
     this.defaultTimeoutMs = opts.defaultTimeoutMs ?? 30_000;
     this.fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
     this.bearerToken = opts.token;
+    this.defaultHeaders = { ...opts.headers };
   }
 
   /** Replace the Bearer token. Used after `client.auth.exchange()`. */
@@ -65,6 +73,15 @@ export class Transport {
   /** Read the current Bearer token (for tests / debugging). */
   getToken(): string | undefined {
     return this.bearerToken;
+  }
+
+  /**
+   * Replace the default headers applied to every request. Used to refresh a
+   * short-lived non-Bearer credential (e.g. a rotated partner assertion)
+   * without reconstructing the client.
+   */
+  setDefaultHeaders(headers: Record<string, string> | undefined): void {
+    this.defaultHeaders = { ...headers };
   }
 
   /** Issue a JSON request and decode the response body. */
@@ -113,6 +130,7 @@ export class Transport {
 
     const headers: Record<string, string> = {
       Accept: "application/json",
+      ...this.defaultHeaders,
       ...opts.headers,
     };
     if (this.bearerToken) {

--- a/packages/sdk-js/src/v4/internal/transport.ts
+++ b/packages/sdk-js/src/v4/internal/transport.ts
@@ -128,9 +128,14 @@ export class Transport {
       opts.signal.addEventListener("abort", () => controller.abort(), { once: true });
     }
 
+    // Precedence: defaultHeaders (lowest) < SDK invariants < per-request
+    // headers < Authorization. `Accept` is defaulted between defaultHeaders
+    // and opts.headers so a stray default can't corrupt JSON decode, while a
+    // per-request override (e.g. the SSE stream's text/event-stream) still
+    // wins.
     const headers: Record<string, string> = {
-      Accept: "application/json",
       ...this.defaultHeaders,
+      Accept: "application/json",
       ...opts.headers,
     };
     if (this.bearerToken) {
@@ -138,7 +143,10 @@ export class Transport {
     }
     let body: BodyInit | undefined;
     if (opts.body !== undefined && opts.body !== null) {
-      headers["Content-Type"] ??= "application/json";
+      // The transport always JSON-serializes the body, so Content-Type is an
+      // invariant — set it after the spreads so a defaultHeaders/per-request
+      // value can't mislabel the payload.
+      headers["Content-Type"] = "application/json";
       body = JSON.stringify(opts.body);
     }
 


### PR DESCRIPTION
## What

Adds an additive `headers` option to the v4 `Client` so callers can send a
**non-Bearer credential** on every request.

- `ClientOptions.headers?: Record<string,string>` / `TransportOptions.headers` —
  default headers merged below per-request headers and below the Bearer header.
- `Client.setHeaders()` / `Transport.setDefaultHeaders()` — refresh a
  short-lived credential without rebuilding the client.

## Why

The AVS now supports **partner-delegated simulate** (PLAN_PARTNER_PAYMENTS): a
partner (Studio) can call the no-fund simulate / wallet-derivation endpoints on
behalf of its own users without a per-user wallet signature, by sending a
short-lived Ed25519 assertion in the `X-Partner-Assertion` header. The SDK had
no way to attach a custom header (auth was hard-wired to `Authorization:
Bearer`), so this unblocks Studio constructing a dedicated partner client:

```ts
new Client({ baseUrl, headers: { "X-Partner-Assertion": assertion } }); // no token
```

## Compatibility

Fully backward-compatible: no existing call site changes; the Bearer token path
is untouched. Builds clean (`tsc -b` + `tsup`).
