### PR TITLE
chore(config): drop avsEndpoint — every host it named is gone

### DIFF
--- a/config/chains.ts
+++ b/config/chains.ts
@@ -27,7 +27,6 @@ export type UniswapV3PoolDef = {
 
 export type ChainConfig = {
   name: string;
-  avsEndpoint: string;
   chainId: string;
   chainEndpoint: string | null;
   explorerApiBaseUrl?: string | null;
@@ -40,7 +39,6 @@ export type ChainConfig = {
 
 const staticChains: Record<string, Omit<ChainConfig, "rpcUrl" | "name">> = {
   dev: {
-    avsEndpoint: "localhost:2206",
     chainId: "11155111", // Sepolia chain ID for local dev
     chainEndpoint: null,
     explorerApiBaseUrl: "https://api-sepolia.etherscan.io/api",
@@ -48,8 +46,6 @@ const staticChains: Record<string, Omit<ChainConfig, "rpcUrl" | "name">> = {
     oracles: {},
   },
   sepolia: {
-    avsEndpoint: "aggregator-sepolia.avaprotocol.org:2206",
-    // avsEndpoint: "ballast.proxy.rlwy.net:10661", EigenLayer-AVS feature branch of feature/railway-migration-phase1-testnet
     chainId: "11155111",
     chainEndpoint: null,
     explorerApiBaseUrl: "https://api-sepolia.etherscan.io/api",
@@ -98,7 +94,6 @@ const staticChains: Record<string, Omit<ChainConfig, "rpcUrl" | "name">> = {
     },
   },
   "base-sepolia": {
-    avsEndpoint: "aggregator-base-sepolia.avaprotocol.org:3206",
     chainId: "84532",
     chainEndpoint: null,
     explorerApiBaseUrl: "https://api-sepolia.basescan.org/api",
@@ -106,7 +101,6 @@ const staticChains: Record<string, Omit<ChainConfig, "rpcUrl" | "name">> = {
     oracles: {},
   },
   base: {
-    avsEndpoint: "aggregator-base.avaprotocol.org:3206",
     chainId: "8453",
     chainEndpoint: null,
     explorerApiBaseUrl: "https://api.basescan.org/api",
@@ -114,7 +108,6 @@ const staticChains: Record<string, Omit<ChainConfig, "rpcUrl" | "name">> = {
     oracles: {},
   },
   ethereum: {
-    avsEndpoint: "aggregator.avaprotocol.org:2206",
     chainId: "1",
     chainEndpoint: null,
     explorerApiBaseUrl: "https://api.etherscan.io/api",
@@ -122,7 +115,6 @@ const staticChains: Record<string, Omit<ChainConfig, "rpcUrl" | "name">> = {
     oracles: {},
   },
   soneium: {
-    avsEndpoint: "aggregator-soneium.avaprotocol.org:2208",
     chainId: "1868",
     chainEndpoint: null,
     explorerApiBaseUrl: "https://soneium.blockscout.com/api",
@@ -130,7 +122,6 @@ const staticChains: Record<string, Omit<ChainConfig, "rpcUrl" | "name">> = {
     oracles: {},
   },
   "soneium-minato": {
-    avsEndpoint: "aggregator-soneium-minato.avaprotocol.org:2208",
     chainId: "1946",
     chainEndpoint: null,
     explorerApiBaseUrl: "https://soneium.blockscout.com/api",
@@ -138,7 +129,6 @@ const staticChains: Record<string, Omit<ChainConfig, "rpcUrl" | "name">> = {
     oracles: {},
   },
   bsc: {
-    avsEndpoint: "aggregator-bsc.avaprotocol.org:2209",
     chainId: "56",
     chainEndpoint: null,
     explorerApiBaseUrl: "https://api.bscscan.com/api",
@@ -146,7 +136,6 @@ const staticChains: Record<string, Omit<ChainConfig, "rpcUrl" | "name">> = {
     oracles: {},
   },
   "bsc-testnet": {
-    avsEndpoint: "aggregator-bsc-testnet.avaprotocol.org:2209",
     chainId: "97",
     chainEndpoint: null,
     explorerApiBaseUrl: "https://api-testnet.bscscan.com/api",

--- a/tests-v3-archive/utils/envalid.ts
+++ b/tests-v3-archive/utils/envalid.ts
@@ -61,8 +61,12 @@ export const ENV_CONFIGS: Record<
     throw new Error(`Chain configuration not found for environment: ${env}`);
   }
   acc[env] = {
-    // For dev environment, use localhost aggregator endpoint for local development
-    aggregatorEndpoint: env === "dev" ? "localhost:2206" : c.avsEndpoint,
+    // Local only. This archived v3 suite dials the gRPC aggregator, and every
+    // hosted one it used to reach (aggregator*.avaprotocol.org:2206) has been
+    // retired with the move to the unified REST gateway — most no longer have
+    // a DNS record. Against a non-local environment these tests cannot run at
+    // all, so naming a dead host here would only disguise that as a timeout.
+    aggregatorEndpoint: "localhost:2206",
     operatorEndpoint: "localhost:9010", // Operator node API endpoint
     chainId: c.chainId,
     chainEndpoint: c.chainEndpoint,


### PR DESCRIPTION
`config/chains.ts` carried an `avsEndpoint` for every chain, and all of them named retired per-chain aggregators: `aggregator.avaprotocol.org:2206`, plus `-sepolia`, `-base`, `-base-sepolia`, `-soneium`, `-bsc` and friends.

Only `aggregator.avaprotocol.org` still resolves at all — to an old AWS address with 2206 closed. The rest have no DNS record left. The deployed operators do not use them either; they dial `${GATEWAY_ADDRESS}`, a Railway private-network address.

## Blast radius

Small, but not zero, and not what I first thought.

Nothing in `packages/` reads the field — the v4 client takes an explicit `baseUrl`. But `tests-v3-archive/utils/envalid.ts` fed it to a v3 gRPC `Client`. That suite is not built, typechecked or run by CI, and it targets the retired v3 API, so it now pins `localhost:2206` outright: against a hosted environment those tests cannot run regardless, and naming a dead host there would only disguise that as a timeout.

Also removes the commented-out `ballast.proxy.rlwy.net` endpoint left over from the Railway migration branch.

## Verification

`@avaprotocol/types` and `@avaprotocol/sdk-js` both build. No remaining `avsEndpoint` reference anywhere in the repo.

## Context

The gateway's real gRPC endpoint for operators is `zephyr.proxy.rlwy.net:57376` (a Railway TCP proxy onto container port 2206) — documented in AvaProtocol/EigenLayer-AVS#738. It is deliberately not reintroduced here, since nothing in the SDK dials gRPC any more.
