### PR TITLE
ci: run a registered Sepolia operator in the E2E stack

### DIFF
--- a/.github/workflows/dev-test-on-pr.yml
+++ b/.github/workflows/dev-test-on-pr.yml
@@ -91,6 +91,12 @@ jobs:
       TENDERLY_PROJECT: ${{ vars.TENDERLY_PROJECT }}
       THEGRAPH_API_KEY: ${{ vars.THEGRAPH_API_KEY }}
       BUNDLER_URL: ${{ secrets.BUNDLER_URL }}
+      # Registered test operator (base64 keystores + passwords) so on-chain
+      # (block/event) triggers actually fire in the E2E stack.
+      OPERATOR_ECDSA_KEYSTORE: ${{ secrets.OPERATOR_ECDSA_KEYSTORE }}
+      OPERATOR_BLS_KEYSTORE: ${{ secrets.OPERATOR_BLS_KEYSTORE }}
+      OPERATOR_ECDSA_KEY_PASSWORD: ${{ secrets.OPERATOR_ECDSA_KEY_PASSWORD }}
+      OPERATOR_BLS_KEY_PASSWORD: ${{ secrets.OPERATOR_BLS_KEY_PASSWORD }}
 
     steps:
       - name: Checkout repository
@@ -111,7 +117,7 @@ jobs:
       - name: Inject secrets into gateway + worker configs
         run: |
           export TEST_ENV ETH_RPC_URL ETH_WS_URL ECDSA_PRIVATE_KEY JWT_SECRET BUNDLER_URL CONTROLLER_PRIVATE_KEY TENDERLY_ACCOUNT TENDERLY_PROJECT TENDERLY_ACCESS_KEY AP_NOTIFY_BOT_TOKEN SENDGRID_KEY THEGRAPH_API_KEY MORALIS_API_KEY CONTEXT_MEMORY_API_KEY
-          for src in gateway worker-sepolia; do
+          for src in gateway worker-sepolia operator-sepolia; do
             envsubst < config/${src}.yaml > config/${src}.runtime.yaml
             echo "Generated config/${src}.runtime.yaml: $(wc -l < config/${src}.runtime.yaml) lines"
             if grep -q "\${.*}" config/${src}.runtime.yaml; then
@@ -179,6 +185,43 @@ jobs:
             docker compose logs worker-sepolia
             exit 1
           fi
+
+      - name: Write operator keystores
+        run: |
+          mkdir -p config/.operator-keys
+          echo "$OPERATOR_ECDSA_KEYSTORE" | base64 -d > config/.operator-keys/operator.ecdsa.key.json
+          echo "$OPERATOR_BLS_KEYSTORE"   | base64 -d > config/.operator-keys/operator.bls.key.json
+          echo "ECDSA keystore: $(wc -c < config/.operator-keys/operator.ecdsa.key.json) bytes; BLS keystore: $(wc -c < config/.operator-keys/operator.bls.key.json) bytes"
+
+      - name: Start operator
+        run: |
+          docker compose up -d operator
+          echo "Waiting for operator to register + connect to the aggregator..."
+          max_attempts=18
+          attempt=0
+          while [ $attempt -lt $max_attempts ]; do
+            # Hard-fail fast if the operator crashed (e.g. not registered,
+            # keystore/password mismatch) — it won't recover on its own.
+            if [ "$(docker compose ps -q operator)" ] && ! docker compose ps operator | grep -qiE "up|running"; then
+              echo "Operator container exited unexpectedly:"
+              docker compose ps operator
+              docker compose logs operator
+              exit 1
+            fi
+            if docker compose logs operator 2>&1 | grep -q "Operator ready"; then
+              echo "Operator is ready and connected!"
+              break
+            fi
+            echo "Attempt $((attempt + 1))/$max_attempts: operator not ready yet..."
+            docker compose logs operator --tail=5
+            sleep 5
+            attempt=$((attempt + 1))
+          done
+          # Give the aggregator a moment to register the operator connection
+          # (operator notifications batch every ~3s) before tests create tasks.
+          sleep 5
+          docker compose ps
+          docker compose logs operator --tail=30
 
       - name: Generate AVS API key
         run: |

--- a/.github/workflows/dev-test-on-pr.yml
+++ b/.github/workflows/dev-test-on-pr.yml
@@ -91,7 +91,7 @@ jobs:
       TENDERLY_PROJECT: ${{ vars.TENDERLY_PROJECT }}
       THEGRAPH_API_KEY: ${{ vars.THEGRAPH_API_KEY }}
       BUNDLER_URL: ${{ secrets.BUNDLER_URL }}
-      # Registered test operator (base64 keystores + passwords) so on-chain
+      # Registered test operator (raw-JSON keystores + passwords) so on-chain
       # (block/event) triggers actually fire in the E2E stack.
       OPERATOR_ECDSA_KEYSTORE: ${{ secrets.OPERATOR_ECDSA_KEYSTORE }}
       OPERATOR_BLS_KEYSTORE: ${{ secrets.OPERATOR_BLS_KEYSTORE }}
@@ -189,9 +189,13 @@ jobs:
       - name: Write operator keystores
         run: |
           mkdir -p config/.operator-keys
-          echo "$OPERATOR_ECDSA_KEYSTORE" | base64 -d > config/.operator-keys/operator.ecdsa.key.json
-          echo "$OPERATOR_BLS_KEYSTORE"   | base64 -d > config/.operator-keys/operator.bls.key.json
+          # Keystores are stored as raw JSON secrets and written verbatim.
+          printf '%s' "$OPERATOR_ECDSA_KEYSTORE" > config/.operator-keys/operator.ecdsa.key.json
+          printf '%s' "$OPERATOR_BLS_KEYSTORE"   > config/.operator-keys/operator.bls.key.json
           echo "ECDSA keystore: $(wc -c < config/.operator-keys/operator.ecdsa.key.json) bytes; BLS keystore: $(wc -c < config/.operator-keys/operator.bls.key.json) bytes"
+          # Sanity-check shape (no secret values printed) so a bad secret fails here, clearly.
+          jq -e '.address and .crypto' config/.operator-keys/operator.ecdsa.key.json > /dev/null && echo "ECDSA keystore JSON valid"
+          jq -e '.pubKey and .crypto'  config/.operator-keys/operator.bls.key.json  > /dev/null && echo "BLS keystore JSON valid"
 
       - name: Start operator
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ temp/
 
 # PR comment output files
 pr-comments-*.json
+
+# Generated at CI runtime from templates + secrets (envsubst / decoded keystores) — never commit.
+config/*.runtime.yaml
+config/.operator-keys/

--- a/config/operator-sepolia.yaml
+++ b/config/operator-sepolia.yaml
@@ -1,0 +1,38 @@
+# Operator config for the CI E2E stack (Sepolia).
+#
+# Runs the registered test operator 0x997e5d40a32c44a3d93e59fc55c4fd20b7d2d49d
+# so tasks with on-chain triggers (block/event) actually fire — without a
+# connected operator the aggregator returns "no connected operator currently
+# monitors chain_id=11155111". Secrets are injected via envsubst in
+# .github/workflows/dev-test-on-pr.yml (mirrors the gateway/worker configs);
+# the ECDSA/BLS keystore passwords come from OPERATOR_{ECDSA,BLS}_KEY_PASSWORD.
+environment: development
+
+operator_address: 0x997e5d40a32c44a3d93e59fc55c4fd20b7d2d49d
+
+avs_registry_coordinator_address: 0xcA95381802FD1398d5BF2D01243210cFb3a2b3BD
+operator_state_retriever_address: 0x070E0ABE8407eb4727fC7C5284bdc1e5E5CBf605
+
+eth_rpc_url: ${ETH_RPC_URL}
+eth_ws_url: ${ETH_WS_URL}
+
+# Keystores are written to config/.operator-keys/ from GitHub secrets in CI.
+ecdsa_private_key_store_path: /app/config/.operator-keys/operator.ecdsa.key.json
+bls_private_key_store_path: /app/config/.operator-keys/operator.bls.key.json
+
+db_path: /tmp/ap-avs-operator
+
+# In-network gRPC address of the gateway (aggregator) container.
+aggregator_server_ip_port_address: "gateway:2206"
+
+eigen_metrics_ip_port_address: 0.0.0.0:9090
+enable_metrics: false
+node_api_ip_port_address: 0.0.0.0:9010
+enable_node_api: true
+
+target_chain:
+  eth_rpc_url: ${ETH_RPC_URL}
+  eth_ws_url: ${ETH_WS_URL}
+
+enabled_features:
+  event_trigger: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,22 @@ services:
       - ./config:/app/config
     depends_on:
       - gateway
+
+  # Registered test operator (0x997e5d40…) so tasks with on-chain triggers
+  # (block/event) actually fire — without a connected operator the aggregator
+  # returns "no connected operator currently monitors chain_id=11155111". The
+  # ECDSA/BLS keystores are written to config/.operator-keys/ from GitHub
+  # secrets in CI; their passwords come from OPERATOR_{ECDSA,BLS}_KEY_PASSWORD.
+  operator:
+    image: avaprotocol/avs-dev:${DOCKER_IMAGE_TAG:-latest}
+    command:
+      - "operator"
+      - "--config"
+      - "/app/config/operator-sepolia.runtime.yaml"
+    environment:
+      OPERATOR_ECDSA_KEY_PASSWORD: ${OPERATOR_ECDSA_KEY_PASSWORD}
+      OPERATOR_BLS_KEY_PASSWORD: ${OPERATOR_BLS_KEY_PASSWORD}
+    volumes:
+      - ./config:/app/config
+    depends_on:
+      - gateway


### PR DESCRIPTION
## Problem

The E2E `gateway` + `worker-sepolia` start fine, but **no operator** is connected — so any task with an on-chain trigger fails with `no connected operator currently monitors chain_id=11155111 for TRIGGER_TYPE_BLOCK triggers`, taking a chunk of every E2E shard red (simulation/CRUD tests pass; execution/trigger-firing tests fail).

An operator can't just be started like the gateway: `Operator.Start()` refuses to boot unless the operator EOA is **registered on-chain with the AVS** (registry coordinator `0xcA95…3BD`), and it needs ECDSA + BLS keystores.

## Fix

Add the **registered test operator `0x997e5d40a32c44a3d93e59fc55c4fd20b7d2d49d`** (the decommissioned bare-metal staging operator, already registered on Sepolia against the same registry coordinator the gateway uses) to the E2E stack:

- **`config/operator-sepolia.yaml`** — envsubst template; `aggregator_server_ip_port_address: gateway:2206`, keystores under `config/.operator-keys/`.
- **`docker-compose.yml`** — an `operator` service (keystore passwords via `OPERATOR_{ECDSA,BLS}_KEY_PASSWORD`, `depends_on: gateway`).
- **`dev-test-on-pr.yml`** — inject the operator config, decode the keystores from base64 secrets, `docker compose up -d operator`, and wait for it to register (fast-fail if it crashes) before running tests.
- **`.gitignore`** — never commit generated runtime configs or decoded keystores.

## Secrets (added to this repo)

`OPERATOR_ECDSA_KEYSTORE` / `OPERATOR_BLS_KEYSTORE` (base64 of the keystore files) and `OPERATOR_ECDSA_KEY_PASSWORD` / `OPERATOR_BLS_KEY_PASSWORD`. Consistent with the existing `CONTROLLER_PRIVATE_KEY` / `ECDSA_PRIVATE_KEY` secrets; testnet only, rotatable.

## Validation

This PR run is the test — the operator should connect and the execution/trigger E2E shards should go green. First-attempt CI wiring; the "Start operator" step is diagnostic-heavy so any connection issue is visible in the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
