### PR TITLE
chore(ci): run the E2E stack on the Alchemy bundler

### DIFF
--- a/.github/workflows/dev-test-on-pr.yml
+++ b/.github/workflows/dev-test-on-pr.yml
@@ -96,6 +96,10 @@ jobs:
       TENDERLY_PROJECT: ${{ vars.TENDERLY_PROJECT }}
       THEGRAPH_API_KEY: ${{ vars.THEGRAPH_API_KEY }}
       BUNDLER_URL: ${{ secrets.BUNDLER_URL }}
+      # Runs the E2E stack on the bundler production uses. Without it the
+      # gateway defaults to bundler_provider: alchemy with no key and fails
+      # closed at send time.
+      ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
       # Registered test operator (raw-JSON keystores + passwords) so on-chain
       # (block/event) triggers actually fire in the E2E stack.
       OPERATOR_ECDSA_KEYSTORE: ${{ secrets.OPERATOR_ECDSA_KEYSTORE }}
@@ -121,7 +125,7 @@ jobs:
 
       - name: Inject secrets into gateway + worker configs
         run: |
-          export TEST_ENV ETH_RPC_URL ETH_WS_URL ECDSA_PRIVATE_KEY JWT_SECRET BUNDLER_URL CONTROLLER_PRIVATE_KEY TENDERLY_ACCOUNT TENDERLY_PROJECT TENDERLY_ACCESS_KEY AP_NOTIFY_BOT_TOKEN SENDGRID_KEY THEGRAPH_API_KEY MORALIS_API_KEY CONTEXT_MEMORY_API_KEY
+          export TEST_ENV ETH_RPC_URL ETH_WS_URL ECDSA_PRIVATE_KEY JWT_SECRET BUNDLER_URL ALCHEMY_API_KEY CONTROLLER_PRIVATE_KEY TENDERLY_ACCOUNT TENDERLY_PROJECT TENDERLY_ACCESS_KEY AP_NOTIFY_BOT_TOKEN SENDGRID_KEY THEGRAPH_API_KEY MORALIS_API_KEY CONTEXT_MEMORY_API_KEY
           for src in gateway worker-sepolia operator-sepolia; do
             envsubst < config/${src}.yaml > config/${src}.runtime.yaml
             echo "Generated config/${src}.runtime.yaml: $(wc -l < config/${src}.runtime.yaml) lines"

--- a/config/gateway.yaml
+++ b/config/gateway.yaml
@@ -45,6 +45,11 @@ smart_wallet:
   eth_rpc_url: ${ETH_RPC_URL}
   eth_ws_url: ${ETH_WS_URL}
   bundler_url: ${BUNDLER_URL}
+  # Bundler — Alchemy, matching production. The endpoint is derived from
+  # alchemy_api_key; bundler_url is not read on this path and is kept only so a
+  # secret-less run can fall back by setting bundler_provider: self_hosted.
+  bundler_provider: alchemy
+  alchemy_api_key: ${ALCHEMY_API_KEY}
   controller_private_key: ${CONTROLLER_PRIVATE_KEY}
   paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92
   max_wallets_per_owner: 2000
@@ -59,6 +64,8 @@ chains:
       eth_rpc_url: ${ETH_RPC_URL}
       eth_ws_url: ${ETH_WS_URL}
       bundler_url: ${BUNDLER_URL}
+      bundler_provider: alchemy
+      alchemy_api_key: ${ALCHEMY_API_KEY}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}
       paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92
       max_wallets_per_owner: 2000
@@ -93,3 +100,8 @@ notifications:
     provider: context-memory
     api_endpoint: "https://context-api.avaprotocol.org"
     api_key: ${CONTEXT_MEMORY_API_KEY}
+
+# The E2E stack never draws on the production Gas Manager policy: the
+# policy's webhook points at the production gateway, which would approve and
+# bill a CI run against production's wallet records and credit ledger.
+disable_gas_sponsorship: true

--- a/config/worker-sepolia.yaml
+++ b/config/worker-sepolia.yaml
@@ -26,7 +26,13 @@ eth_rpc_url: ${ETH_RPC_URL}
 eth_ws_url: ${ETH_WS_URL}
 
 bundler_url: ${BUNDLER_URL}
+# Alchemy, matching production; endpoint derived from the key.
+bundler_provider: alchemy
+alchemy_api_key: ${ALCHEMY_API_KEY}
 
 smart_wallet:
   controller_private_key: ${CONTROLLER_PRIVATE_KEY}
   paymaster_address: 0xd856f532F7C032e6b30d76F19187F25A068D6d92
+
+# Never draw on the production Gas Manager policy from CI.
+disable_gas_sponsorship: true


### PR DESCRIPTION
Companion to [EigenLayer-AVS #724](https://github.com/AvaProtocol/EigenLayer-AVS/pull/724) (merged). Tracked by [EigenLayer-AVS #725](https://github.com/AvaProtocol/EigenLayer-AVS/issues/725).

## The bug this fixes

`config/gateway.yaml` and `config/worker-sepolia.yaml` set `bundler_url` but **no `bundler_provider`** — and that field defaults to `alchemy`:

```go
func (c *SmartWalletConfig) ProviderName() string {
    if p == "" { return BundlerProviderAlchemy }
```

On the Alchemy path the endpoint is derived from `alchemy_api_key` and `bundler_url` is **never read**. This workflow sets no Alchemy variable at all, so the stack resolves to `bundler_provider: alchemy` with an empty key and fails closed at send time with `bundler_provider=alchemy but alchemy_api_key is empty`.

Worth noting: every `dev-test-on-pr` run since 2026-08-01 has failed. I have not confirmed this is the cause, but it fits — the default flipped to alchemy in the EntryPoint v0.7 cutover, and nothing here supplies a key.

## What changed

- `ALCHEMY_API_KEY` secret added to this repo; exported in the workflow and included in the `envsubst` list so it reaches the generated runtime configs.
- Both configs declare `bundler_provider: alchemy` explicitly and take `alchemy_api_key` from it — the same path production uses.
- `bundler_url` is kept so a secret-less run can fall back by setting `bundler_provider: self_hosted`. That fallback disappears when the self-hosted bundlers are retired (EigenLayer-AVS #725).

## Also: the E2E stack no longer requests gas sponsorship

Both configs now set `disable_gas_sponsorship: true`.

Once a stack has an Alchemy key it is one config line away from asking for sponsorship — and the Gas Manager policy's custom-rules webhook is a single URL pointing at the **production** gateway. A CI run requesting sponsorship would have production approve it, deciding against production's wallet records and billing production's credit ledger for a test.

## Why now

The self-hosted bundlers were being kept alive largely by CI. `bundler-sepolia` logged 131 `eth_sendUserOperation` calls over Aug 5–7 from our own fixture wallets; this stack is one of the two sources. Moving both to Alchemy is the prerequisite for retiring those services.

## Test plan

- [ ] `dev-test-on-pr` goes green — the real check, since these runs have been failing since Aug 1
- [ ] Gateway logs show the Alchemy bundler endpoint rather than `bundler-sepolia.avaprotocol.org`
- [x] EigenLayer-AVS side verified: a live Sepolia UserOp sent and mined through Alchemy (`PASS: TestUserOpETHWithdrawal_Sepolia`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)