### PR TITLE
feat(v4): Uniswap swap builders + contractWrite execution readers

### DIFF
--- a/.changeset/ondemand-action-helpers.md
+++ b/.changeset/ondemand-action-helpers.md
@@ -1,0 +1,18 @@
+---
+"@avaprotocol/sdk-js": minor
+---
+
+feat(v4): Uniswap V3 swap/quote node builders + contractWrite execution readers
+
+Adds the SDK surface for a chat agent's one-time "preview → confirm → execute"
+market order:
+
+- `UniswapV3.swapNode` / `UniswapV3.quoteNode` / `UniswapV3.minAmountOut` —
+  assemble a single-hop `exactInputSingle` swap and its QuoterV2 quote over
+  `Protocols.uniswapV3`, and compute `amountOutMinimum` from a slippage tolerance.
+- `readContractWriteExecutions(resp)` — read the normalized per-method outcome
+  (`confirmed` / `pending` / `failed`) plus `userOpHash` / `transactionHash` from
+  a `contractWrite` `nodes.run` response.
+
+Pairs with the `Idempotency-Key` support on `nodes.run`. The example CLI gains a
+`nodes:run <file.json> [--idempotency-key KEY]` command.

--- a/docs/on-demand-actions.md
+++ b/docs/on-demand-actions.md
@@ -1,0 +1,83 @@
+# On-demand actions (single-node execute)
+
+Run one node on demand with `client.nodes.run` — no workflow to build or deploy.
+This is the SDK surface behind a chat agent's "preview → confirm → execute" for a
+one-time action such as a Uniswap market order.
+
+## The building blocks
+
+- `client.nodes.run(req, options?)` — execute a single node. A `contractWrite`
+  node is **Tenderly-simulated by default** (a preview); set the node's
+  `isSimulated: false` to execute for real through the smart wallet. A real
+  execute is fund-moving and needs a Bearer JWT.
+- `options.idempotencyKey` — sent as the `Idempotency-Key` header. Reuse one key
+  across retries of a single Confirm so a re-send can't broadcast a second UserOp.
+- `UniswapV3.swapNode` / `UniswapV3.quoteNode` / `UniswapV3.minAmountOut` —
+  build the swap and quote nodes and compute the slippage floor.
+- `readContractWriteExecutions(resp)` — read the normalized per-method outcome
+  (`confirmed` / `pending` / `failed`) plus `userOpHash` / `transactionHash`
+  from a `contractWrite` response.
+
+## Market order: quote → preview → execute
+
+```ts
+import {
+  Client,
+  UniswapV3,
+  readContractWriteExecutions,
+} from "@avaprotocol/sdk-js";
+
+const chainId = 11_155_111; // Sepolia
+const settings = { settings: { runner: smartWalletAddress } };
+
+// 1. Quote the expected output (simulated QuoterV2 call).
+const quoteResp = await client.nodes.run({
+  node: UniswapV3.quoteNode({
+    id: "q", name: "q", chainId,
+    tokenIn: WETH, tokenOut: USDC, fee: 3000, amountIn: "1000000000000000",
+  }),
+  inputVariables: settings,
+});
+// The predicted amountOut is decoded into the node output (output.data.*).
+const expectedOut = /* read amountOut from quoteResp.output */ "0";
+
+// 2. Slippage floor (0.5%).
+const amountOutMinimum = UniswapV3.minAmountOut(expectedOut, 50);
+
+// 3. Build the swap once; run it in two modes.
+const swap = (isSimulated: boolean) =>
+  UniswapV3.swapNode({
+    id: "swap", name: "swap", chainId,
+    tokenIn: WETH, tokenOut: USDC, fee: 3000, recipient: smartWalletAddress,
+    amountIn: "1000000000000000", amountOutMinimum, isSimulated,
+  });
+
+// 3a. Preview (simulate) — show the user the outcome.
+const preview = await client.nodes.run({ node: swap(true), inputVariables: settings });
+
+// 3b. Execute (real) — after the user confirms. One idempotency key per Confirm.
+const executed = await client.nodes.run(
+  { node: swap(false), inputVariables: settings },
+  { idempotencyKey: `swap-${confirmId}` },
+);
+
+for (const r of readContractWriteExecutions(executed)) {
+  // r.executionStatus: "confirmed" | "pending" | "failed"
+  // r.userOpHash (always for a real execute), r.transactionHash (once mined)
+}
+```
+
+## Notes
+
+- **Approval is a separate action.** Atomic approve+swap batching is deferred on
+  the gateway, so `swapNode` emits a single `exactInputSingle` call. Approve the
+  input token to SwapRouter02 as its own action first (or trade an already-approved
+  token).
+- **Pool / fee tier is the caller's choice.** Pass the `fee` tier for the pool you
+  intend to trade; the builders don't discover pools.
+- **Pending ≠ failed.** A submitted-but-unmined UserOp reports `pending` with a
+  `userOpHash` (and no `transactionHash` yet) — poll it rather than treating it as
+  a failure.
+- Reading `executionStatus` / receipts requires a gateway that surfaces
+  contractWrite metadata under `metadata.results` (AVS PR #660+); older gateways
+  return an empty list from `readContractWriteExecutions`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,6 +51,7 @@ yarn start executions:watch <exec-id> --workflow-id <wid> --timeout 90s
 | `workflows:pause <id>` / `workflows:resume <id>` | Toggle status |
 | `workflows:trigger <id> [--blocking]` | Manually fire the trigger |
 | `workflows:simulate <file.json>` | Simulate without persisting |
+| `nodes:run <file.json> [--idempotency-key KEY]` | Run a single node in isolation (no workflow); pass a key to make a real execute retry-safe |
 | `workflows:count [--owner ADDR]` | Count workflows |
 | `executions:list <workflow-id> [--limit N]` | Nested list |
 | `executions:get <execution-id> --workflow-id <wid>` | Single execution |

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -56,6 +56,7 @@ interface CliFlags {
   owner?: string;
   factory?: string;
   timeout?: string;
+  idempotencyKey?: string;
 }
 
 interface ParsedArgs {
@@ -100,6 +101,9 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
         break;
       case "timeout":
         flags.timeout = argv[++i];
+        break;
+      case "idempotency-key":
+        flags.idempotencyKey = argv[++i];
         break;
       default:
         // Unknown flag — fold into positional so command-specific
@@ -316,6 +320,22 @@ const commands: Record<string, { description: string; usage: string; run: Comman
       await ensureAuth(client);
       const body = readJsonFile<v4.SimulateWorkflowRequest>(file);
       return client.workflows.simulate(body);
+    },
+  },
+
+  "nodes:run": {
+    description: "Run a single node in isolation (no workflow persisted)",
+    usage: "nodes:run <file.json> [--idempotency-key KEY]",
+    run: async (client, [file], flags) => {
+      if (!file) fail(EXIT_USER_ERROR, "NODES_BAD_ARGS", "Usage: nodes:run <file.json>");
+      await ensureAuth(client);
+      const body = readJsonFile<v4.RunNodeRequest>(file);
+      // A --idempotency-key makes a real execute (node config isSimulated:false)
+      // safe to retry without broadcasting a second UserOp.
+      return client.nodes.run(
+        body,
+        flags.idempotencyKey ? { idempotencyKey: flags.idempotencyKey } : undefined,
+      );
     },
   },
 

--- a/packages/sdk-js/src/v4/builders/uniswap.ts
+++ b/packages/sdk-js/src/v4/builders/uniswap.ts
@@ -1,0 +1,164 @@
+import type { v4 } from "@avaprotocol/types";
+
+import { Protocols } from "../protocols";
+import { Nodes } from "./nodes";
+
+/**
+ * Uniswap V3 single-hop swap builders — thin, typed assemblers over
+ * `Protocols.uniswapV3` (addresses + ABIs) and `Nodes.contractWrite`. They
+ * emit a single-method node so, with atomic multi-call batching deferred on the
+ * gateway, the ERC-20 approval is a **separate** action the caller runs first
+ * (or the input token is already approved to the router).
+ *
+ * The market-order shape is: quote (`quoteNode`, simulated) → compute
+ * `amountOutMinimum` from a slippage tolerance (`minAmountOut`) → swap
+ * (`swapNode`). Pool discovery / fee-tier selection is the caller's job — pass
+ * the `fee` tier for the pool you intend to trade against.
+ */
+
+/** Uniswap V3 pool fee tiers, in hundredths of a bip (0.01%, 0.05%, 0.3%, 1%). */
+export type UniswapV3FeeTier = 100 | 500 | 3000 | 10000;
+
+const DEFAULT_SQRT_PRICE_LIMIT = "0";
+
+function addressForChain(
+  map: Partial<Record<number, string>>,
+  chainId: number,
+  label: string,
+): string {
+  const addr = map[chainId];
+  if (!addr) {
+    throw new Error(
+      `Uniswap V3 ${label} address is not known for chain ${chainId}; pass an explicit override`,
+    );
+  }
+  return addr;
+}
+
+export interface UniswapV3SwapNodeOptions {
+  id: string;
+  name: string;
+  chainId: number;
+  /** Input token address (must be an ERC-20; native ETH is not exactInputSingle). */
+  tokenIn: string;
+  /** Output token address. */
+  tokenOut: string;
+  /** Pool fee tier for the tokenIn/tokenOut pool being traded. */
+  fee: UniswapV3FeeTier;
+  /** Swap output recipient — usually the runner smart wallet. */
+  recipient: string;
+  /** Exact input amount, in tokenIn's smallest unit (wei). */
+  amountIn: string;
+  /**
+   * Minimum acceptable output (slippage floor), in tokenOut's smallest unit.
+   * Required — compute it from a quote with {@link minAmountOut} rather than
+   * passing "0", which disables slippage protection.
+   */
+  amountOutMinimum: string;
+  /** Price-limit bound; "0" (default) means no limit. */
+  sqrtPriceLimitX96?: string;
+  /** Override the SwapRouter02 address (defaults to the per-chain canonical one). */
+  routerAddress?: string;
+  /** When false, execute the real swap; omit/true to Tenderly-simulate (preview). */
+  isSimulated?: boolean;
+}
+
+export interface UniswapV3QuoteNodeOptions {
+  id: string;
+  name: string;
+  chainId: number;
+  tokenIn: string;
+  tokenOut: string;
+  fee: UniswapV3FeeTier;
+  amountIn: string;
+  sqrtPriceLimitX96?: string;
+  /** Override the QuoterV2 address (defaults to the per-chain canonical one). */
+  quoterAddress?: string;
+}
+
+export const UniswapV3 = Object.freeze({
+  /**
+   * Build a `contractWrite` node executing a single-hop `exactInputSingle` swap
+   * on SwapRouter02. Run it via `client.nodes.run` — with `isSimulated: false`
+   * (and an idempotency key) to execute for real, or the default simulate for a
+   * preview.
+   */
+  swapNode(opts: UniswapV3SwapNodeOptions): v4.Node {
+    const router =
+      opts.routerAddress ??
+      addressForChain(Protocols.uniswapV3.swapRouter02, opts.chainId, "SwapRouter02");
+    return Nodes.contractWrite({
+      id: opts.id,
+      name: opts.name,
+      chainId: opts.chainId,
+      contractAddress: router,
+      contractAbi: Protocols.uniswapV3.swapRouter02Abi,
+      ...(opts.isSimulated !== undefined ? { isSimulated: opts.isSimulated } : {}),
+      methodCalls: [
+        {
+          methodName: "exactInputSingle",
+          // The gateway maps a single JSON object onto the ABI tuple by field name.
+          methodParams: [
+            JSON.stringify({
+              tokenIn: opts.tokenIn,
+              tokenOut: opts.tokenOut,
+              fee: opts.fee,
+              recipient: opts.recipient,
+              amountIn: opts.amountIn,
+              amountOutMinimum: opts.amountOutMinimum,
+              sqrtPriceLimitX96: opts.sqrtPriceLimitX96 ?? DEFAULT_SQRT_PRICE_LIMIT,
+            }),
+          ],
+        },
+      ],
+    });
+  },
+
+  /**
+   * Build a node that quotes `exactInputSingle` via QuoterV2. QuoterV2 is a
+   * state-changing "revert-to-return" call, so it is modelled as a
+   * **simulated** `contractWrite` (not `contractRead`); run it via
+   * `client.nodes.run` to read the predicted `amountOut` from the output.
+   */
+  quoteNode(opts: UniswapV3QuoteNodeOptions): v4.Node {
+    const quoter =
+      opts.quoterAddress ??
+      addressForChain(Protocols.uniswapV3.quoterV2, opts.chainId, "QuoterV2");
+    return Nodes.contractWrite({
+      id: opts.id,
+      name: opts.name,
+      chainId: opts.chainId,
+      contractAddress: quoter,
+      contractAbi: Protocols.uniswapV3.quoterV2Abi,
+      isSimulated: true,
+      methodCalls: [
+        {
+          methodName: "quoteExactInputSingle",
+          methodParams: [
+            JSON.stringify({
+              tokenIn: opts.tokenIn,
+              tokenOut: opts.tokenOut,
+              amountIn: opts.amountIn,
+              fee: opts.fee,
+              sqrtPriceLimitX96: opts.sqrtPriceLimitX96 ?? DEFAULT_SQRT_PRICE_LIMIT,
+            }),
+          ],
+        },
+      ],
+    });
+  },
+
+  /**
+   * Compute `amountOutMinimum` from a quoted output and a slippage tolerance in
+   * basis points (bps; 50 = 0.5%). Floor-divides in integer wei, so the result
+   * is a conservative minimum. Throws on a slippage outside [0, 10000].
+   */
+  minAmountOut(expectedOut: string | bigint, slippageBps: number): string {
+    if (!Number.isInteger(slippageBps) || slippageBps < 0 || slippageBps > 10_000) {
+      throw new Error("slippageBps must be an integer in [0, 10000]");
+    }
+    const out = typeof expectedOut === "bigint" ? expectedOut : BigInt(expectedOut);
+    if (out < 0n) throw new Error("expectedOut must be non-negative");
+    return ((out * BigInt(10_000 - slippageBps)) / 10_000n).toString();
+  },
+});

--- a/packages/sdk-js/src/v4/index.ts
+++ b/packages/sdk-js/src/v4/index.ts
@@ -8,6 +8,12 @@ export { Chains, type ChainId } from "./chains";
 export { Triggers } from "./builders/triggers";
 export { Nodes } from "./builders/nodes";
 export {
+  UniswapV3,
+  type UniswapV3FeeTier,
+  type UniswapV3SwapNodeOptions,
+  type UniswapV3QuoteNodeOptions,
+} from "./builders/uniswap";
+export {
   Protocols,
   Tokens,
   lookupToken,
@@ -33,6 +39,11 @@ export { AuthResource } from "./resources/auth";
 export { ExecutionsResource } from "./resources/executions";
 export { HealthResource } from "./resources/health";
 export { NodesResource, type RunNodeOptions } from "./resources/nodes";
+export {
+  readContractWriteExecutions,
+  type ContractWriteExecutionStatus,
+  type ContractWriteMethodExecution,
+} from "./results/contractWrite";
 export { OperatorsResource } from "./resources/operators";
 export { SecretsResource } from "./resources/secrets";
 export { TokensResource } from "./resources/tokens";

--- a/packages/sdk-js/src/v4/results/contractWrite.ts
+++ b/packages/sdk-js/src/v4/results/contractWrite.ts
@@ -37,7 +37,11 @@ export interface ContractWriteMethodExecution {
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  // Exclude arrays (typeof [] === "object") so only plain objects are read as
+  // records — a malformed array entry shouldn't masquerade as a result/receipt.
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
 }
 
 /**

--- a/packages/sdk-js/src/v4/results/contractWrite.ts
+++ b/packages/sdk-js/src/v4/results/contractWrite.ts
@@ -1,0 +1,81 @@
+import type { v4 } from "@avaprotocol/types";
+
+/**
+ * Typed readers for a `contractWrite` `client.nodes.run` response.
+ *
+ * The gateway returns per-method results under `metadata.results[]`, each with
+ * a receipt. For a real execute (`isSimulated: false`) the receipt carries the
+ * normalized outcome the preview→confirm→execute flow branches on. These
+ * helpers pull that out of the otherwise-untyped response bag.
+ *
+ * Requires the gateway to surface array-typed contractWrite metadata (it is
+ * wrapped under `metadata.results`); older gateways dropped it, in which case
+ * these readers return an empty list.
+ */
+
+/**
+ * Normalized on-chain outcome of a single method call:
+ * - `confirmed` — mined and the inner call succeeded
+ * - `pending` — the UserOp was submitted but is not yet mined (poll `userOpHash`)
+ * - `failed` — submission failed or the transaction/inner call reverted
+ */
+export type ContractWriteExecutionStatus = "confirmed" | "pending" | "failed";
+
+export interface ContractWriteMethodExecution {
+  /** ABI method name (e.g. "exactInputSingle", "approve"). */
+  methodName: string;
+  /** True only when the method confirmed successfully. */
+  success: boolean;
+  /** Error summary when the method did not succeed. */
+  error?: string;
+  /** Normalized outcome; absent on a simulated run that predates the field. */
+  executionStatus?: ContractWriteExecutionStatus;
+  /** ERC-4337 UserOp hash — present for a real execute (use it to poll pending). */
+  userOpHash?: string;
+  /** On-chain transaction hash — present once mined (absent while pending). */
+  transactionHash?: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+/**
+ * Extract the per-method execution results from a `contractWrite` `nodes.run`
+ * response. Returns an empty array when the response carries no results (a
+ * non-contractWrite node, or a gateway that doesn't surface the metadata).
+ */
+export function readContractWriteExecutions(
+  resp: v4.RunNodeResponse,
+): ContractWriteMethodExecution[] {
+  const results = asRecord(resp?.metadata).results;
+  if (!Array.isArray(results)) return [];
+
+  return results.map((raw): ContractWriteMethodExecution => {
+    const entry = asRecord(raw);
+    const receipt = asRecord(entry.receipt);
+    const out: ContractWriteMethodExecution = {
+      methodName: typeof entry.methodName === "string" ? entry.methodName : "",
+      success: entry.success === true,
+    };
+    if (typeof entry.error === "string" && entry.error) out.error = entry.error;
+
+    const status = receipt.executionStatus;
+    if (status === "confirmed" || status === "pending" || status === "failed") {
+      out.executionStatus = status;
+    }
+    if (typeof receipt.userOpHash === "string" && receipt.userOpHash) {
+      out.userOpHash = receipt.userOpHash;
+    }
+    // The gateway uses the sentinel "pending" for an unmined tx hash; surface a
+    // transactionHash only once it's a real mined hash.
+    if (
+      typeof receipt.transactionHash === "string" &&
+      receipt.transactionHash &&
+      receipt.transactionHash !== "pending"
+    ) {
+      out.transactionHash = receipt.transactionHash;
+    }
+    return out;
+  });
+}

--- a/tests/v4/onchain-helpers.test.ts
+++ b/tests/v4/onchain-helpers.test.ts
@@ -1,0 +1,188 @@
+import {
+  Chains,
+  Protocols,
+  UniswapV3,
+  readContractWriteExecutions,
+  type v4,
+} from "@avaprotocol/sdk-js";
+
+/**
+ * Unit tests for the on-demand-action helpers — pure builders / readers, no
+ * gateway required.
+ */
+
+const WETH = "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14"; // Sepolia WETH
+const USDC = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"; // Sepolia USDC
+const RUNNER = "0x2222222222222222222222222222222222222222";
+
+type CWConfig = {
+  contractAddress: string;
+  isSimulated?: boolean;
+  methodCalls: Array<{ methodName: string; methodParams: string[] }>;
+};
+const configOf = (node: v4.Node): CWConfig => (node as unknown as { config: CWConfig }).config;
+
+describe("UniswapV3.swapNode", () => {
+  test("emits an exactInputSingle contractWrite against SwapRouter02", () => {
+    const node = UniswapV3.swapNode({
+      id: "swap",
+      name: "swap",
+      chainId: Chains.Sepolia,
+      tokenIn: WETH,
+      tokenOut: USDC,
+      fee: 3000,
+      recipient: RUNNER,
+      amountIn: "1000000000000000",
+      amountOutMinimum: "990000",
+    });
+    expect(node.type).toBe("contractWrite");
+    const config = configOf(node);
+    expect(config.contractAddress).toBe(Protocols.uniswapV3.swapRouter02[Chains.Sepolia]);
+    expect(config.methodCalls[0].methodName).toBe("exactInputSingle");
+    expect(JSON.parse(config.methodCalls[0].methodParams[0])).toEqual({
+      tokenIn: WETH,
+      tokenOut: USDC,
+      fee: 3000,
+      recipient: RUNNER,
+      amountIn: "1000000000000000",
+      amountOutMinimum: "990000",
+      sqrtPriceLimitX96: "0",
+    });
+  });
+
+  test("passes isSimulated through and honors a router override", () => {
+    const override = "0x9999999999999999999999999999999999999999";
+    const node = UniswapV3.swapNode({
+      id: "s",
+      name: "s",
+      chainId: 999999,
+      tokenIn: WETH,
+      tokenOut: USDC,
+      fee: 500,
+      recipient: RUNNER,
+      amountIn: "1",
+      amountOutMinimum: "0",
+      routerAddress: override,
+      isSimulated: false,
+    });
+    const config = configOf(node);
+    expect(config.contractAddress).toBe(override);
+    expect(config.isSimulated).toBe(false);
+  });
+
+  test("throws for an unknown chain without a router override", () => {
+    expect(() =>
+      UniswapV3.swapNode({
+        id: "s",
+        name: "s",
+        chainId: 999999,
+        tokenIn: WETH,
+        tokenOut: USDC,
+        fee: 3000,
+        recipient: RUNNER,
+        amountIn: "1",
+        amountOutMinimum: "0",
+      }),
+    ).toThrow(/SwapRouter02 address is not known for chain 999999/);
+  });
+});
+
+describe("UniswapV3.quoteNode", () => {
+  test("emits a simulated quoteExactInputSingle against QuoterV2", () => {
+    const node = UniswapV3.quoteNode({
+      id: "q",
+      name: "q",
+      chainId: Chains.Sepolia,
+      tokenIn: WETH,
+      tokenOut: USDC,
+      fee: 3000,
+      amountIn: "1000000000000000",
+    });
+    const config = configOf(node);
+    expect(config.contractAddress).toBe(Protocols.uniswapV3.quoterV2[Chains.Sepolia]);
+    expect(config.isSimulated).toBe(true);
+    expect(config.methodCalls[0].methodName).toBe("quoteExactInputSingle");
+    expect(JSON.parse(config.methodCalls[0].methodParams[0])).toEqual({
+      tokenIn: WETH,
+      tokenOut: USDC,
+      amountIn: "1000000000000000",
+      fee: 3000,
+      sqrtPriceLimitX96: "0",
+    });
+  });
+});
+
+describe("UniswapV3.minAmountOut", () => {
+  test("applies slippage in integer wei (floor)", () => {
+    expect(UniswapV3.minAmountOut("1000000", 50)).toBe("995000"); // 0.5%
+    expect(UniswapV3.minAmountOut(1_000_000n, 0)).toBe("1000000");
+    expect(UniswapV3.minAmountOut("3", 1)).toBe("2"); // 3 * 9999 / 10000 = 2 (floor)
+  });
+
+  test("rejects out-of-range slippage and negative output", () => {
+    expect(() => UniswapV3.minAmountOut("100", -1)).toThrow(/slippageBps/);
+    expect(() => UniswapV3.minAmountOut("100", 10001)).toThrow(/slippageBps/);
+    expect(() => UniswapV3.minAmountOut("100", 1.5)).toThrow(/slippageBps/);
+    expect(() => UniswapV3.minAmountOut("-1", 10)).toThrow(/non-negative/);
+  });
+});
+
+describe("readContractWriteExecutions", () => {
+  const resp = (metadata: unknown): v4.RunNodeResponse =>
+    ({ success: true, metadata } as unknown as v4.RunNodeResponse);
+
+  test("extracts confirmed method results with userOpHash + txHash", () => {
+    const out = readContractWriteExecutions(
+      resp({
+        results: [
+          {
+            methodName: "exactInputSingle",
+            success: true,
+            receipt: {
+              executionStatus: "confirmed",
+              userOpHash: "0xuo",
+              transactionHash: "0xtx",
+            },
+          },
+        ],
+      }),
+    );
+    expect(out).toEqual([
+      {
+        methodName: "exactInputSingle",
+        success: true,
+        executionStatus: "confirmed",
+        userOpHash: "0xuo",
+        transactionHash: "0xtx",
+      },
+    ]);
+  });
+
+  test("treats a submitted-but-unmined UserOp as pending with no txHash", () => {
+    const out = readContractWriteExecutions(
+      resp({
+        results: [
+          {
+            methodName: "exactInputSingle",
+            success: false,
+            receipt: {
+              executionStatus: "pending",
+              userOpHash: "0xuo",
+              transactionHash: "pending",
+            },
+          },
+        ],
+      }),
+    );
+    expect(out[0].executionStatus).toBe("pending");
+    expect(out[0].userOpHash).toBe("0xuo");
+    expect(out[0].transactionHash).toBeUndefined();
+    expect(out[0].success).toBe(false);
+  });
+
+  test("returns [] when the response has no results array", () => {
+    expect(readContractWriteExecutions(resp(undefined))).toEqual([]);
+    expect(readContractWriteExecutions(resp({}))).toEqual([]);
+    expect(readContractWriteExecutions({ success: true } as v4.RunNodeResponse)).toEqual([]);
+  });
+});

--- a/tests/v4/onchain-helpers.test.ts
+++ b/tests/v4/onchain-helpers.test.ts
@@ -11,9 +11,12 @@ import {
  * gateway required.
  */
 
-const WETH = "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14"; // Sepolia WETH
-const USDC = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"; // Sepolia USDC
-const RUNNER = "0x2222222222222222222222222222222222222222";
+// Token addresses come from the shared protocol catalog (drift-proof), the same
+// source the Uniswap template test uses — not re-hardcoded here.
+const WETH = Protocols.uniswapV3.tokens.WETH[Chains.Sepolia]!;
+const USDC = Protocols.uniswapV3.tokens.USDC[Chains.Sepolia]!;
+// A pure builder input — any address works; these tests never hit a wallet.
+const RECIPIENT = "0x2222222222222222222222222222222222222222";
 
 type CWConfig = {
   contractAddress: string;
@@ -31,7 +34,7 @@ describe("UniswapV3.swapNode", () => {
       tokenIn: WETH,
       tokenOut: USDC,
       fee: 3000,
-      recipient: RUNNER,
+      recipient: RECIPIENT,
       amountIn: "1000000000000000",
       amountOutMinimum: "990000",
     });
@@ -43,7 +46,7 @@ describe("UniswapV3.swapNode", () => {
       tokenIn: WETH,
       tokenOut: USDC,
       fee: 3000,
-      recipient: RUNNER,
+      recipient: RECIPIENT,
       amountIn: "1000000000000000",
       amountOutMinimum: "990000",
       sqrtPriceLimitX96: "0",
@@ -59,7 +62,7 @@ describe("UniswapV3.swapNode", () => {
       tokenIn: WETH,
       tokenOut: USDC,
       fee: 500,
-      recipient: RUNNER,
+      recipient: RECIPIENT,
       amountIn: "1",
       amountOutMinimum: "0",
       routerAddress: override,
@@ -79,7 +82,7 @@ describe("UniswapV3.swapNode", () => {
         tokenIn: WETH,
         tokenOut: USDC,
         fee: 3000,
-        recipient: RUNNER,
+        recipient: RECIPIENT,
         amountIn: "1",
         amountOutMinimum: "0",
       }),


### PR DESCRIPTION
The SDK surface for a chat agent's one-time **preview → confirm → execute** action (e.g. a Uniswap market order), on top of the gateway's single-node `nodes:run`. Pairs with the `Idempotency-Key` support already on `staging`.

## What's added

- **`UniswapV3.swapNode` / `UniswapV3.quoteNode` / `UniswapV3.minAmountOut`** — assemble a single-hop `exactInputSingle` swap and its QuoterV2 quote over `Protocols.uniswapV3`, and compute `amountOutMinimum` from a slippage tolerance (bps). QuoterV2 is modelled as a *simulated* `contractWrite` (it's a revert-to-return call). Approval is a separate action (atomic batching is deferred on the gateway), and pool/fee-tier selection is the caller's.
- **`readContractWriteExecutions(resp)`** — read the normalized per-method outcome (`confirmed` / `pending` / `failed`) plus `userOpHash` / `transactionHash` from a `contractWrite` `nodes.run` response. A submitted-but-unmined UserOp reads as `pending` (with a `userOpHash`, no `transactionHash`), not a failure.
- **Example CLI**: `nodes:run <file.json> [--idempotency-key KEY]`.
- **Docs**: `docs/on-demand-actions.md` walks the quote → preview → execute flow.

## Dependency

`readContractWriteExecutions` reads `metadata.results[]`, which the gateway only surfaces after **AvaProtocol/EigenLayer-AVS#660** (array-typed contractWrite metadata was previously dropped). Against an older gateway it returns an empty list — the builders and idempotency work regardless.

## Tests

`tests/v4/onchain-helpers.test.ts` — builder output/tuple encoding, router/quoter resolution + overrides, slippage math and bounds, and the execution readers (confirmed / pending / empty). `tsc`, `eslint packages/*/src`, and the unit suites are green (31/31 with the smoke suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
