### PR TITLE
test: isolate suite state — per-worker/run salts, per-suite identities

### DIFF
--- a/tests/utils/client.ts
+++ b/tests/utils/client.ts
@@ -31,6 +31,32 @@ export function testPrivateKey(): string {
   return requireEnv("TEST_PRIVATE_KEY");
 }
 
+/**
+ * A private EOA for one suite, and the client authenticated as it.
+ *
+ * Unique salts stop two suites sharing a wallet, but they do not help a query
+ * scoped by OWNER — every suite authenticating as TEST_PRIVATE_KEY sees every
+ * other suite's wallets, workflows, and secrets. A suite that asserts on
+ * anything owner-wide is therefore order-dependent no matter how its salts are
+ * allocated.
+ *
+ * A random key removes that entirely: the gateway mints a JWT from any
+ * signature, so identity costs nothing. Use this for CRUD, listing, and
+ * pagination suites.
+ *
+ * It is NOT for suites that need funds. A fresh EOA owns nothing, so anything
+ * sending a real UserOp, spending gas, or touching a pre-funded fixture wallet
+ * must keep using {@link authenticateClient} with the shared key.
+ */
+export async function getIsolatedClient(
+  overrides?: Partial<ClientOptions>,
+): Promise<{ client: Client; owner: string; privateKey: string }> {
+  const wallet = Wallet.createRandom();
+  const client = getClient(overrides);
+  await authenticateClient(client, wallet.privateKey);
+  return { client, owner: wallet.address, privateKey: wallet.privateKey };
+}
+
 /** Returns a fresh, unauthenticated v4 Client pointed at the test stack. */
 export function getClient(overrides?: Partial<ClientOptions>): Client {
   return new Client({
@@ -156,14 +182,57 @@ export async function buildAuthPayload(
 // ---------------------------------------------------------------------
 
 /**
- * Per-process salt counter. Tests pick salts from a high range
- * (1_000+) so they don't collide with user-driven workflows in dev.
+ * Salt allocation, unique per worker AND per run.
  *
- * For most call sites a single `nextTestSalt()` is enough; rare
- * suites that need stable per-test salts can pass an explicit
- * `saltValue` to `createSmartWallet`.
+ * A plain module-level counter is not enough, and the way it failed is worth
+ * keeping in mind. Jest gives every worker its own process, so a counter
+ * seeded at a constant restarts in each one: with 9 workers, nine of them
+ * hand out salt 1001. Same salt + same owner EOA = the *same* smart-wallet
+ * address, so two suites that each believed they had a private wallet were
+ * writing to one. Tests that scope a query by `smartWalletAddress` — the
+ * correct thing to do — still saw the other suite's records, and exact-count
+ * assertions failed intermittently depending on which worker got there first.
+ *
+ * The same reset also repeated salts across runs, so state accumulated on a
+ * handful of addresses instead of spreading. The observable symptom was the
+ * shared test EOA holding only four wallets after many full-suite runs.
+ *
+ * The base therefore mixes two things:
+ *   - JEST_WORKER_ID, so parallel workers never overlap;
+ *   - a per-run seed (CI run id, else the process start time), so today's run
+ *     cannot land on yesterday's wallets.
+ *
+ * Salts stay above 1_000 so they never collide with user-driven wallets in
+ * dev. Note `max_wallets_per_owner` is 2_000 per chain — unique salts mean
+ * wallet records accumulate, so a long-lived shared test EOA needs an
+ * occasional sweep rather than being assumed infinite.
  */
-let saltCursor = 1_000;
+// The two strides must not be able to alias. Worker occupies the low digits
+// and cannot exceed its stride (10k wallets from one worker in one run is far
+// beyond anything the suite does); the run seed occupies digits above that.
+// Getting this backwards silently reintroduces the bug in a subtler form:
+// with a worker stride of 100k and a run stride of 1k, worker 4 of run 555
+// and worker 3 of run 655 both land on 956000 — and since wallet records
+// persist, a later run would inherit an earlier one's state.
+const SALT_WORKER_STRIDE = 10_000;
+const SALT_RUN_STRIDE = 1_000_000;
+
+function saltBase(): number {
+  const worker = Number(process.env.JEST_WORKER_ID ?? 1);
+  // GITHUB_RUN_ID in CI; wall-clock locally. Either way it changes per run.
+  const runSeed = Number(process.env.GITHUB_RUN_ID ?? Date.now()) % 100_000;
+  return 1_000 + runSeed * SALT_RUN_STRIDE + worker * SALT_WORKER_STRIDE;
+}
+
+let saltCursor = saltBase();
+
+/**
+ * A salt no other worker or run will hand out.
+ *
+ * Suites that need a salt stable across re-runs must pass an explicit
+ * `saltValue` to `createSmartWallet` — but be aware that opts out of the
+ * isolation above and shares the wallet with anything else using that salt.
+ */
 export function nextTestSalt(): string {
   saltCursor += 1;
   return String(saltCursor);

--- a/tests/v4/executions/execution.test.ts
+++ b/tests/v4/executions/execution.test.ts
@@ -13,8 +13,7 @@
 import { Client, Triggers } from "@avaprotocol/sdk-js";
 
 import {
-  authenticateClient,
-  getClient,
+  getIsolatedClient,
   getCurrentBlockNumber,
   createSmartWallet,
   nextTestSalt,
@@ -29,8 +28,9 @@ describe("Execution Management Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    // A private EOA for this suite. Salts alone do not isolate an
+    // owner-scoped query, and this suite asserts on exact counts.
+    ({ client } = await getIsolatedClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/executions/getExecutions.test.ts
+++ b/tests/v4/executions/getExecutions.test.ts
@@ -13,8 +13,7 @@
 import { Client, Triggers } from "@avaprotocol/sdk-js";
 
 import {
-  authenticateClient,
-  getClient,
+  getIsolatedClient,
   getCurrentBlockNumber,
   createSmartWallet,
   nextTestSalt,
@@ -49,8 +48,9 @@ describe("executions.list Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    // A private EOA for this suite. Salts alone do not isolate an
+    // owner-scoped query, and this suite asserts on exact counts.
+    ({ client } = await getIsolatedClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/workflows/workflow.test.ts
+++ b/tests/v4/workflows/workflow.test.ts
@@ -14,8 +14,7 @@
 import { Client } from "@avaprotocol/sdk-js";
 
 import {
-  authenticateClient,
-  getClient,
+  getIsolatedClient,
   getEOAAddress,
   createSmartWallet,
   nextTestSalt,
@@ -31,8 +30,9 @@ describe("Workflow Management Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    // A private EOA for this suite. Salts alone do not isolate an
+    // owner-scoped query, and this suite asserts on exact counts.
+    ({ client } = await getIsolatedClient());
     eoaAddress = getEOAAddress();
   });
 


### PR DESCRIPTION
`workflows.list › limit + after cursor` failed intermittently against a shared gateway. The cause turned out to be narrower and more fixable than "shared production state".

## Root cause: salts, not state

```ts
let saltCursor = 1_000;                    // module scope
export function nextTestSalt() { saltCursor += 1; return String(saltCursor); }
```

Jest gives every worker its own process, so that counter restarts in each one. With nine workers, **nine of them hand out salt 1001**. Same salt + same owner EOA derives the *same* smart wallet — so two suites that each believed they had a private wallet were writing to one.

The failing test does scope its query correctly:

```ts
const wallet = await createSmartWallet(client, { saltValue: nextTestSalt() });
await client.workflows.list({ smartWalletAddress: [wallet.address], … });
```

The wallet simply wasn't private, so another suite's workflow landed inside the filter and `3` became `4`.

The same reset repeated salts **across runs**, so state piled onto a handful of addresses instead of spreading. The tell: the shared test EOA held only **4 wallets** after many full-suite runs. If salts were unique that would be in the hundreds.

## Fix 1 — salts unique per worker and per run

Mixes `JEST_WORKER_ID` with a per-run seed (`GITHUB_RUN_ID` in CI, wall clock locally).

**The stride order matters, and the obvious arrangement is wrong.** With a 100k worker stride and a 1k run stride the components alias:

```
worker 4, run 555 -> 956000
worker 3, run 655 -> 956000   ← identical
```

Since wallet records persist, a later run would inherit an earlier one's state — the same bug in a subtler form. Worker now occupies the low digits under a stride it cannot exhaust; the run seed sits above it. Verified exhaustively over 400 runs × 64 workers, probing both ends of each worker's range: **zero collisions**.

## Fix 2 — per-suite identity

Unique salts do nothing for a query scoped by **owner** — every suite authenticating as `TEST_PRIVATE_KEY` sees every other suite's records.

`getIsolatedClient()` mints a random EOA and authenticates as it. Identity is free: the gateway mints a JWT from any signature.

Applied to the three suites that assert exact counts and need no funds. **It is not for funded flows** — a fresh EOA owns nothing, so anything spending gas or touching a pre-funded fixture keeps the shared key, and the helper says so.

Safe here because `createFromTemplate` is a cron trigger plus one `customCode` node with **zero on-chain nodes** — triggering it runs JavaScript in the gateway. The wallet is a `runner` label; it is never deployed.

## Verification (against the deployed gateway, v4.9.1)

```
workflows + executions, 3 consecutive parallel runs:  71 passed each time
full suite:                                          333 passed, 6 skipped  (unchanged)
```

## Not addressed

- The 6 skips are deliberate opt-in gates (`PER_NODE_CHAIN_READY`, `DURABLE_E2E`, `RUN_GUARDIAN_LIVE`) — nothing silently opting out.
- Eight other `list()`-calling suites are **unaudited** for the same owner-scoping pattern. The salt fix helps all of them; the identity fix has only been applied where exact-count assertions were confirmed.
- Whether the full suite should run against production at all is a separate, bigger question — these runs still create real workflows, secrets and policies on a live gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
