### PR TITLE
chore(ci): drop dead BUNDLER_URL from E2E configs

### DIFF
--- a/.github/workflows/dev-test-on-pr.yml
+++ b/.github/workflows/dev-test-on-pr.yml
@@ -95,10 +95,7 @@ jobs:
       TENDERLY_ACCOUNT: ${{ vars.TENDERLY_ACCOUNT }}
       TENDERLY_PROJECT: ${{ vars.TENDERLY_PROJECT }}
       THEGRAPH_API_KEY: ${{ vars.THEGRAPH_API_KEY }}
-      BUNDLER_URL: ${{ secrets.BUNDLER_URL }}
-      # Runs the E2E stack on the bundler production uses. Without it the
-      # gateway defaults to bundler_provider: alchemy with no key and fails
-      # closed at send time.
+      # Required: E2E stack uses Alchemy (production path). Missing key fails closed.
       ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
       # Registered test operator (raw-JSON keystores + passwords) so on-chain
       # (block/event) triggers actually fire in the E2E stack.
@@ -125,7 +122,7 @@ jobs:
 
       - name: Inject secrets into gateway + worker configs
         run: |
-          export TEST_ENV ETH_RPC_URL ETH_WS_URL ECDSA_PRIVATE_KEY JWT_SECRET BUNDLER_URL ALCHEMY_API_KEY CONTROLLER_PRIVATE_KEY TENDERLY_ACCOUNT TENDERLY_PROJECT TENDERLY_ACCESS_KEY AP_NOTIFY_BOT_TOKEN SENDGRID_KEY THEGRAPH_API_KEY MORALIS_API_KEY CONTEXT_MEMORY_API_KEY
+          export TEST_ENV ETH_RPC_URL ETH_WS_URL ECDSA_PRIVATE_KEY JWT_SECRET ALCHEMY_API_KEY CONTROLLER_PRIVATE_KEY TENDERLY_ACCOUNT TENDERLY_PROJECT TENDERLY_ACCESS_KEY AP_NOTIFY_BOT_TOKEN SENDGRID_KEY THEGRAPH_API_KEY MORALIS_API_KEY CONTEXT_MEMORY_API_KEY
           for src in gateway worker-sepolia operator-sepolia; do
             envsubst < config/${src}.yaml > config/${src}.runtime.yaml
             echo "Generated config/${src}.runtime.yaml: $(wc -l < config/${src}.runtime.yaml) lines"

--- a/config/gateway.yaml
+++ b/config/gateway.yaml
@@ -44,10 +44,8 @@ tenderly_access_key: ${TENDERLY_ACCESS_KEY}
 smart_wallet:
   eth_rpc_url: ${ETH_RPC_URL}
   eth_ws_url: ${ETH_WS_URL}
-  bundler_url: ${BUNDLER_URL}
-  # Bundler — Alchemy, matching production. The endpoint is derived from
-  # alchemy_api_key; bundler_url is not read on this path and is kept only so a
-  # secret-less run can fall back by setting bundler_provider: self_hosted.
+  # Bundler — Alchemy, matching production. Endpoint derived from
+  # alchemy_api_key + chain subdomain; no self_hosted fallback in CI.
   bundler_provider: alchemy
   alchemy_api_key: ${ALCHEMY_API_KEY}
   controller_private_key: ${CONTROLLER_PRIVATE_KEY}
@@ -63,7 +61,6 @@ chains:
     smart_wallet:
       eth_rpc_url: ${ETH_RPC_URL}
       eth_ws_url: ${ETH_WS_URL}
-      bundler_url: ${BUNDLER_URL}
       bundler_provider: alchemy
       alchemy_api_key: ${ALCHEMY_API_KEY}
       controller_private_key: ${CONTROLLER_PRIVATE_KEY}

--- a/config/worker-sepolia.yaml
+++ b/config/worker-sepolia.yaml
@@ -25,8 +25,7 @@ gateway_address: "gateway:2206"
 eth_rpc_url: ${ETH_RPC_URL}
 eth_ws_url: ${ETH_WS_URL}
 
-bundler_url: ${BUNDLER_URL}
-# Alchemy, matching production; endpoint derived from the key.
+# Alchemy, matching production; endpoint derived from alchemy_api_key.
 bundler_provider: alchemy
 alchemy_api_key: ${ALCHEMY_API_KEY}
 


### PR DESCRIPTION
- **chore(ci): drop dead BUNDLER_URL from E2E gateway/worker configs**

E2E already runs bundler_provider: alchemy. bundler_url was only kept for a secret-less self_hosted fallback that nothing uses after the shared Voltaire hosts retire (EigenLayer-AVS #725). Require ALCHEMY_API_KEY only.