### PR TITLE
feat(sdk): uniswapV3Capability grant compile and coverage helpers

### DIFF
--- a/packages/sdk-js/src/v4/builders/sessionPolicy.ts
+++ b/packages/sdk-js/src/v4/builders/sessionPolicy.ts
@@ -148,7 +148,7 @@ export const SessionPolicyActions = Object.freeze({
       router?: string;
     }
   ): v4.AllowedAction[] {
-    if (!opts?.approveTokens?.length) {
+    if (!opts.approveTokens.length) {
       throw new Error(
         "uniswapV3Capability requires at least one approveTokens entry (e.g. USDC and WETH)"
       );
@@ -235,7 +235,9 @@ export function missingActions(
       missing.push({ target: r.target, selectors: [...r.selectors] });
       continue;
     }
-    const uncovered = r.selectors.filter((s) => !set.has(s.toLowerCase()));
+    const uncovered = r.selectors
+      .filter((s) => !set.has(s.toLowerCase()))
+      .map((s) => s.toLowerCase());
     if (uncovered.length > 0) {
       missing.push({ target: r.target, selectors: uncovered });
     }

--- a/packages/sdk-js/src/v4/builders/sessionPolicy.ts
+++ b/packages/sdk-js/src/v4/builders/sessionPolicy.ts
@@ -124,6 +124,47 @@ export const SessionPolicyActions = Object.freeze({
   },
 
   /**
+   * Uniswap V3 capability compile: router `exactInputSingle` plus `approve`
+   * for every ERC-20 the agent may spend as `tokenIn`.
+   *
+   * **Why this exists:** a USDC-only Uniswap grant (router + approve(USDC))
+   * covers USDC→ETH buys but **not** demoted ETH→USDC sells, which need
+   * `approve(WETH)` before `exactInputSingle`. Passing only the spend-cap
+   * token is the historical Studio default and is the root of
+   * FINDINGS_AA23_WETH_SELL_SESSION_SCOPE.md.
+   *
+   * Studio / clients should pass **both** the cap token (e.g. USDC) and
+   * catalog WETH (and any other tradeable `tokenIn`) for Auto mode.
+   *
+   * Cap token / USD notional is still set via `erc20SpendCap` on the policy
+   * request — this helper only builds allowlist rows.
+   */
+  uniswapV3Capability(
+    chainId: number,
+    opts: {
+      /** Tokens the agent may `approve` for the router (must include every tokenIn). */
+      approveTokens: readonly string[];
+      /** Override SwapRouter02 when not using the catalog address. */
+      router?: string;
+    }
+  ): v4.AllowedAction[] {
+    if (!opts?.approveTokens?.length) {
+      throw new Error(
+        "uniswapV3Capability requires at least one approveTokens entry (e.g. USDC and WETH)"
+      );
+    }
+    const actions: v4.AllowedAction[] = [
+      SessionPolicyActions.uniswapV3Swap(chainId, {
+        target: opts.router,
+      }),
+    ];
+    for (const token of opts.approveTokens) {
+      actions.push(SessionPolicyActions.erc20Approve(token));
+    }
+    return SessionPolicyActions.merge(actions);
+  },
+
+  /**
    * Merge actions that share a target, so the grant carries one entry per
    * contract.
    *
@@ -153,3 +194,51 @@ export const SessionPolicyActions = Object.freeze({
     }));
   },
 });
+
+/**
+ * Pure allowlist coverage — does `granted` cover every row in `required`?
+ *
+ * Same semantics Studio's `grantCoverage` uses for action rows (case-insensitive
+ * target + selector). Cap-token / amount / expiry checks stay product-side.
+ *
+ * Used so clients can preflight demoted WETH sells against an existing
+ * USDC-only grant without inventing rows.
+ */
+export function actionsCover(
+  required: readonly v4.AllowedAction[],
+  granted: readonly v4.AllowedAction[]
+): boolean {
+  return missingActions(required, granted).length === 0;
+}
+
+/**
+ * Required `{ target, selectors[] }` rows not fully covered by `granted`.
+ * A required selector is covered when some granted row for the same target
+ * includes it. Partial target coverage returns only the uncovered selectors
+ * on that target (or the whole row if the target is absent).
+ */
+export function missingActions(
+  required: readonly v4.AllowedAction[],
+  granted: readonly v4.AllowedAction[]
+): v4.AllowedAction[] {
+  const byTarget = new Map<string, Set<string>>();
+  for (const g of granted) {
+    const key = g.target.toLowerCase();
+    const set = byTarget.get(key) ?? new Set<string>();
+    for (const s of g.selectors) set.add(s.toLowerCase());
+    byTarget.set(key, set);
+  }
+  const missing: v4.AllowedAction[] = [];
+  for (const r of required) {
+    const set = byTarget.get(r.target.toLowerCase());
+    if (!set) {
+      missing.push({ target: r.target, selectors: [...r.selectors] });
+      continue;
+    }
+    const uncovered = r.selectors.filter((s) => !set.has(s.toLowerCase()));
+    if (uncovered.length > 0) {
+      missing.push({ target: r.target, selectors: uncovered });
+    }
+  }
+  return missing;
+}

--- a/packages/sdk-js/src/v4/index.ts
+++ b/packages/sdk-js/src/v4/index.ts
@@ -18,6 +18,8 @@ export {
   SELECTOR_ERC20_APPROVE,
   SELECTOR_ERC20_TRANSFER,
   SELECTOR_UNISWAP_V3_EXACT_INPUT_SINGLE,
+  actionsCover,
+  missingActions,
 } from "./builders/sessionPolicy";
 export {
   Protocols,

--- a/tests/v4/core/sessionPolicyActions.test.ts
+++ b/tests/v4/core/sessionPolicyActions.test.ts
@@ -127,11 +127,12 @@ describe("SessionPolicyActions", () => {
         approveTokens: [USDC, WETH],
       });
       const router = Protocols.uniswapV3.swapRouter02[SEPOLIA];
+      expect(router).toBeDefined();
       expect(actions).toHaveLength(3);
       const byTarget = Object.fromEntries(
         actions.map((a) => [a.target.toLowerCase(), a.selectors])
       );
-      expect(byTarget[router!.toLowerCase()]).toEqual(["0x04e45aaf"]);
+      expect(byTarget[String(router).toLowerCase()]).toEqual(["0x04e45aaf"]);
       expect(byTarget[USDC.toLowerCase()]).toEqual(["0x095ea7b3"]);
       expect(byTarget[WETH.toLowerCase()]).toEqual(["0x095ea7b3"]);
     });

--- a/tests/v4/core/sessionPolicyActions.test.ts
+++ b/tests/v4/core/sessionPolicyActions.test.ts
@@ -7,10 +7,16 @@
  * later as an operation refused at validation.
  */
 
-import { SessionPolicyActions, Protocols } from "@avaprotocol/sdk-js";
+import {
+  SessionPolicyActions,
+  Protocols,
+  actionsCover,
+  missingActions,
+} from "@avaprotocol/sdk-js";
 
 const SEPOLIA = 11_155_111;
 const USDC = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238";
+const WETH = "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14";
 
 describe("SessionPolicyActions", () => {
   // Selectors verified against `cast sig`. If one of these ever changes it is
@@ -112,6 +118,56 @@ describe("SessionPolicyActions", () => {
         SessionPolicyActions.erc20Approve(USDC),
       ]);
       expect(merged[0].selectors).toEqual(["0x095ea7b3"]);
+    });
+  });
+
+  describe("uniswapV3Capability", () => {
+    test("includes router exactInputSingle and approve for each token", () => {
+      const actions = SessionPolicyActions.uniswapV3Capability(SEPOLIA, {
+        approveTokens: [USDC, WETH],
+      });
+      const router = Protocols.uniswapV3.swapRouter02[SEPOLIA];
+      expect(actions).toHaveLength(3);
+      const byTarget = Object.fromEntries(
+        actions.map((a) => [a.target.toLowerCase(), a.selectors])
+      );
+      expect(byTarget[router!.toLowerCase()]).toEqual(["0x04e45aaf"]);
+      expect(byTarget[USDC.toLowerCase()]).toEqual(["0x095ea7b3"]);
+      expect(byTarget[WETH.toLowerCase()]).toEqual(["0x095ea7b3"]);
+    });
+
+    test("refuses an empty approveTokens list", () => {
+      expect(() =>
+        SessionPolicyActions.uniswapV3Capability(SEPOLIA, { approveTokens: [] })
+      ).toThrow(/approveTokens/);
+    });
+  });
+
+  describe("actionsCover / missingActions", () => {
+    test("USDC grant misses WETH approve", () => {
+      const granted = SessionPolicyActions.uniswapV3Capability(SEPOLIA, {
+        approveTokens: [USDC],
+      });
+      const required = SessionPolicyActions.uniswapV3Capability(SEPOLIA, {
+        approveTokens: [WETH],
+      });
+      expect(actionsCover(required, granted)).toBe(false);
+      const miss = missingActions(required, granted);
+      expect(
+        miss.some((m) => m.target.toLowerCase() === WETH.toLowerCase())
+      ).toBe(true);
+    });
+
+    test("USDC+WETH grant covers demoted sell rows", () => {
+      const granted = SessionPolicyActions.uniswapV3Capability(SEPOLIA, {
+        approveTokens: [USDC, WETH],
+      });
+      const required = SessionPolicyActions.merge([
+        SessionPolicyActions.erc20Approve(WETH),
+        SessionPolicyActions.uniswapV3Swap(SEPOLIA),
+      ]);
+      expect(actionsCover(required, granted)).toBe(true);
+      expect(missingActions(required, granted)).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary

SDK half of the Auto WETH-sell AA23 fix (session allowlist scope).

- **`SessionPolicyActions.uniswapV3Capability(chainId, { approveTokens })`** — router `exactInputSingle` + `approve` for each listed token (pass USDC **and** WETH for Auto demote sells)
- **`actionsCover` / `missingActions`** — pure allowlist coverage for client preflight
- Unit tests for capability shape and USDC-only vs USDC+WETH coverage

Studio should call `uniswapV3Capability` from `grantScope.ts` instead of `merge(swap, approve(USDC only))`. Gateway companion: EigenLayer-AVS #711.

## Test plan
- [x] `yarn jest tests/v4/core/sessionPolicyActions.test.ts`
- [ ] CI green
- [ ] Studio consumes builder for Uniswap Auto capability compile
