### PR TITLE
feat: session policies — client surface for the smart-wallet grant

### DIFF
--- a/packages/sdk-js/src/v4/client.ts
+++ b/packages/sdk-js/src/v4/client.ts
@@ -7,6 +7,7 @@ import { OperatorsResource } from "./resources/operators";
 import { SecretsResource } from "./resources/secrets";
 import { TokensResource } from "./resources/tokens";
 import { TriggersResource } from "./resources/triggers";
+import { PoliciesResource } from "./resources/policies";
 import { WalletsResource } from "./resources/wallets";
 import { WorkflowsResource } from "./resources/workflows";
 
@@ -57,6 +58,7 @@ export class Client {
   readonly health: HealthResource;
   readonly nodes: NodesResource;
   readonly operators: OperatorsResource;
+  readonly policies: PoliciesResource;
   readonly secrets: SecretsResource;
   readonly tokens: TokensResource;
   readonly triggers: TriggersResource;
@@ -80,6 +82,7 @@ export class Client {
     this.health = new HealthResource(this.transport);
     this.nodes = new NodesResource(this.transport);
     this.operators = new OperatorsResource(this.transport);
+    this.policies = new PoliciesResource(this.transport);
     this.secrets = new SecretsResource(this.transport);
     this.tokens = new TokensResource(this.transport);
     this.triggers = new TriggersResource(this.transport);

--- a/packages/sdk-js/src/v4/index.ts
+++ b/packages/sdk-js/src/v4/index.ts
@@ -48,6 +48,8 @@ export { OperatorsResource } from "./resources/operators";
 export { SecretsResource } from "./resources/secrets";
 export { TokensResource } from "./resources/tokens";
 export { TriggersResource } from "./resources/triggers";
+export { PoliciesResource } from "./resources/policies";
+export type { TypedDataSigner } from "./resources/policies";
 export { WalletsResource } from "./resources/wallets";
 export { WorkflowsResource } from "./resources/workflows";
 

--- a/packages/sdk-js/src/v4/resources/policies.ts
+++ b/packages/sdk-js/src/v4/resources/policies.ts
@@ -95,14 +95,19 @@ export class PoliciesResource {
   /**
    * GET /wallets/{address}/policies — the wallet's grants, newest first.
    *
+   * `chainId` is optional: omitted, the gateway uses the JWT's `aud` chain.
+   *
    * Grant material (the install calldata and the owner's signature) is never
    * echoed back; this is the manage screen's read, not a way to recover an
    * authorization.
    */
-  list(address: string, chainId: number): Promise<v4.SessionPolicyList> {
+  list(
+    address: string,
+    opts?: { chainId?: number },
+  ): Promise<v4.SessionPolicyList> {
     return this.transport.request<v4.SessionPolicyList>({
       path: `/wallets/${encodeURIComponent(address)}/policies`,
-      query: { chainId },
+      query: opts,
     });
   }
 
@@ -110,11 +115,11 @@ export class PoliciesResource {
   get(
     address: string,
     policyId: string,
-    chainId: number,
+    opts?: { chainId?: number },
   ): Promise<v4.SessionPolicy> {
     return this.transport.request<v4.SessionPolicy>({
       path: `/wallets/${encodeURIComponent(address)}/policies/${encodeURIComponent(policyId)}`,
-      query: { chainId },
+      query: opts,
     });
   }
 
@@ -134,12 +139,12 @@ export class PoliciesResource {
   revoke(
     address: string,
     policyId: string,
-    chainId: number,
+    opts?: { chainId?: number },
   ): Promise<v4.RevokePolicyResponse> {
     return this.transport.request<v4.RevokePolicyResponse>({
       path: `/wallets/${encodeURIComponent(address)}/policies/${encodeURIComponent(policyId)}`,
       method: "DELETE",
-      query: { chainId },
+      query: opts,
     });
   }
 

--- a/packages/sdk-js/src/v4/resources/policies.ts
+++ b/packages/sdk-js/src/v4/resources/policies.ts
@@ -1,0 +1,184 @@
+import type { v4 } from "@avaprotocol/types";
+
+import { Transport } from "../internal/transport";
+
+/**
+ * Signs an EIP-712 payload and returns a 65-byte `0x…` signature.
+ *
+ * This is the wallet's `eth_signTypedData_v4`. It is passed in rather than
+ * built here because the SDK has no opinion about how the owner's key is
+ * held — a browser wallet, a hardware signer, and a test key all satisfy it.
+ *
+ * With viem:
+ * ```ts
+ * const sign = (typedData) => walletClient.signTypedData(typedData as never);
+ * ```
+ * With ethers v6:
+ * ```ts
+ * const sign = ({ domain, types, message }: any) =>
+ *   signer.signTypedData(domain, omitEIP712Domain(types), message);
+ * ```
+ */
+export type TypedDataSigner = (
+  typedData: Readonly<Record<string, unknown>>,
+) => Promise<string>;
+
+/**
+ * `client.policies.*` — session policies, the grant that lets the gateway
+ * execute on a smart wallet.
+ *
+ * Why this exists at all: an Alchemy Modular Account v2 trusts exactly one
+ * signer, the owner's EOA, and the gateway does not hold that key. So the
+ * gateway can only act through a validation entity the owner has explicitly
+ * installed. A policy IS that grant — scoped to specific targets and
+ * selectors, capped in ERC-20 spend, and time-bounded.
+ *
+ * Granting is deliberately two calls. The owner signs an EIP-712 payload that
+ * cannot exist until the gateway has allocated an entity and computed the
+ * nonce the installing operation will use, so `prepare` returns the payload
+ * and `submit` takes the signature back. Nothing reaches the chain in either:
+ * the install rides the first workflow operation on that wallet, which is why
+ * a grant is gasless to authorize and free to revoke before it is used.
+ *
+ * Every endpoint requires the owner's own JWT. A partner assertion is refused
+ * outright — granting spend authority needs proven wallet ownership, not a
+ * partner's word for it.
+ */
+export class PoliciesResource {
+  constructor(private readonly transport: Transport) {}
+
+  /**
+   * POST /wallets/{address}/policies:prepare — allocate the grant and get
+   * the payload to sign.
+   *
+   * Stores nothing. A prepare that is never submitted leaves no state, so
+   * abandoning the grant screen costs the user nothing.
+   *
+   * The returned `policyId`, `entityId`, `deadline`, and `validUntil` must be
+   * echoed verbatim to {@link submit}: the gateway rebuilds the grant from
+   * them, so altering one only produces a signature that no longer verifies.
+   * Prefer {@link grant}, which handles the echoing for you.
+   */
+  prepare(
+    address: string,
+    req: v4.PreparePolicyRequest,
+  ): Promise<v4.PreparedPolicy> {
+    return this.transport.request<v4.PreparedPolicy>({
+      path: `/wallets/${encodeURIComponent(address)}/policies:prepare`,
+      method: "POST",
+      body: req,
+    });
+  }
+
+  /**
+   * POST /wallets/{address}/policies:submit — hand back the owner's
+   * signature and persist the grant.
+   *
+   * Returns the policy as `pending`: authorized, but not yet on chain. It
+   * becomes `active` when the first workflow operation applies the install.
+   *
+   * A 409 means the validation entity was taken by another grant while this
+   * one was being signed — prepare again rather than retrying the submit,
+   * since the entity is baked into the signed calldata.
+   */
+  submit(
+    address: string,
+    req: v4.SubmitPolicyRequest,
+  ): Promise<v4.SessionPolicy> {
+    return this.transport.request<v4.SessionPolicy>({
+      path: `/wallets/${encodeURIComponent(address)}/policies:submit`,
+      method: "POST",
+      body: req,
+    });
+  }
+
+  /**
+   * GET /wallets/{address}/policies — the wallet's grants, newest first.
+   *
+   * Grant material (the install calldata and the owner's signature) is never
+   * echoed back; this is the manage screen's read, not a way to recover an
+   * authorization.
+   */
+  list(address: string, chainId: number): Promise<v4.SessionPolicyList> {
+    return this.transport.request<v4.SessionPolicyList>({
+      path: `/wallets/${encodeURIComponent(address)}/policies`,
+      query: { chainId },
+    });
+  }
+
+  /** GET /wallets/{address}/policies/{policyId} — one grant. */
+  get(
+    address: string,
+    policyId: string,
+    chainId: number,
+  ): Promise<v4.SessionPolicy> {
+    return this.transport.request<v4.SessionPolicy>({
+      path: `/wallets/${encodeURIComponent(address)}/policies/${encodeURIComponent(policyId)}`,
+      query: { chainId },
+    });
+  }
+
+  /**
+   * DELETE /wallets/{address}/policies/{policyId} — revoke.
+   *
+   * Before the grant's first use this is complete on its own: nothing was
+   * installed, so deleting the authorization ends it. Afterwards the
+   * validation module is still on the account and clearing it needs a
+   * separate on-chain uninstall — the gateway stops using the grant either
+   * way, but only the first case leaves nothing behind.
+   */
+  revoke(
+    address: string,
+    policyId: string,
+    chainId: number,
+  ): Promise<v4.SessionPolicy> {
+    return this.transport.request<v4.SessionPolicy>({
+      path: `/wallets/${encodeURIComponent(address)}/policies/${encodeURIComponent(policyId)}`,
+      method: "DELETE",
+      query: { chainId },
+    });
+  }
+
+  /**
+   * The whole grant in one call: prepare, sign, submit.
+   *
+   * This is what a grant screen wants. It echoes the prepared allocations
+   * back verbatim, which is the part that is easy to get subtly wrong by
+   * hand — `validUntil` in particular is an ABSOLUTE timestamp baked into the
+   * signed calldata, so recomputing it from `expiresInSeconds` at submit time
+   * changes the digest and the signature stops verifying.
+   *
+   * ```ts
+   * const policy = await client.policies.grant(wallet, {
+   *   chainId: 11155111,
+   *   agentLabel: "TradingBot",
+   *   allowedActions: [{ target: usdc, selectors: ["0x095ea7b3"] }],
+   *   erc20SpendCap: { token: usdc, amount: "500000000" },
+   *   expiresInSeconds: 30 * 24 * 60 * 60,
+   * }, (typedData) => walletClient.signTypedData(typedData as never));
+   * ```
+   */
+  async grant(
+    address: string,
+    req: v4.PreparePolicyRequest,
+    sign: TypedDataSigner,
+  ): Promise<v4.SessionPolicy> {
+    const prepared = await this.prepare(address, req);
+    const signature = await sign(prepared.typedData);
+
+    return this.submit(address, {
+      chainId: prepared.chainId,
+      policyId: prepared.policyId,
+      entityId: prepared.entityId,
+      deadline: prepared.deadline,
+      // Absolute, from prepare — NOT recomputed. It is inside the signed
+      // calldata, so a recomputed value invalidates the signature.
+      validUntil: prepared.validUntil,
+      agentLabel: req.agentLabel,
+      justification: req.justification,
+      allowedActions: req.allowedActions,
+      erc20SpendCap: req.erc20SpendCap,
+      signature,
+    });
+  }
+}

--- a/packages/sdk-js/src/v4/resources/policies.ts
+++ b/packages/sdk-js/src/v4/resources/policies.ts
@@ -126,13 +126,17 @@ export class PoliciesResource {
    * validation module is still on the account and clearing it needs a
    * separate on-chain uninstall — the gateway stops using the grant either
    * way, but only the first case leaves nothing behind.
+   *
+   * The response says which happened: `deleted` when the grant never reached
+   * the chain, `revoked` when the record is retained for audit because a
+   * module is still installed.
    */
   revoke(
     address: string,
     policyId: string,
     chainId: number,
-  ): Promise<v4.SessionPolicy> {
-    return this.transport.request<v4.SessionPolicy>({
+  ): Promise<v4.RevokePolicyResponse> {
+    return this.transport.request<v4.RevokePolicyResponse>({
       path: `/wallets/${encodeURIComponent(address)}/policies/${encodeURIComponent(policyId)}`,
       method: "DELETE",
       query: { chainId },

--- a/packages/types/openapi/openapi.yaml
+++ b/packages/types/openapi/openapi.yaml
@@ -1639,6 +1639,180 @@ components:
           type: array
           items: { $ref: '#/components/schemas/OperatorInfo' }
 
+    # -------------------------------------------------------------------
+    # Session policies
+    # -------------------------------------------------------------------
+
+    AllowedAction:
+      type: object
+      required: [target, selectors]
+      properties:
+        target:
+          $ref: '#/components/schemas/EthereumAddress'
+        selectors:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            pattern: '^0x[a-fA-F0-9]{8}$'
+          description: 4-byte function selectors permitted on the target.
+      description: One contract the agent may call, scoped to selectors.
+
+    Erc20SpendCap:
+      type: object
+      required: [token, amount]
+      properties:
+        token:
+          $ref: '#/components/schemas/EthereumAddress'
+        amount:
+          type: string
+          pattern: '^[0-9]+$'
+          description: Total cap in the token's smallest unit (decimal string, no reset).
+          example: '500000000'
+      description: |
+        Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+        token must appear as an `allowedActions` target.
+
+    PreparePolicyRequest:
+      type: object
+      required: [chainId, agentLabel, allowedActions, erc20SpendCap, expiresInSeconds]
+      properties:
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        agentLabel:
+          type: string
+          minLength: 1
+          maxLength: 120
+        justification:
+          type: string
+          maxLength: 500
+        allowedActions:
+          type: array
+          minItems: 1
+          items: { $ref: '#/components/schemas/AllowedAction' }
+        erc20SpendCap: { $ref: '#/components/schemas/Erc20SpendCap' }
+        expiresInSeconds:
+          type: integer
+          format: int64
+          minimum: 60
+          description: Grant lifetime, relative (skew-proof). Becomes an absolute validUntil.
+
+    PreparedPolicy:
+      type: object
+      required: [policyId, chainId, entityId, sessionSigner, deadline, validUntil, digest, typedData]
+      properties:
+        policyId: { $ref: '#/components/schemas/Ulid' }
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        entityId:
+          type: integer
+          format: int64
+          description: The validation entity allocated for this grant (provisional until submit).
+        sessionSigner:
+          $ref: '#/components/schemas/EthereumAddress'
+        deadline:
+          type: integer
+          format: int64
+          description: Unix seconds; bounds signing → first use, NOT the grant lifetime.
+        validUntil:
+          type: integer
+          format: int64
+          description: Absolute grant expiry, unix milliseconds. Echo verbatim to submit.
+        digest:
+          type: string
+          pattern: '^0x[a-fA-F0-9]{64}$'
+          description: The EIP-712 hash the typed data produces, for client-side verification.
+        typedData:
+          type: object
+          additionalProperties: true
+          description: The exact eth_signTypedData_v4 payload for the owner's wallet.
+
+    SubmitPolicyRequest:
+      type: object
+      required: [chainId, policyId, entityId, deadline, validUntil, agentLabel, allowedActions, erc20SpendCap, signature]
+      properties:
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        policyId: { $ref: '#/components/schemas/Ulid' }
+        entityId:
+          type: integer
+          format: int64
+        deadline:
+          type: integer
+          format: int64
+        validUntil:
+          type: integer
+          format: int64
+          description: The ABSOLUTE expiry from prepare. It is baked into the signed calldata; recomputing it would change the digest.
+        agentLabel:
+          type: string
+          minLength: 1
+          maxLength: 120
+        justification:
+          type: string
+          maxLength: 500
+        allowedActions:
+          type: array
+          minItems: 1
+          items: { $ref: '#/components/schemas/AllowedAction' }
+        erc20SpendCap: { $ref: '#/components/schemas/Erc20SpendCap' }
+        signature:
+          type: string
+          pattern: '^0x[a-fA-F0-9]{130}$'
+          description: The owner's 65-byte signature over the prepared digest.
+
+    SessionPolicy:
+      type: object
+      required: [id, runner, chainId, status, entityId, sessionSigner, agentLabel, validUntil, createdAt]
+      properties:
+        id: { $ref: '#/components/schemas/Ulid' }
+        runner: { $ref: '#/components/schemas/EthereumAddress' }
+        chainId: { $ref: '#/components/schemas/ChainId' }
+        status:
+          type: string
+          enum: [pending, active, revoked]
+          description: |
+            pending = signed and stored, install not yet on-chain (revocable
+            for free). active = install applied. revoked = grants nothing.
+        entityId:
+          type: integer
+          format: int64
+        sessionSigner:
+          $ref: '#/components/schemas/EthereumAddress'
+        agentLabel: { type: string }
+        justification: { type: string }
+        allowedActions:
+          type: array
+          items: { $ref: '#/components/schemas/AllowedAction' }
+        erc20SpendCap: { $ref: '#/components/schemas/Erc20SpendCap' }
+        validUntil:
+          type: integer
+          format: int64
+          description: Unix milliseconds.
+        createdAt:
+          type: integer
+          format: int64
+          description: Unix milliseconds.
+
+    SessionPolicyList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/SessionPolicy' }
+
+    RevokePolicyResponse:
+      type: object
+      required: [status, onChainCleanupRequired]
+      properties:
+        status:
+          type: string
+          enum: [deleted, revoked]
+          description: deleted = was pending, nothing was ever installed. revoked = retained for audit.
+        onChainCleanupRequired:
+          type: boolean
+          description: |
+            True when the grant's validation is still installed on the
+            account and needs the owner's uninstallValidation to clear.
+
   responses:
     BadRequest:
       description: Request validation failed.
@@ -2343,6 +2517,153 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/NonceResponse' }
         '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  # =====================================================================
+  # Session policies — grants of execution authority on a wallet
+  # =====================================================================
+  # A policy is the record behind the grant screen: which agent may act on a
+  # wallet, bounded by allowed actions, an ERC-20 spend cap, and an expiry.
+  # Granting is prepare → sign → submit: the wallet needs the EIP-712 payload
+  # before the owner can sign it, and nothing is stored until the signature
+  # comes back. Fund authority — never reachable through a partner assertion.
+
+  /wallets/{address}/policies:prepare:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+    post:
+      tags: [Policies]
+      summary: Allocate a grant and return the EIP-712 payload the owner signs
+      description: |
+        Allocates the policy id, validation entity, and session signer, builds
+        the exact `installValidation` calldata the signature will commit to,
+        and returns the typed data for `eth_signTypedData_v4`. Stores nothing:
+        a prepare that is never submitted leaves no state behind. The echoed
+        fields must be passed back verbatim to `:submit` — the gateway
+        recomputes everything from them, so tampering only produces a
+        signature that no longer verifies.
+      operationId: prepareWalletPolicy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/PreparePolicyRequest' }
+      responses:
+        '200':
+          description: Payload to sign, plus the allocations submit must echo.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PreparedPolicy' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /wallets/{address}/policies:submit:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+    post:
+      tags: [Policies]
+      summary: Submit the owner's signature and persist the grant
+      description: |
+        Recomputes the grant from the echoed prepare fields, verifies the
+        signature recovers to the authenticated owner, re-checks the entity
+        allocation inside the write, and stores the policy as `pending`. The
+        install itself rides the first workflow operation on this wallet —
+        nothing reaches the chain here.
+      operationId: submitWalletPolicy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SubmitPolicyRequest' }
+      responses:
+        '201':
+          description: Grant stored; the gateway may now execute within it.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SessionPolicy' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409':
+          description: |
+            The validation entity was taken by another grant while this one
+            was being signed. Prepare again.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+
+  /wallets/{address}/policies:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+      - $ref: '#/components/parameters/ChainIdQuery'
+    get:
+      tags: [Policies]
+      summary: List the wallet's session policies
+      description: Grant material (calldata, signatures) is never echoed.
+      operationId: listWalletPolicies
+      responses:
+        '200':
+          description: Policies for this wallet, newest first.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SessionPolicyList' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /wallets/{address}/policies/{policyId}:
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/EthereumAddress' }
+      - name: policyId
+        in: path
+        required: true
+        schema: { $ref: '#/components/schemas/Ulid' }
+      - $ref: '#/components/parameters/ChainIdQuery'
+    get:
+      tags: [Policies]
+      summary: Get one session policy
+      operationId: getWalletPolicy
+      responses:
+        '200':
+          description: The policy.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SessionPolicy' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    delete:
+      tags: [Policies]
+      summary: Revoke a session policy
+      description: |
+        A `pending` grant (never used on-chain) is deleted outright — nothing
+        was installed, so nothing remains. An `active` grant stops authorizing
+        immediately, but its on-chain validation still exists until the owner
+        executes `uninstallValidation`; the response says which case applied.
+      operationId: revokeWalletPolicy
+      responses:
+        '200':
+          description: Revocation outcome.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RevokePolicyResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
   # =====================================================================

--- a/packages/types/src/openapi.gen.ts
+++ b/packages/types/src/openapi.gen.ts
@@ -526,6 +526,121 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/wallets/{address}/policies:prepare": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly address: components["schemas"]["EthereumAddress"];
+            };
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /**
+         * Allocate a grant and return the EIP-712 payload the owner signs
+         * @description Allocates the policy id, validation entity, and session signer, builds
+         *     the exact `installValidation` calldata the signature will commit to,
+         *     and returns the typed data for `eth_signTypedData_v4`. Stores nothing:
+         *     a prepare that is never submitted leaves no state behind. The echoed
+         *     fields must be passed back verbatim to `:submit` — the gateway
+         *     recomputes everything from them, so tampering only produces a
+         *     signature that no longer verifies.
+         */
+        readonly post: operations["prepareWalletPolicy"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/wallets/{address}/policies:submit": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly address: components["schemas"]["EthereumAddress"];
+            };
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /**
+         * Submit the owner's signature and persist the grant
+         * @description Recomputes the grant from the echoed prepare fields, verifies the
+         *     signature recovers to the authenticated owner, re-checks the entity
+         *     allocation inside the write, and stores the policy as `pending`. The
+         *     install itself rides the first workflow operation on this wallet —
+         *     nothing reaches the chain here.
+         */
+        readonly post: operations["submitWalletPolicy"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/wallets/{address}/policies": {
+        readonly parameters: {
+            readonly query?: {
+                /**
+                 * @description The chain to operate on (a single value). Omit to use the aggregator
+                 *     default (the request's JWT `aud` chain, then the gateway default).
+                 */
+                readonly chainId?: components["parameters"]["ChainIdQuery"];
+            };
+            readonly header?: never;
+            readonly path: {
+                readonly address: components["schemas"]["EthereumAddress"];
+            };
+            readonly cookie?: never;
+        };
+        /**
+         * List the wallet's session policies
+         * @description Grant material (calldata, signatures) is never echoed.
+         */
+        readonly get: operations["listWalletPolicies"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/wallets/{address}/policies/{policyId}": {
+        readonly parameters: {
+            readonly query?: {
+                /**
+                 * @description The chain to operate on (a single value). Omit to use the aggregator
+                 *     default (the request's JWT `aud` chain, then the gateway default).
+                 */
+                readonly chainId?: components["parameters"]["ChainIdQuery"];
+            };
+            readonly header?: never;
+            readonly path: {
+                readonly address: components["schemas"]["EthereumAddress"];
+                readonly policyId: components["schemas"]["Ulid"];
+            };
+            readonly cookie?: never;
+        };
+        /** Get one session policy */
+        readonly get: operations["getWalletPolicy"];
+        readonly put?: never;
+        readonly post?: never;
+        /**
+         * Revoke a session policy
+         * @description A `pending` grant (never used on-chain) is deleted outright — nothing
+         *     was installed, so nothing remains. An `active` grant stops authorizing
+         *     immediately, but its on-chain validation still exists until the owner
+         *     executes `uninstallValidation`; the response says which case applied.
+         */
+        readonly delete: operations["revokeWalletPolicy"];
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/secrets": {
         readonly parameters: {
             readonly query?: never;
@@ -1713,6 +1828,124 @@ export interface components {
         readonly OperatorList: {
             readonly data: readonly components["schemas"]["OperatorInfo"][];
         };
+        /** @description One contract the agent may call, scoped to selectors. */
+        readonly AllowedAction: {
+            readonly target: components["schemas"]["EthereumAddress"];
+            /** @description 4-byte function selectors permitted on the target. */
+            readonly selectors: readonly string[];
+        };
+        /**
+         * @description Cumulative ERC-20 spend cap, enforced on-chain at execution. The
+         *     token must appear as an `allowedActions` target.
+         */
+        readonly Erc20SpendCap: {
+            readonly token: components["schemas"]["EthereumAddress"];
+            /**
+             * @description Total cap in the token's smallest unit (decimal string, no reset).
+             * @example 500000000
+             */
+            readonly amount: string;
+        };
+        readonly PreparePolicyRequest: {
+            readonly chainId: components["schemas"]["ChainId"];
+            readonly agentLabel: string;
+            readonly justification?: string;
+            readonly allowedActions: readonly components["schemas"]["AllowedAction"][];
+            readonly erc20SpendCap: components["schemas"]["Erc20SpendCap"];
+            /**
+             * Format: int64
+             * @description Grant lifetime, relative (skew-proof). Becomes an absolute validUntil.
+             */
+            readonly expiresInSeconds: number;
+        };
+        readonly PreparedPolicy: {
+            readonly policyId: components["schemas"]["Ulid"];
+            readonly chainId: components["schemas"]["ChainId"];
+            /**
+             * Format: int64
+             * @description The validation entity allocated for this grant (provisional until submit).
+             */
+            readonly entityId: number;
+            readonly sessionSigner: components["schemas"]["EthereumAddress"];
+            /**
+             * Format: int64
+             * @description Unix seconds; bounds signing → first use, NOT the grant lifetime.
+             */
+            readonly deadline: number;
+            /**
+             * Format: int64
+             * @description Absolute grant expiry, unix milliseconds. Echo verbatim to submit.
+             */
+            readonly validUntil: number;
+            /** @description The EIP-712 hash the typed data produces, for client-side verification. */
+            readonly digest: string;
+            /** @description The exact eth_signTypedData_v4 payload for the owner's wallet. */
+            readonly typedData: {
+                readonly [key: string]: unknown;
+            };
+        };
+        readonly SubmitPolicyRequest: {
+            readonly chainId: components["schemas"]["ChainId"];
+            readonly policyId: components["schemas"]["Ulid"];
+            /** Format: int64 */
+            readonly entityId: number;
+            /** Format: int64 */
+            readonly deadline: number;
+            /**
+             * Format: int64
+             * @description The ABSOLUTE expiry from prepare. It is baked into the signed calldata; recomputing it would change the digest.
+             */
+            readonly validUntil: number;
+            readonly agentLabel: string;
+            readonly justification?: string;
+            readonly allowedActions: readonly components["schemas"]["AllowedAction"][];
+            readonly erc20SpendCap: components["schemas"]["Erc20SpendCap"];
+            /** @description The owner's 65-byte signature over the prepared digest. */
+            readonly signature: string;
+        };
+        readonly SessionPolicy: {
+            readonly id: components["schemas"]["Ulid"];
+            readonly runner: components["schemas"]["EthereumAddress"];
+            readonly chainId: components["schemas"]["ChainId"];
+            /**
+             * @description pending = signed and stored, install not yet on-chain (revocable
+             *     for free). active = install applied. revoked = grants nothing.
+             * @enum {string}
+             */
+            readonly status: "pending" | "active" | "revoked";
+            /** Format: int64 */
+            readonly entityId: number;
+            readonly sessionSigner: components["schemas"]["EthereumAddress"];
+            readonly agentLabel: string;
+            readonly justification?: string;
+            readonly allowedActions?: readonly components["schemas"]["AllowedAction"][];
+            readonly erc20SpendCap?: components["schemas"]["Erc20SpendCap"];
+            /**
+             * Format: int64
+             * @description Unix milliseconds.
+             */
+            readonly validUntil: number;
+            /**
+             * Format: int64
+             * @description Unix milliseconds.
+             */
+            readonly createdAt: number;
+        };
+        readonly SessionPolicyList: {
+            readonly items: readonly components["schemas"]["SessionPolicy"][];
+        };
+        readonly RevokePolicyResponse: {
+            /**
+             * @description deleted = was pending, nothing was ever installed. revoked = retained for audit.
+             * @enum {string}
+             */
+            readonly status: "deleted" | "revoked";
+            /**
+             * @description True when the grant's validation is still installed on the
+             *     account and needs the owner's uninstallValidation to clear.
+             */
+            readonly onChainCleanupRequired: boolean;
+        };
     };
     responses: {
         /** @description Request validation failed. */
@@ -2497,6 +2730,173 @@ export interface operations {
                 };
             };
             readonly 401: components["responses"]["Unauthorized"];
+            readonly 404: components["responses"]["NotFound"];
+        };
+    };
+    readonly prepareWalletPolicy: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly address: components["schemas"]["EthereumAddress"];
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["PreparePolicyRequest"];
+            };
+        };
+        readonly responses: {
+            /** @description Payload to sign, plus the allocations submit must echo. */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["PreparedPolicy"];
+                };
+            };
+            readonly 400: components["responses"]["BadRequest"];
+            readonly 401: components["responses"]["Unauthorized"];
+            readonly 403: components["responses"]["Forbidden"];
+            readonly 404: components["responses"]["NotFound"];
+        };
+    };
+    readonly submitWalletPolicy: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly address: components["schemas"]["EthereumAddress"];
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["SubmitPolicyRequest"];
+            };
+        };
+        readonly responses: {
+            /** @description Grant stored; the gateway may now execute within it. */
+            readonly 201: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["SessionPolicy"];
+                };
+            };
+            readonly 400: components["responses"]["BadRequest"];
+            readonly 401: components["responses"]["Unauthorized"];
+            readonly 403: components["responses"]["Forbidden"];
+            readonly 404: components["responses"]["NotFound"];
+            /**
+             * @description The validation entity was taken by another grant while this one
+             *     was being signed. Prepare again.
+             */
+            readonly 409: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    readonly listWalletPolicies: {
+        readonly parameters: {
+            readonly query?: {
+                /**
+                 * @description The chain to operate on (a single value). Omit to use the aggregator
+                 *     default (the request's JWT `aud` chain, then the gateway default).
+                 */
+                readonly chainId?: components["parameters"]["ChainIdQuery"];
+            };
+            readonly header?: never;
+            readonly path: {
+                readonly address: components["schemas"]["EthereumAddress"];
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Policies for this wallet, newest first. */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["SessionPolicyList"];
+                };
+            };
+            readonly 401: components["responses"]["Unauthorized"];
+            readonly 403: components["responses"]["Forbidden"];
+            readonly 404: components["responses"]["NotFound"];
+        };
+    };
+    readonly getWalletPolicy: {
+        readonly parameters: {
+            readonly query?: {
+                /**
+                 * @description The chain to operate on (a single value). Omit to use the aggregator
+                 *     default (the request's JWT `aud` chain, then the gateway default).
+                 */
+                readonly chainId?: components["parameters"]["ChainIdQuery"];
+            };
+            readonly header?: never;
+            readonly path: {
+                readonly address: components["schemas"]["EthereumAddress"];
+                readonly policyId: components["schemas"]["Ulid"];
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description The policy. */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["SessionPolicy"];
+                };
+            };
+            readonly 401: components["responses"]["Unauthorized"];
+            readonly 403: components["responses"]["Forbidden"];
+            readonly 404: components["responses"]["NotFound"];
+        };
+    };
+    readonly revokeWalletPolicy: {
+        readonly parameters: {
+            readonly query?: {
+                /**
+                 * @description The chain to operate on (a single value). Omit to use the aggregator
+                 *     default (the request's JWT `aud` chain, then the gateway default).
+                 */
+                readonly chainId?: components["parameters"]["ChainIdQuery"];
+            };
+            readonly header?: never;
+            readonly path: {
+                readonly address: components["schemas"]["EthereumAddress"];
+                readonly policyId: components["schemas"]["Ulid"];
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Revocation outcome. */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["RevokePolicyResponse"];
+                };
+            };
+            readonly 401: components["responses"]["Unauthorized"];
+            readonly 403: components["responses"]["Forbidden"];
             readonly 404: components["responses"]["NotFound"];
         };
     };

--- a/packages/types/src/v4.ts
+++ b/packages/types/src/v4.ts
@@ -91,6 +91,21 @@ export type WithdrawResponse = components["schemas"]["WithdrawResponse"];
 export type NonceResponse = components["schemas"]["NonceResponse"];
 
 // ---------------------------------------------------------------------
+// Session policies — the grant that lets the gateway execute for a wallet
+// ---------------------------------------------------------------------
+
+export type SessionPolicy = components["schemas"]["SessionPolicy"];
+export type SessionPolicyList = components["schemas"]["SessionPolicyList"];
+// Status is an inline enum on SessionPolicy rather than its own schema, so
+// it is derived from the parent — keeping it in step automatically.
+export type SessionPolicyStatus = SessionPolicy["status"];
+export type PreparePolicyRequest = components["schemas"]["PreparePolicyRequest"];
+export type PreparedPolicy = components["schemas"]["PreparedPolicy"];
+export type SubmitPolicyRequest = components["schemas"]["SubmitPolicyRequest"];
+export type AllowedAction = components["schemas"]["AllowedAction"];
+export type Erc20SpendCap = components["schemas"]["Erc20SpendCap"];
+
+// ---------------------------------------------------------------------
 // Secrets, tokens, operators, auth, problem
 // ---------------------------------------------------------------------
 

--- a/packages/types/src/v4.ts
+++ b/packages/types/src/v4.ts
@@ -104,6 +104,7 @@ export type PreparedPolicy = components["schemas"]["PreparedPolicy"];
 export type SubmitPolicyRequest = components["schemas"]["SubmitPolicyRequest"];
 export type AllowedAction = components["schemas"]["AllowedAction"];
 export type Erc20SpendCap = components["schemas"]["Erc20SpendCap"];
+export type RevokePolicyResponse = components["schemas"]["RevokePolicyResponse"];
 
 // ---------------------------------------------------------------------
 // Secrets, tokens, operators, auth, problem

--- a/tests/v4/core/policies.test.ts
+++ b/tests/v4/core/policies.test.ts
@@ -1,0 +1,172 @@
+/**
+ * `client.policies.grant()` against a stand-in gateway.
+ *
+ * This suite needs no real gateway: the SDK's own HTTP leaves the test
+ * process, so a local listener can play the gateway and assert exactly what
+ * the SDK sent. That is the point — the logic worth protecting here is not
+ * "does the request reach the server", it is "does submit echo prepare's
+ * allocations byte for byte".
+ *
+ * Why that matters: `validUntil` is an ABSOLUTE timestamp baked into the
+ * install calldata the owner signs. Recomputing it at submit time from
+ * `expiresInSeconds` — the obvious-looking thing to do, since that is what
+ * the caller supplied — changes the digest, and the signature silently stops
+ * verifying. The failure surfaces on chain, much later, as an invalid
+ * signature that names nothing.
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { Client } from "@avaprotocol/sdk-js";
+import type { v4 } from "@avaprotocol/types";
+
+interface Captured {
+  prepareBody?: Record<string, unknown>;
+  submitBody?: Record<string, unknown>;
+  paths: string[];
+}
+
+const PREPARED = {
+  policyId: "01JABCDEF0000000000000000",
+  chainId: 11155111,
+  entityId: 7,
+  sessionSigner: "0x82F2Dd9a552a69f2ceD7Ff2D05c43aB8430158FB",
+  deadline: 1785541743,
+  // Deliberately unrelated to expiresInSeconds below, so a recomputed value
+  // cannot coincidentally match.
+  validUntil: 1799999999000,
+  digest: `0x${"ab".repeat(32)}`,
+  typedData: { domain: { chainId: 11155111 }, message: { nonce: "0x1" } },
+} satisfies v4.PreparedPolicy;
+
+async function startGateway(captured: Captured): Promise<{ url: string; close: () => Promise<void> }> {
+  const server: Server = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      const path = req.url ?? "";
+      captured.paths.push(path);
+      const body = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+      res.setHeader("content-type", "application/json");
+
+      if (path.includes("policies:prepare")) {
+        captured.prepareBody = body;
+        res.statusCode = 200;
+        res.end(JSON.stringify(PREPARED));
+        return;
+      }
+      if (path.includes("policies:submit")) {
+        captured.submitBody = body;
+        res.statusCode = 201;
+        res.end(JSON.stringify({ id: PREPARED.policyId, status: "pending" }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end("{}");
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe("policies.grant", () => {
+  const wallet = "0x209eb31c199bEB4c386eF83CF442DE1a00667a1F";
+  const request: v4.PreparePolicyRequest = {
+    chainId: 11155111,
+    agentLabel: "TradingBot",
+    justification: "Execute swaps you approve in chat",
+    allowedActions: [
+      { target: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238", selectors: ["0x095ea7b3"] },
+    ],
+    erc20SpendCap: {
+      token: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+      amount: "500000000",
+    },
+    expiresInSeconds: 2_592_000,
+  };
+
+  let gateway: { url: string; close: () => Promise<void> };
+  let captured: Captured;
+  let client: Client;
+
+  beforeEach(async () => {
+    captured = { paths: [] };
+    gateway = await startGateway(captured);
+    client = new Client({ baseUrl: `${gateway.url}/api/v1`, token: "test-jwt" });
+  });
+
+  afterEach(async () => {
+    await gateway.close();
+  });
+
+  test("signs the typed data the gateway returned, not something rebuilt", async () => {
+    let signedWith: unknown;
+    await client.policies.grant(wallet, request, async (typedData) => {
+      signedWith = typedData;
+      return `0x${"11".repeat(65)}`;
+    });
+
+    expect(signedWith).toEqual(PREPARED.typedData);
+  });
+
+  test("echoes prepare's allocations verbatim to submit", async () => {
+    await client.policies.grant(wallet, request, async () => `0x${"11".repeat(65)}`);
+
+    const submitted = captured.submitBody!;
+    expect(submitted.policyId).toBe(PREPARED.policyId);
+    expect(submitted.entityId).toBe(PREPARED.entityId);
+    expect(submitted.deadline).toBe(PREPARED.deadline);
+    expect(submitted.chainId).toBe(PREPARED.chainId);
+  });
+
+  test("submits the ABSOLUTE validUntil from prepare, never a recomputed one", async () => {
+    const before = Date.now();
+    await client.policies.grant(wallet, request, async () => `0x${"11".repeat(65)}`);
+
+    const submitted = captured.submitBody!;
+    expect(submitted.validUntil).toBe(PREPARED.validUntil);
+
+    // Guard the specific mistake: deriving it from expiresInSeconds. That
+    // would land near now + 30 days and change the digest the owner signed.
+    const recomputed = before + request.expiresInSeconds * 1000;
+    expect(Math.abs((submitted.validUntil as number) - recomputed)).toBeGreaterThan(60_000);
+  });
+
+  test("carries the grant terms through so the gateway rebuilds the same calldata", async () => {
+    await client.policies.grant(wallet, request, async () => `0x${"11".repeat(65)}`);
+
+    const submitted = captured.submitBody!;
+    expect(submitted.allowedActions).toEqual(request.allowedActions);
+    expect(submitted.erc20SpendCap).toEqual(request.erc20SpendCap);
+    expect(submitted.agentLabel).toBe(request.agentLabel);
+    expect(submitted.justification).toBe(request.justification);
+    expect(submitted.signature).toBe(`0x${"11".repeat(65)}`);
+  });
+
+  test("hits prepare then submit, in that order", async () => {
+    await client.policies.grant(wallet, request, async () => `0x${"11".repeat(65)}`);
+
+    expect(captured.paths).toHaveLength(2);
+    expect(captured.paths[0]).toContain("policies:prepare");
+    expect(captured.paths[1]).toContain("policies:submit");
+  });
+
+  test("a signer that refuses leaves nothing submitted", async () => {
+    await expect(
+      client.policies.grant(wallet, request, async () => {
+        throw new Error("user rejected");
+      }),
+    ).rejects.toThrow("user rejected");
+
+    // Prepare stores nothing server-side, so an abandoned grant screen must
+    // not have reached submit either.
+    expect(captured.submitBody).toBeUndefined();
+    expect(captured.paths).toHaveLength(1);
+  });
+});

--- a/tests/v4/core/policiesLive.test.ts
+++ b/tests/v4/core/policiesLive.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The grant flow against a live gateway.
+ *
+ * `policies.test.ts` proves the SDK sends the right shapes; this proves the
+ * gateway accepts them and that the signature actually verifies. Those are
+ * different failures: a contract mismatch passes the stub and dies here.
+ *
+ * The owner signs with `eth_signTypedData_v4` over the payload the gateway
+ * returned. Nothing reaches the chain — a grant is stored as `pending` and the
+ * on-chain install rides the first workflow operation on that wallet — so this
+ * costs no gas and needs no funded account.
+ */
+
+import { Wallet as EthersWallet } from "ethers";
+
+import { Client } from "@avaprotocol/sdk-js";
+import type { v4 } from "@avaprotocol/types";
+
+import { getClient, authenticateClient, testPrivateKey, TEST_AUTH_CHAIN_ID } from "../../utils/client";
+
+// Sepolia test USDC — the same token the Uniswap fixtures use.
+const TOKEN = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238";
+const APPROVE_SELECTOR = "0x095ea7b3";
+
+/**
+ * ethers signs typed data from (domain, types, message) and rejects the
+ * EIP712Domain entry that eth_signTypedData_v4 payloads carry — it derives
+ * that from the domain itself. Browser wallets take the whole envelope, which
+ * is why the SDK passes it through untouched rather than destructuring.
+ */
+function signTypedDataWithEthers(privateKey: string) {
+  const signer = new EthersWallet(privateKey);
+  return async (typedData: Readonly<Record<string, unknown>>): Promise<string> => {
+    const { domain, types, message } = typedData as {
+      domain: Record<string, unknown>;
+      types: Record<string, unknown>;
+      message: Record<string, unknown>;
+    };
+    const { EIP712Domain: _ignored, ...rest } = types as Record<string, unknown>;
+    return signer.signTypedData(domain as never, rest as never, message as never);
+  };
+}
+
+describe("policies (live gateway)", () => {
+  let client: Client;
+  let owner: string;
+  let wallet: string;
+
+  beforeAll(async () => {
+    client = getClient();
+    await authenticateClient(client);
+    owner = new EthersWallet(testPrivateKey()).address;
+
+    // Salt 0 is the owner's default wallet; ensure-and-register is idempotent.
+    const w = await client.wallets.create({ salt: "0" });
+    wallet = w.address;
+  }, 120_000);
+
+  test("the gateway returns a signable payload and no state", async () => {
+    const prepared = await client.policies.prepare(wallet, request());
+
+    expect(prepared.policyId).toBeTruthy();
+    expect(prepared.entityId).toBeGreaterThanOrEqual(1); // 0 is the owner's own validation
+    expect(prepared.digest).toMatch(/^0x[0-9a-fA-F]{64}$/);
+    expect(prepared.typedData).toBeTruthy();
+
+    // validUntil is absolute and must be echoed to submit, not recomputed.
+    expect(prepared.validUntil).toBeGreaterThan(Date.now());
+
+    // Prepare stores nothing: an abandoned grant screen leaves no policy.
+    const after = await client.policies.list(wallet, TEST_AUTH_CHAIN_ID);
+    expect(after.items.some((p) => p.id === prepared.policyId)).toBe(false);
+  }, 120_000);
+
+  test("a grant signed by the owner is accepted and stored pending", async () => {
+    const policy = await client.policies.grant(
+      wallet,
+      request(),
+      signTypedDataWithEthers(testPrivateKey()),
+    );
+
+    expect(policy.id).toBeTruthy();
+    // Pending, not active: the install rides the first workflow operation.
+    expect(policy.status).toBe("pending");
+
+    const listed = await client.policies.list(wallet, TEST_AUTH_CHAIN_ID);
+    expect(listed.items.some((p) => p.id === policy.id)).toBe(true);
+
+    // Grant material must never be echoed back — this is a read for the
+    // manage screen, not a way to recover an authorization.
+    const fetched = await client.policies.get(wallet, policy.id, TEST_AUTH_CHAIN_ID);
+    expect(JSON.stringify(fetched)).not.toContain("installCall");
+    expect(JSON.stringify(fetched)).not.toContain("ownerSignature");
+
+    // Revoking before first use is complete on its own: nothing was installed.
+    // Never used, so nothing was installed: the record goes away entirely
+    // rather than being retained for audit.
+    const revoked = await client.policies.revoke(wallet, policy.id, TEST_AUTH_CHAIN_ID);
+    expect(revoked.status).toBe("deleted");
+  }, 180_000);
+
+  test("a signature from someone other than the owner is refused", async () => {
+    const stranger = EthersWallet.createRandom();
+    await expect(
+      client.policies.grant(wallet, request(), signTypedDataWithEthers(stranger.privateKey)),
+    ).rejects.toThrow();
+
+    // And nothing was stored for it.
+    const listed = await client.policies.list(wallet, TEST_AUTH_CHAIN_ID);
+    expect(listed.items.every((p) => p.status !== "pending" || p.agentLabel !== "ImposterBot")).toBe(true);
+  }, 180_000);
+
+  function request(label = "TradingBot"): v4.PreparePolicyRequest {
+    return {
+      chainId: TEST_AUTH_CHAIN_ID,
+      agentLabel: label,
+      justification: "Execute swaps you approve in chat",
+      allowedActions: [{ target: TOKEN, selectors: [APPROVE_SELECTOR] }],
+      erc20SpendCap: { token: TOKEN, amount: "500000000" },
+      expiresInSeconds: 30 * 24 * 60 * 60,
+    };
+  }
+});

--- a/tests/v4/core/policiesLive.test.ts
+++ b/tests/v4/core/policiesLive.test.ts
@@ -43,13 +43,11 @@ function signTypedDataWithEthers(privateKey: string) {
 
 describe("policies (live gateway)", () => {
   let client: Client;
-  let owner: string;
   let wallet: string;
 
   beforeAll(async () => {
     client = getClient();
     await authenticateClient(client);
-    owner = new EthersWallet(testPrivateKey()).address;
 
     // Salt 0 is the owner's default wallet; ensure-and-register is idempotent.
     const w = await client.wallets.create({ salt: "0" });
@@ -68,7 +66,7 @@ describe("policies (live gateway)", () => {
     expect(prepared.validUntil).toBeGreaterThan(Date.now());
 
     // Prepare stores nothing: an abandoned grant screen leaves no policy.
-    const after = await client.policies.list(wallet, TEST_AUTH_CHAIN_ID);
+    const after = await client.policies.list(wallet);
     expect(after.items.some((p) => p.id === prepared.policyId)).toBe(false);
   }, 120_000);
 
@@ -83,31 +81,35 @@ describe("policies (live gateway)", () => {
     // Pending, not active: the install rides the first workflow operation.
     expect(policy.status).toBe("pending");
 
-    const listed = await client.policies.list(wallet, TEST_AUTH_CHAIN_ID);
+    const listed = await client.policies.list(wallet);
     expect(listed.items.some((p) => p.id === policy.id)).toBe(true);
 
     // Grant material must never be echoed back — this is a read for the
     // manage screen, not a way to recover an authorization.
-    const fetched = await client.policies.get(wallet, policy.id, TEST_AUTH_CHAIN_ID);
+    const fetched = await client.policies.get(wallet, policy.id);
     expect(JSON.stringify(fetched)).not.toContain("installCall");
     expect(JSON.stringify(fetched)).not.toContain("ownerSignature");
 
     // Revoking before first use is complete on its own: nothing was installed.
     // Never used, so nothing was installed: the record goes away entirely
     // rather than being retained for audit.
-    const revoked = await client.policies.revoke(wallet, policy.id, TEST_AUTH_CHAIN_ID);
+    const revoked = await client.policies.revoke(wallet, policy.id);
     expect(revoked.status).toBe("deleted");
   }, 180_000);
 
   test("a signature from someone other than the owner is refused", async () => {
     const stranger = EthersWallet.createRandom();
+    // A label unique to this attempt, so the assertion below can only be
+    // satisfied by this grant's absence — not by it happening to look like
+    // some other policy on the wallet.
+    const label = `ImposterBot-${Date.now()}`;
+
     await expect(
-      client.policies.grant(wallet, request(), signTypedDataWithEthers(stranger.privateKey)),
+      client.policies.grant(wallet, request(label), signTypedDataWithEthers(stranger.privateKey)),
     ).rejects.toThrow();
 
-    // And nothing was stored for it.
-    const listed = await client.policies.list(wallet, TEST_AUTH_CHAIN_ID);
-    expect(listed.items.every((p) => p.status !== "pending" || p.agentLabel !== "ImposterBot")).toBe(true);
+    const listed = await client.policies.list(wallet);
+    expect(listed.items.some((p) => p.agentLabel === label)).toBe(false);
   }, 180_000);
 
   function request(label = "TradingBot"): v4.PreparePolicyRequest {


### PR DESCRIPTION
`client.policies.*` — the grant that lets the gateway execute on a smart wallet.

Since the MA v2 cutover a smart account trusts exactly one signer, the owner's EOA, and the gateway does not hold that key. It can only act through a validation entity the owner has installed. This is the client surface for creating, listing, and revoking that grant.

## Why granting is two calls

The owner signs an EIP-712 payload that **cannot exist** until the gateway has allocated a validation entity and computed the nonce the installing operation will use. So `prepare` returns the payload and `submit` takes the signature back.

Neither touches the chain. A grant is stored `pending` and the on-chain install rides the first workflow operation on that wallet — which is why authorizing is gasless and revoking before first use is free.

`grant()` does all three steps and exists mainly to get one detail right: prepare's allocations must be echoed to submit **verbatim**. `validUntil` is the trap — an absolute timestamp baked into the calldata the owner signed, so recomputing it from `expiresInSeconds` (the obvious move, since that's what the caller passed) changes the digest and the signature silently stops verifying, surfacing on chain much later as an invalid signature naming nothing. A test pins that specific mistake rather than just asserting equality.

Signing is a caller-supplied callback, not a wallet dependency — browser wallet, hardware signer, and test key all satisfy the same shape.

## Two suites, deliberately

**`policies.test.ts`** — a local listener stands in as the gateway and asserts exactly what the SDK sent. Needs no gateway: the SDK's HTTP leaves the test process, unlike `tests/utils/stubServer.ts`, which exists because the *gateway* makes those requests.

**`policiesLive.test.ts`** — a real gateway, a real signer, a real signature. Running it immediately found two things the stub could not:

1. **Real response shapes.** `SessionPolicyList` is `{ items }`, not `{ data }`; `revoke` returns a `RevokePolicyResponse` distinguishing `deleted` (never installed, record gone) from `revoked` (module still on the account, record retained for audit) — not a `SessionPolicy`. The resource's return type was wrong and is corrected.

2. **A gateway bug.** The prepare response carried `name`/`version`/`salt` as empty strings although its `EIP712Domain` declares only `chainId` and `verifyingContract`. The digest was fine, but ethers v6 rejects `salt: ""` outright — the grant died before the owner was asked to sign. Fixed in **AvaProtocol/EigenLayer-AVS#699**.

The stub tests would have stayed green through that bug forever. It only appeared when a real signer met a real payload.

## Depends on

**AvaProtocol/EigenLayer-AVS#699** must be deployed before `policiesLive.test.ts` passes in CI. Everything else is independent.

## Verified

Against a local gateway built from that fix:

```
tests/v4/core/policiesLive.test.ts   3 passed
tests/v4/core/policies.test.ts       6 passed
tests/v4/core (full)                86 passed, 7 suites
```

Types regenerated from staging's OpenAPI. `SessionPolicyStatus` is derived from its parent rather than aliased — the spec declares it inline, so aliasing a schema that doesn't exist was a build error, and deriving keeps the two in step automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
