### PR TITLE
chore(sdk): bump @avaprotocol/protocols to 0.10.0

### DIFF
--- a/.changeset/bump-protocols-0.10.0.md
+++ b/.changeset/bump-protocols-0.10.0.md
@@ -1,0 +1,5 @@
+---
+"@avaprotocol/sdk-js": minor
+---
+
+Bump `@avaprotocol/protocols` to `^0.10.0`. Uniswap V3 SwapRouter02 / WETH / native USDC now exist on Arbitrum and Optimism, so `SessionPolicyActions.uniswapV3Swap(42161)` and `uniswapV3Swap(10)` resolve from the catalog instead of throwing.

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -37,7 +37,7 @@
     "prepare": "node ../../scripts/prepare-package.js"
   },
   "dependencies": {
-    "@avaprotocol/protocols": "^0.9.0",
+    "@avaprotocol/protocols": "^0.10.0",
     "@avaprotocol/types": "^4.5.1",
     "dotenv": "^16.4.5",
     "ethers": "^6.13.2"

--- a/tests/v4/core/protocolsCatalog.test.ts
+++ b/tests/v4/core/protocolsCatalog.test.ts
@@ -1,14 +1,14 @@
 /**
- * Catalog compatibility after `@avaprotocol/protocols@0.9.0`.
+ * Catalog compatibility after `@avaprotocol/protocols@0.10.0`.
  *
- * Pure data — no gateway. Pins the 0.9.0 surface the SDK re-exports so a
+ * Pure data — no gateway. Pins the 0.10.0 surface the SDK re-exports so a
  * stale lockfile or a catalog regression cannot silently drop Arb/OP or
  * collapse Ethereum multi-market back to Core-only.
  */
 
 import { Chains, Protocols } from "@avaprotocol/sdk-js";
 
-describe("protocols catalog 0.9.0", () => {
+describe("protocols catalog 0.10.0", () => {
   test("spreads new catalog chain IDs onto SDK Chains", () => {
     expect(Chains.ArbitrumOne).toBe(42_161);
     expect(Chains.OptimismMainnet).toBe(10);
@@ -33,6 +33,18 @@ describe("protocols catalog 0.9.0", () => {
     const eth = Protocols.aaveV3.markets[Chains.EthereumMainnet] ?? [];
     expect(eth.map((m) => m.key)).toEqual(["core", "etherFi", "lido", "horizon"]);
     expect(eth[0]?.pool).toBe(Protocols.aaveV3.pool[Chains.EthereumMainnet]);
+  });
+
+  test("Uniswap V3 SwapRouter02 + WETH resolve on Arbitrum and Optimism", () => {
+    const officialRouter = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45";
+    expect(Protocols.uniswapV3.swapRouter02[Chains.ArbitrumOne]).toBe(officialRouter);
+    expect(Protocols.uniswapV3.swapRouter02[Chains.OptimismMainnet]).toBe(officialRouter);
+    expect(Protocols.wrapped.weth[Chains.ArbitrumOne]).toBe(
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
+    );
+    expect(Protocols.wrapped.weth[Chains.OptimismMainnet]).toBe(
+      "0x4200000000000000000000000000000000000006"
+    );
   });
 
   test("existing Core callers stay on the same Sepolia Pool", () => {

--- a/tests/v4/core/sessionPolicyActions.test.ts
+++ b/tests/v4/core/sessionPolicyActions.test.ts
@@ -40,6 +40,20 @@ describe("SessionPolicyActions", () => {
     expect(action.target).toBe(Protocols.uniswapV3.swapRouter02[SEPOLIA]);
   });
 
+  test("uniswapV3Swap resolves Arbitrum and Optimism from the 0.10.0 catalog", () => {
+    const ARBITRUM = 42_161;
+    const OPTIMISM = 10;
+    expect(SessionPolicyActions.uniswapV3Swap(ARBITRUM).target).toBe(
+      Protocols.uniswapV3.swapRouter02[ARBITRUM]
+    );
+    expect(SessionPolicyActions.uniswapV3Swap(OPTIMISM).target).toBe(
+      Protocols.uniswapV3.swapRouter02[OPTIMISM]
+    );
+    expect(SessionPolicyActions.uniswapV3Swap(ARBITRUM).target).toBe(
+      "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"
+    );
+  });
+
   // Better to refuse than to grant a zero address or the wrong chain's router.
   test("an unknown chain is refused, with the way out in the message", () => {
     expect(() => SessionPolicyActions.uniswapV3Swap(999_999)).toThrow(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz"
   integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
 
-"@avaprotocol/protocols@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@avaprotocol/protocols/-/protocols-0.9.0.tgz#5be016967a268a53d74cf8f2cb84ed0667fa9808"
-  integrity sha512-heiC72RYmSZd93/p8vqK117rDjw/uI1hKWyx1MBzparDexshj6/4dHX002nU8U58aLhKuJIGQV19kRH8CinayA==
+"@avaprotocol/protocols@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@avaprotocol/protocols/-/protocols-0.10.0.tgz#909e52eb7526552543c7c3b1556a846b1fdfefe3"
+  integrity sha512-qBN0V99KRGbKlWfmKzYls52C5neb1nVHl5qj0PW2mDTgmrG8nxjp8reqAdLidbntJsUfPPnTYr5aauTlDo0d5g==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.27.1":
   version "7.27.1"


### PR DESCRIPTION
## Summary

Bumps `@avaprotocol/protocols` from `^0.9.0` to **`^0.10.0`** so the SDK picks up Uniswap V3 + WETH on Arbitrum and Optimism.

`SessionPolicyActions.uniswapV3Swap(42161)` (and `10`) now resolves `SwapRouter02` from the catalog. No SDK logic change — the helper already refused unknown chains and reads `Protocols.uniswapV3.swapRouter02[chainId]`.

Also pins the official router / WETH addresses in the catalog unit tests.

## Test plan

- [x] `yarn workspace @avaprotocol/sdk-js build:declarations`
- [x] `yarn test tests/v4/core/protocolsCatalog.test.ts tests/v4/core/sessionPolicyActions.test.ts tests/v4/onchain-helpers.test.ts` (38 passed)