### PR TITLE
chore: sync execution-budget types, fix fixtures under the new gateway floors

### DIFF
--- a/packages/types/openapi/openapi.yaml
+++ b/packages/types/openapi/openapi.yaml
@@ -778,11 +778,17 @@ components:
       properties:
         channel:
           type: string
+          enum: [telegram, api]
           description: 'External-signal flavor — signal channel: `telegram` or `api`.'
         approvers:
           type: array
           items: { type: string }
-          description: External-signal flavor — authorized approver identities. Empty = the workflow owner.
+          description: >-
+            External-signal flavor — authorized approver identities. Empty = the
+            workflow owner. NOTE (v1): not yet enforced — the signal endpoint
+            authorizes by workflow ownership only, so the owner can always approve
+            regardless of this list. Delegated-approver enforcement (Telegram binding)
+            is a follow-up; do not rely on this field for security yet.
         prompt:
           type: string
           description: External-signal flavor — message shown to the approver.
@@ -975,11 +981,42 @@ components:
         maxExecution:
           type: integer
           format: int64
-          description: Cap on how many times this workflow may execute. 0 = unlimited.
+          description: >-
+            Cap on how many times this workflow may execute. The workflow
+            reaches status `completed` once `executionCount` hits this value.
+            Present and finite on every workflow created since the server
+            began assigning a default — a create request that omits the field
+            takes that default, and one that sends 0 or a negative is rejected,
+            so "run forever" is not expressible. Absent on workflows created
+            before that change and stored uncapped; those keep running without
+            a limit, and `remainingExecutions` is likewise absent for them.
         executionCount:
           type: integer
           format: int64
           description: How many times this workflow has executed so far.
+        remainingExecutions:
+          type: integer
+          format: int64
+          description: >-
+            Runs left before the workflow completes — `maxExecution` minus
+            `executionCount`, floored at 0. Derived server-side so clients do
+            not have to reproduce the arithmetic (and so an absent
+            `executionCount` on a never-run workflow cannot be misread).
+            Reported as 0 rather than omitted once the budget is spent. Absent
+            only on legacy uncapped workflows, where no finite number exists.
+        completionReason:
+          type: string
+          enum:
+            - TASK_COMPLETION_REASON_UNSPECIFIED
+            - TASK_COMPLETION_REASON_MAX_EXECUTIONS_REACHED
+            - TASK_COMPLETION_REASON_EXPIRED
+          description: >-
+            Why the workflow reached a terminal state. An exhausted execution
+            budget and a passed expiry both produce status `completed`, so the
+            status alone cannot distinguish them. Absent or UNSPECIFIED while
+            the workflow is still runnable, and on workflows that terminated
+            before this field existed. Cancellation is not represented —
+            cancelling deletes the workflow rather than leaving a record.
         createdAt:
           type: integer
           format: int64
@@ -1007,7 +1044,15 @@ components:
         inputVariables: { $ref: '#/components/schemas/InputVariables' }
         startAt: { type: integer, format: int64 }
         expiredAt: { type: integer, format: int64 }
-        maxExecution: { type: integer, format: int64 }
+        maxExecution:
+          type: integer
+          format: int64
+          minimum: 1
+          description: >-
+            Optional cap on total executions. Omit the field to take the server
+            default. Sending 0 (or a negative) is rejected rather than treated
+            as unlimited: unlimited execution is not offered, because every run
+            spends metered provider quota.
 
     WorkflowList:
       type: object

--- a/packages/types/src/openapi.gen.ts
+++ b/packages/types/src/openapi.gen.ts
@@ -1070,9 +1070,12 @@ export interface components {
          *     bridge arrival on another chain). Exactly one flavor must be configured.
          */
         readonly AwaitNodeConfig: {
-            /** @description External-signal flavor — signal channel: `telegram` or `api`. */
-            readonly channel?: string;
-            /** @description External-signal flavor — authorized approver identities. Empty = the workflow owner. */
+            /**
+             * @description External-signal flavor — signal channel: `telegram` or `api`.
+             * @enum {string}
+             */
+            readonly channel?: "telegram" | "api";
+            /** @description External-signal flavor — authorized approver identities. Empty = the workflow owner. NOTE (v1): not yet enforced — the signal endpoint authorizes by workflow ownership only, so the owner can always approve regardless of this list. Delegated-approver enforcement (Telegram binding) is a follow-up; do not rely on this field for security yet. */
             readonly approvers?: readonly string[];
             /** @description External-signal flavor — message shown to the approver. */
             readonly prompt?: string;
@@ -1264,7 +1267,7 @@ export interface components {
             readonly expiredAt?: number;
             /**
              * Format: int64
-             * @description Cap on how many times this workflow may execute. 0 = unlimited.
+             * @description Cap on how many times this workflow may execute. The workflow reaches status `completed` once `executionCount` hits this value. Present and finite on every workflow created since the server began assigning a default — a create request that omits the field takes that default, and one that sends 0 or a negative is rejected, so "run forever" is not expressible. Absent on workflows created before that change and stored uncapped; those keep running without a limit, and `remainingExecutions` is likewise absent for them.
              */
             readonly maxExecution?: number;
             /**
@@ -1272,6 +1275,16 @@ export interface components {
              * @description How many times this workflow has executed so far.
              */
             readonly executionCount?: number;
+            /**
+             * Format: int64
+             * @description Runs left before the workflow completes — `maxExecution` minus `executionCount`, floored at 0. Derived server-side so clients do not have to reproduce the arithmetic (and so an absent `executionCount` on a never-run workflow cannot be misread). Reported as 0 rather than omitted once the budget is spent. Absent only on legacy uncapped workflows, where no finite number exists.
+             */
+            readonly remainingExecutions?: number;
+            /**
+             * @description Why the workflow reached a terminal state. An exhausted execution budget and a passed expiry both produce status `completed`, so the status alone cannot distinguish them. Absent or UNSPECIFIED while the workflow is still runnable, and on workflows that terminated before this field existed. Cancellation is not represented — cancelling deletes the workflow rather than leaving a record.
+             * @enum {string}
+             */
+            readonly completionReason?: "TASK_COMPLETION_REASON_UNSPECIFIED" | "TASK_COMPLETION_REASON_MAX_EXECUTIONS_REACHED" | "TASK_COMPLETION_REASON_EXPIRED";
             /**
              * Format: int64
              * @description Unix-epoch milliseconds — when the workflow was first created.
@@ -1294,7 +1307,10 @@ export interface components {
             readonly startAt?: number;
             /** Format: int64 */
             readonly expiredAt?: number;
-            /** Format: int64 */
+            /**
+             * Format: int64
+             * @description Optional cap on total executions. Omit the field to take the server default. Sending 0 (or a negative) is rejected rather than treated as unlimited: unlimited execution is not offered, because every run spends metered provider quota.
+             */
             readonly maxExecution?: number;
         };
         readonly WorkflowList: {

--- a/tests/v4/executions/execution.test.ts
+++ b/tests/v4/executions/execution.test.ts
@@ -46,8 +46,12 @@ describe("Execution Management Tests", () => {
     const blockNumber = await getCurrentBlockNumber();
 
     const created = await client.workflows.create({
+      // The template caps at 1 execution; this test triggers three times, so it
+      // needs a bigger budget. It used to pass 0 (unlimited), which the gateway
+      // now rejects — every run spends metered provider quota, so a workflow
+      // must declare a finite budget or take the server default.
       ...createFromTemplate(wallet.address),
-      maxExecution: 0,
+      maxExecution: 10,
       trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
     });
     const wfId = created.id as string;
@@ -74,8 +78,8 @@ describe("Execution Management Tests", () => {
     const wallet = await createSmartWallet(client, { saltValue: nextTestSalt() });
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
-      maxExecution: 0,
-      trigger: Triggers.cron({ id: "trigger", name: "cron", schedule: ["* * * * *"] }),
+      maxExecution: 10,
+      trigger: Triggers.cron({ id: "trigger", name: "cron", schedule: ["0 * * * *"] }),
     });
     const wfId = created.id as string;
     createdWorkflowIds.push(wfId);
@@ -98,7 +102,7 @@ describe("Execution Management Tests", () => {
     const blockNumber = await getCurrentBlockNumber();
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
-      maxExecution: 0,
+      maxExecution: 10,
       trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
     });
     const wfId = created.id as string;

--- a/tests/v4/executions/getExecution.test.ts
+++ b/tests/v4/executions/getExecution.test.ts
@@ -101,7 +101,7 @@ describe("executions.retrieve Tests", () => {
     const wallet = await createSmartWallet(client);
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
-      trigger: Triggers.cron({ id: "trigger", name: "cronTrigger", schedule: ["* * * * *"] }),
+      trigger: Triggers.cron({ id: "trigger", name: "cronTrigger", schedule: ["0 * * * *"] }),
     });
     const wfId = created.id as string;
     createdWorkflowIds.push(wfId);

--- a/tests/v4/nodes/branchNode.test.ts
+++ b/tests/v4/nodes/branchNode.test.ts
@@ -151,7 +151,7 @@ describe("BranchNode Tests", () => {
 
         const wfReq = {
           ...createFromTemplate(wallet.address),
-          trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 3 }),
+          trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
           nodes: [branch, nodeA, nodeB],
           edges: [
             { id: "e1", source: "trigger", target: "branch" },

--- a/tests/v4/templates/telegram-alert-on-transfer.test.ts
+++ b/tests/v4/templates/telegram-alert-on-transfer.test.ts
@@ -51,7 +51,10 @@ describe("Template: Telegram alert on transfer", () => {
     const created = await client.workflows.create({
       name: "Telegram alert on transfer",
       smartWalletAddress: wallet.address,
-      maxExecution: 0,
+      // An event trigger fires at whatever rate the chain produces matching
+      // logs, so the gateway's execution cap is its only static bound. 0 used
+      // to mean unlimited and is now rejected — pass an explicit budget.
+      maxExecution: 10,
       trigger: Triggers.event({
         id: "trigger",
         name: "transferMonitor",

--- a/tests/v4/templates/workflow-usdc-read-write-customcode.test.ts
+++ b/tests/v4/templates/workflow-usdc-read-write-customcode.test.ts
@@ -50,7 +50,7 @@ describe("Template: USDC read+write+customCode", () => {
       trigger: Triggers.cron({
         id: "timeTrigger",
         name: "timeTrigger",
-        schedule: ["*/2 * * * *"],
+        schedule: ["*/5 * * * *"],
       }),
       nodes: [
         Nodes.contractRead({

--- a/tests/v4/workflows/triggerWorkflow.test.ts
+++ b/tests/v4/workflows/triggerWorkflow.test.ts
@@ -75,7 +75,7 @@ describe("workflows.trigger Tests", () => {
       const wallet = await createSmartWallet(client);
       const created = await client.workflows.create({
         ...createFromTemplate(wallet.address),
-        trigger: Triggers.cron({ id: "trigger", name: "cronTrigger", schedule: ["* * * * *"] }),
+        trigger: Triggers.cron({ id: "trigger", name: "cronTrigger", schedule: ["0 * * * *"] }),
       });
       const wfId = created.id as string;
       createdWorkflowIds.push(wfId);
@@ -164,7 +164,7 @@ describe("workflows.trigger Tests", () => {
       const wallet = await createSmartWallet(client);
       const created = await client.workflows.create({
         ...createFromTemplate(wallet.address),
-        trigger: Triggers.cron({ id: "trigger", name: "cron", schedule: ["* * * * *"] }),
+        trigger: Triggers.cron({ id: "trigger", name: "cron", schedule: ["0 * * * *"] }),
       });
       const wfId = created.id as string;
       createdWorkflowIds.push(wfId);
@@ -188,7 +188,7 @@ describe("workflows.trigger Tests", () => {
       const wallet = await createSmartWallet(client);
       const created = await client.workflows.create({
         ...createFromTemplate(wallet.address),
-        trigger: Triggers.cron({ id: "trigger", name: "cron", schedule: ["* * * * *"] }),
+        trigger: Triggers.cron({ id: "trigger", name: "cron", schedule: ["0 * * * *"] }),
       });
       const wfId = created.id as string;
       createdWorkflowIds.push(wfId);
@@ -221,7 +221,7 @@ describe("workflows.trigger Tests", () => {
       const created = await client.workflows.create({
         ...createFromTemplate(wallet.address),
         maxExecution: 1,
-        trigger: Triggers.cron({ id: "trigger", name: "cron", schedule: ["* * * * *"] }),
+        trigger: Triggers.cron({ id: "trigger", name: "cron", schedule: ["0 * * * *"] }),
       });
       const wfId = created.id as string;
       createdWorkflowIds.push(wfId);


### PR DESCRIPTION
Follow-up to [AVS #673](https://github.com/AvaProtocol/EigenLayer-AVS/pull/673), merged to `staging` as `35b74c6`, which added constant execution ceilings to the gateway.

## 1. Type sync (the expected part)

`yarn openapi-download` + `yarn types-gen`. Two new fields on the Workflow response:

```ts
readonly remainingExecutions?: number;
readonly completionReason?: "TASK_COMPLETION_REASON_UNSPECIFIED"
  | "TASK_COMPLETION_REASON_MAX_EXECUTIONS_REACHED"
  | "TASK_COMPLETION_REASON_EXPIRED";
```

plus `minimum: 1` on the `maxExecution` request field.

Nothing hand-written needed updating — `v4.Workflow` is an alias for `components["schemas"]["Workflow"]`, so the new fields arrive through the generated schema automatically.

## 2. Fixtures the gateway now refuses (the part that mattered)

A survey of the suite against the new floors turned up **eleven sites that construct workflows the gateway rejects**. These fail at `workflows.create` — before any assertion runs — so against a staging gateway they'd surface as opaque create errors rather than meaningful test failures.

| What | Where | Why it broke |
|---|---|---|
| `* * * * *` | triggerWorkflow ×4, execution, getExecution | 1 min < the 5-min cron floor |
| `*/2 * * * *` | USDC read-write template | 2 min < the 5-min cron floor |
| `interval: 3` | branchNode | 36s on Sepolia's 12s blocks < the 60s block floor |
| `maxExecution: 0` | execution ×3, telegram template | 0 meant unlimited; now rejected outright |

**Cron fixes** went to the suite's existing hourly convention (`0 * * * *`), not to `*/5 * * * *`. Both clear the floor, but parking a dozen fixtures exactly on the boundary means any future tightening breaks all of them at once. These tests fire their own trigger via `workflows.trigger()`, so the schedule was never load-bearing.

**Block fix** is `interval: 5`, matching the ~10 other block fixtures in the suite.

**`maxExecution: 0`** was the interesting one. It wasn't asking for unlimited — it was overriding `createFromTemplate`'s cap of 1 because those tests trigger more than once (the largest triggers three times). An explicit budget of 10 is what they actually needed. Worth noting the gateway now *rejects* an explicit 0 rather than silently defaulting it, which is why these surface as hard errors rather than passing quietly.

## Dependency: #233 is now required, not optional

The guardian live e2e still passes `* * * * *` at `guardian-wallet-risk-monitor.test.ts:399`, which the gateway now rejects. I deliberately did **not** fix it here — [#233](https://github.com/AvaProtocol/ava-sdk-js/pull/233) already changes that line, so touching it would only manufacture a conflict.

That reframes #233. It was opened as hygiene (loud cleanup failures + a client-side schedule floor); it is now also the compatibility fix for the guardian template. It's gated behind `RUN_GUARDIAN_LIVE=1` so CI won't catch the breakage — the failure would only appear when someone runs the live e2e.

**Suggested merge order: #233 first, then this.**

## Testing

- `yarn build` clean, `tsc --noEmit` clean, `yarn lint` clean.
- Offline templates suite: 9 suites, 32/32 pass.
- The full v4 suite needs a live gateway, so it isn't run here. The fixture changes are exactly what make it able to pass against a post-#673 gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
