### PR TITLE
chore: cut staging → main (protocols 0.12.0 changeset)

### DIFF
--- a/.changeset/bump-protocols-0.12.0.md
+++ b/.changeset/bump-protocols-0.12.0.md
@@ -1,5 +1,0 @@
----
-"@avaprotocol/sdk-js": minor
----
-
-Bump `@avaprotocol/protocols` to `^0.12.0`. Unichain (130) and Robinhood (4663) chain IDs plus Uniswap V3 / WETH now resolve from the catalog, so `SessionPolicyActions.uniswapV3Swap(130)` and `uniswapV3Swap(4663)` no longer throw. Adds Railway E2E for expansion-chain auth + WETH `contractRead` / `simulate`.

--- a/.changeset/bump-protocols-0.12.0.md
+++ b/.changeset/bump-protocols-0.12.0.md
@@ -1,0 +1,5 @@
+---
+"@avaprotocol/sdk-js": minor
+---
+
+Bump `@avaprotocol/protocols` to `^0.12.0`. Unichain (130) and Robinhood (4663) chain IDs plus Uniswap V3 / WETH now resolve from the catalog, so `SessionPolicyActions.uniswapV3Swap(130)` and `uniswapV3Swap(4663)` no longer throw. Adds Railway E2E for expansion-chain auth + WETH `contractRead` / `simulate`.

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @avaprotocol/sdk-js
 
+## 4.11.0
+
+### Minor Changes
+
+- c088142: Bump `@avaprotocol/protocols` to `^0.12.0`. Unichain (130) and Robinhood (4663) chain IDs plus Uniswap V3 / WETH now resolve from the catalog, so `SessionPolicyActions.uniswapV3Swap(130)` and `uniswapV3Swap(4663)` no longer throw. Adds Railway E2E for expansion-chain auth + WETH `contractRead` / `simulate`.
+
 ## 4.10.0
 
 ### Minor Changes

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -37,7 +37,7 @@
     "prepare": "node ../../scripts/prepare-package.js"
   },
   "dependencies": {
-    "@avaprotocol/protocols": "^0.10.0",
+    "@avaprotocol/protocols": "^0.12.0",
     "@avaprotocol/types": "^4.5.1",
     "dotenv": "^16.4.5",
     "ethers": "^6.13.2"

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avaprotocol/sdk-js",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "TypeScript SDK for Ava Protocol's AVS REST API. Resource-grouped sub-clients, fetch transport, EIP-191 auth.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/utils/client.ts
+++ b/tests/utils/client.ts
@@ -32,6 +32,18 @@ export function testPrivateKey(): string {
 }
 
 /**
+ * Decode a JWT payload. Header/payload are base64url (`-`/`_`, no
+ * padding); Node's `base64` alphabet mis-decodes those.
+ */
+export function decodeJwtPayload(token: string): Record<string, unknown> {
+  const body = token.split(".")[1];
+  if (!body) {
+    throw new Error("JWT missing payload");
+  }
+  return JSON.parse(Buffer.from(body, "base64url").toString());
+}
+
+/**
  * A private EOA for one suite, and the client authenticated as it.
  *
  * Unique salts stop two suites sharing a wallet, but they do not help a query

--- a/tests/v4/core/auth.test.ts
+++ b/tests/v4/core/auth.test.ts
@@ -20,6 +20,7 @@ import {
   TEST_AUTH_URI,
   authenticateClient,
   buildAuthPayload,
+  decodeJwtPayload,
   generateSignature,
   getClient,
   getEOAAddress,
@@ -138,9 +139,7 @@ describe("Authentication Tests", () => {
       // The token also gets stashed on the transport for follow-up calls.
       expect(client.token).toEqual(res.token);
 
-      const [, body] = res.token.split(".");
-      expect(body).toBeTruthy();
-      const decoded = JSON.parse(Buffer.from(body, "base64").toString());
+      const decoded = decodeJwtPayload(res.token);
       expect(decoded).toMatchObject({
         iss: "AvaProtocol",
         sub: payload.ownerAddress,
@@ -182,8 +181,7 @@ describe("Authentication Tests", () => {
       // The JWT body should encode the requested chain id in the
       // audience claim — that's how downstream chain-routed handlers
       // know which chain the caller is operating against.
-      const [, body] = res.token.split(".");
-      const decoded = JSON.parse(Buffer.from(body, "base64").toString());
+      const decoded = decodeJwtPayload(res.token);
       expect(decoded.iss).toBe("AvaProtocol");
       expect(String(decoded.aud)).toBe("56");
     });
@@ -201,10 +199,51 @@ describe("Authentication Tests", () => {
         version,
       });
       expect(res.token).toBeTruthy();
-      const [, body] = res.token.split(".");
-      const decoded = JSON.parse(Buffer.from(body, "base64").toString());
+      const decoded = decodeJwtPayload(res.token);
       expect(decoded.iss).toBe("AvaProtocol");
       expect(String(decoded.aud)).toBe("42161");
+    });
+
+    test("mints a JWT scoped to OP Mainnet (10) — Wave B worker reachable via gateway", async () => {
+      const c = getClient();
+      const { version } = await c.health.check();
+      const res = await c.auth.exchangeWithKey(testPrivateKey(), {
+        uri: TEST_AUTH_URI,
+        chainId: 10,
+        version,
+      });
+      expect(res.token).toBeTruthy();
+      const decoded = decodeJwtPayload(res.token);
+      expect(decoded.iss).toBe("AvaProtocol");
+      expect(String(decoded.aud)).toBe("10");
+    });
+
+    test("mints a JWT scoped to Unichain (130) — Wave B worker reachable via gateway", async () => {
+      const c = getClient();
+      const { version } = await c.health.check();
+      const res = await c.auth.exchangeWithKey(testPrivateKey(), {
+        uri: TEST_AUTH_URI,
+        chainId: 130,
+        version,
+      });
+      expect(res.token).toBeTruthy();
+      const decoded = decodeJwtPayload(res.token);
+      expect(decoded.iss).toBe("AvaProtocol");
+      expect(String(decoded.aud)).toBe("130");
+    });
+
+    test("mints a JWT scoped to Robinhood Chain (4663) — worker reachable via gateway", async () => {
+      const c = getClient();
+      const { version } = await c.health.check();
+      const res = await c.auth.exchangeWithKey(testPrivateKey(), {
+        uri: TEST_AUTH_URI,
+        chainId: 4663,
+        version,
+      });
+      expect(res.token).toBeTruthy();
+      const decoded = decodeJwtPayload(res.token);
+      expect(decoded.iss).toBe("AvaProtocol");
+      expect(String(decoded.aud)).toBe("4663");
     });
 
     test("rejects a signature that doesn't match the owner", async () => {

--- a/tests/v4/core/auth.test.ts
+++ b/tests/v4/core/auth.test.ts
@@ -188,6 +188,25 @@ describe("Authentication Tests", () => {
       expect(String(decoded.aud)).toBe("56");
     });
 
+    test("mints a JWT scoped to Arbitrum One (42161) — proves new-chain worker is reachable via gateway", async () => {
+      // Same probe as BNB (56). Signing the canonical auth message
+      // against chainId 42161 and getting a JWT with aud=42161 means
+      // the gateway has Arbitrum in chains[], TokenEnrichmentService
+      // initialized, and the EIP-191 template accepts the chain id.
+      const c = getClient();
+      const { version } = await c.health.check();
+      const res = await c.auth.exchangeWithKey(testPrivateKey(), {
+        uri: TEST_AUTH_URI,
+        chainId: 42161,
+        version,
+      });
+      expect(res.token).toBeTruthy();
+      const [, body] = res.token.split(".");
+      const decoded = JSON.parse(Buffer.from(body, "base64").toString());
+      expect(decoded.iss).toBe("AvaProtocol");
+      expect(String(decoded.aud)).toBe("42161");
+    });
+
     test("rejects a signature that doesn't match the owner", async () => {
       const payload = await buildAuthPayload(client);
       // Re-sign the message with a different key — verifier will

--- a/tests/v4/core/protocolsCatalog.test.ts
+++ b/tests/v4/core/protocolsCatalog.test.ts
@@ -1,17 +1,19 @@
 /**
- * Catalog compatibility after `@avaprotocol/protocols@0.10.0`.
+ * Catalog compatibility after `@avaprotocol/protocols@0.12.0`.
  *
- * Pure data — no gateway. Pins the 0.10.0 surface the SDK re-exports so a
- * stale lockfile or a catalog regression cannot silently drop Arb/OP or
- * collapse Ethereum multi-market back to Core-only.
+ * Pure data — no gateway. Pins the catalog surface the SDK re-exports so a
+ * stale lockfile or a catalog regression cannot silently drop Arb/OP/
+ * Unichain/Robinhood or collapse Ethereum multi-market back to Core-only.
  */
 
 import { Chains, Protocols } from "@avaprotocol/sdk-js";
 
-describe("protocols catalog 0.10.0", () => {
+describe("protocols catalog 0.12.0", () => {
   test("spreads new catalog chain IDs onto SDK Chains", () => {
     expect(Chains.ArbitrumOne).toBe(42_161);
     expect(Chains.OptimismMainnet).toBe(10);
+    expect(Chains.UnichainMainnet).toBe(130);
+    expect(Chains.RobinhoodMainnet).toBe(4_663);
     expect(Chains.Sepolia).toBe(11_155_111);
     expect(Chains.EigenLayerAuth).toBe(Chains.Sepolia);
   });
@@ -35,15 +37,27 @@ describe("protocols catalog 0.10.0", () => {
     expect(eth[0]?.pool).toBe(Protocols.aaveV3.pool[Chains.EthereumMainnet]);
   });
 
-  test("Uniswap V3 SwapRouter02 + WETH resolve on Arbitrum and Optimism", () => {
+  test("Uniswap V3 SwapRouter02 + WETH resolve on Arbitrum, Optimism, Unichain, Robinhood", () => {
     const officialRouter = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45";
     expect(Protocols.uniswapV3.swapRouter02[Chains.ArbitrumOne]).toBe(officialRouter);
     expect(Protocols.uniswapV3.swapRouter02[Chains.OptimismMainnet]).toBe(officialRouter);
+    expect(Protocols.uniswapV3.swapRouter02[Chains.UnichainMainnet]).toBe(
+      "0x73855d06DE49d0fe4A9c42636Ba96c62da12FF9C"
+    );
+    expect(Protocols.uniswapV3.swapRouter02[Chains.RobinhoodMainnet]).toBe(
+      "0xCaf681a66D020601342297493863E78C959E5cb2"
+    );
     expect(Protocols.wrapped.weth[Chains.ArbitrumOne]).toBe(
       "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
     );
     expect(Protocols.wrapped.weth[Chains.OptimismMainnet]).toBe(
       "0x4200000000000000000000000000000000000006"
+    );
+    expect(Protocols.wrapped.weth[Chains.UnichainMainnet]).toBe(
+      "0x4200000000000000000000000000000000000006"
+    );
+    expect(Protocols.wrapped.weth[Chains.RobinhoodMainnet]).toBe(
+      "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73"
     );
   });
 

--- a/tests/v4/core/sessionPolicyActions.test.ts
+++ b/tests/v4/core/sessionPolicyActions.test.ts
@@ -40,17 +40,31 @@ describe("SessionPolicyActions", () => {
     expect(action.target).toBe(Protocols.uniswapV3.swapRouter02[SEPOLIA]);
   });
 
-  test("uniswapV3Swap resolves Arbitrum and Optimism from the 0.10.0 catalog", () => {
+  test("uniswapV3Swap resolves Arbitrum, Optimism, Unichain, and Robinhood from the catalog", () => {
     const ARBITRUM = 42_161;
     const OPTIMISM = 10;
+    const UNICHAIN = 130;
+    const ROBINHOOD = 4_663;
     expect(SessionPolicyActions.uniswapV3Swap(ARBITRUM).target).toBe(
       Protocols.uniswapV3.swapRouter02[ARBITRUM]
     );
     expect(SessionPolicyActions.uniswapV3Swap(OPTIMISM).target).toBe(
       Protocols.uniswapV3.swapRouter02[OPTIMISM]
     );
+    expect(SessionPolicyActions.uniswapV3Swap(UNICHAIN).target).toBe(
+      Protocols.uniswapV3.swapRouter02[UNICHAIN]
+    );
+    expect(SessionPolicyActions.uniswapV3Swap(ROBINHOOD).target).toBe(
+      Protocols.uniswapV3.swapRouter02[ROBINHOOD]
+    );
     expect(SessionPolicyActions.uniswapV3Swap(ARBITRUM).target).toBe(
       "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"
+    );
+    expect(SessionPolicyActions.uniswapV3Swap(UNICHAIN).target).toBe(
+      "0x73855d06DE49d0fe4A9c42636Ba96c62da12FF9C"
+    );
+    expect(SessionPolicyActions.uniswapV3Swap(ROBINHOOD).target).toBe(
+      "0xCaf681a66D020601342297493863E78C959E5cb2"
     );
   });
 

--- a/tests/v4/templates/expansion-chains-e2e.test.ts
+++ b/tests/v4/templates/expansion-chains-e2e.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Wave A / Wave B / Robinhood read-only E2E against a multi-chain gateway.
+ *
+ * Local docker-compose only wires Sepolia, so this file no-ops unless
+ * TEST_ENV=railway (or MULTICHAIN_TEST=1). Against Railway it:
+ *
+ *   1. Mints a JWT whose `aud` is the target chain on the isolated
+ *      client's transport (gateway has the chain in chains[]).
+ *   2. `nodes.run` a WETH/WBNB `symbol()` contractRead under that
+ *      chain-scoped token — real RPC through that chain's worker.
+ *   3. `workflows.simulate` the same read — Tenderly Simulation API
+ *      for that chain id (Phase 6 of Adding_A_New_Chain.md).
+ *
+ * No UserOp is submitted. Uses an isolated EOA so production
+ * `max_wallets_per_owner` on the shared test key is not a problem.
+ *
+ * `.env` wins over `.env.railway` (override:false), so point at
+ * production explicitly:
+ *
+ *   TEST_ENV=railway AVS_REST_URL=https://api.avaprotocol.org/api/v1 \
+ *     yarn jest tests/v4/templates/expansion-chains-e2e.test.ts
+ */
+
+import { Chains, Client, Nodes, Protocols, Triggers } from "@avaprotocol/sdk-js";
+
+import {
+  TEST_AUTH_URI,
+  createSmartWallet,
+  decodeJwtPayload,
+  getIsolatedClient,
+  settingsForChain,
+} from "../../utils/client";
+
+jest.setTimeout(120_000);
+
+const MULTICHAIN_STACK =
+  process.env.MULTICHAIN_TEST === "1" || process.env.TEST_ENV === "railway";
+const describeExpansion = MULTICHAIN_STACK ? describe : describe.skip;
+
+const SYMBOL_ABI = [...Protocols.erc20.symbolAbi];
+
+const CHAINS: ReadonlyArray<{
+  name: string;
+  chainId: number;
+  weth: string;
+  symbol: string;
+}> = [
+  {
+    name: "BNB Smart Chain",
+    chainId: Chains.BnbMainnet,
+    weth: Protocols.wrapped.weth[Chains.BnbMainnet]!,
+    symbol: "WBNB",
+  },
+  {
+    name: "Arbitrum One",
+    chainId: Chains.ArbitrumOne,
+    weth: Protocols.wrapped.weth[Chains.ArbitrumOne]!,
+    symbol: "WETH",
+  },
+  {
+    name: "OP Mainnet",
+    chainId: Chains.OptimismMainnet,
+    weth: Protocols.wrapped.weth[Chains.OptimismMainnet]!,
+    symbol: "WETH",
+  },
+  {
+    name: "Unichain",
+    chainId: Chains.UnichainMainnet,
+    weth: Protocols.wrapped.weth[Chains.UnichainMainnet]!,
+    symbol: "WETH",
+  },
+  {
+    name: "Robinhood Chain",
+    chainId: Chains.RobinhoodMainnet,
+    weth: Protocols.wrapped.weth[Chains.RobinhoodMainnet]!,
+    symbol: "WETH",
+  },
+];
+
+describeExpansion("Expansion chains E2E (auth + WETH read + simulate)", () => {
+  let client: Client;
+  let runner: string;
+  let isolatedKey: string;
+
+  beforeAll(async () => {
+    // Isolated EOA: the shared TEST_PRIVATE_KEY is already at
+    // production max_wallets_per_owner. This suite is read-only.
+    const isolated = await getIsolatedClient();
+    client = isolated.client;
+    isolatedKey = isolated.privateKey;
+    const wallet = await createSmartWallet(client);
+    runner = wallet.address;
+  });
+
+  describe.each(CHAINS)("$name ($chainId)", ({ chainId, weth, symbol }) => {
+    beforeEach(async () => {
+      // Re-mint on the shared client as the isolated owner so
+      // nodes.run / simulate run under a JWT whose aud is this chain.
+      const { version } = await client.health.check();
+      await client.auth.exchangeWithKey(isolatedKey, {
+        uri: TEST_AUTH_URI,
+        chainId,
+        version,
+      });
+    });
+
+    test("mints a JWT scoped to the chain", async () => {
+      expect(client.token).toBeTruthy();
+      const decoded = decodeJwtPayload(client.token!);
+      expect(decoded.iss).toBe("AvaProtocol");
+      expect(String(decoded.aud)).toBe(String(chainId));
+    });
+
+    test("nodes.run reads wrapped-native symbol via the chain worker", async () => {
+      const result = await client.nodes.run({
+        node: Nodes.contractRead({
+          id: "r",
+          name: "wethSymbol",
+          chainId,
+          contractAddress: weth,
+          contractAbi: SYMBOL_ABI,
+          methodCalls: [{ methodName: "symbol", methodParams: [] }],
+        }),
+        inputVariables: { settings: settingsForChain(runner, chainId) },
+      });
+      if (!result.success) {
+        throw new Error(`nodes.run failed on ${chainId}: ${JSON.stringify(result)}`);
+      }
+      const data = (result.output as { data: Record<string, unknown> }).data;
+      expect(data.symbol).toBe(symbol);
+    });
+
+    test("workflows.simulate reads wrapped-native symbol via Tenderly", async () => {
+      const sim = await client.workflows.simulate({
+        trigger: Triggers.manual({
+          id: "trigger",
+          name: "manualTrigger",
+          lang: "json",
+          data: {},
+        }),
+        nodes: [
+          Nodes.contractRead({
+            id: "r",
+            name: "wethSymbol",
+            chainId,
+            contractAddress: weth,
+            contractAbi: SYMBOL_ABI,
+            methodCalls: [{ methodName: "symbol", methodParams: [] }],
+          }),
+        ],
+        edges: [{ id: "e1", source: "trigger", target: "r" }],
+        inputVariables: { settings: settingsForChain(runner, chainId) },
+      });
+      if (sim.status !== "success") {
+        throw new Error(`simulate failed on ${chainId}: ${JSON.stringify(sim)}`);
+      }
+      const step = sim.steps?.find((s) => s.id === "r");
+      expect(step?.success).toBe(true);
+      const data = (step?.output as { data: Record<string, unknown> }).data;
+      expect(data.symbol).toBe(symbol);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz"
   integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
 
-"@avaprotocol/protocols@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@avaprotocol/protocols/-/protocols-0.10.0.tgz#909e52eb7526552543c7c3b1556a846b1fdfefe3"
-  integrity sha512-qBN0V99KRGbKlWfmKzYls52C5neb1nVHl5qj0PW2mDTgmrG8nxjp8reqAdLidbntJsUfPPnTYr5aauTlDo0d5g==
+"@avaprotocol/protocols@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@avaprotocol/protocols/-/protocols-0.12.0.tgz#d65704ad19ced5f2fe2649d9ef3545b37b808417"
+  integrity sha512-h6SBMr2jLmi4bxy+vHVaNGGGTmaOkw9jUyLbjxLvy4fF3eVSs0ROAQpK6B2YeTsIQTsCT+TtooHsrlxjrDPPnQ==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.27.1":
   version "7.27.1"


### PR DESCRIPTION
## Summary

Cut `staging` to `main`. Version bump is **not** in this PR — run `yarn run version` then publish after merge (or on this branch before merge).

Includes:

- `#251` — auth probe JWT `aud=42161` for the Arbitrum worker
- `#252` — bump `@avaprotocol/protocols` to `^0.12.0` (Unichain `130` + Robinhood `4663` catalog IDs / Uniswap V3 / WETH), auth probes for `10` / `130` / `4663`, Railway expansion-chain E2E
- Changeset `.changeset/bump-protocols-0.12.0.md` — **minor** for `@avaprotocol/sdk-js` (will become **4.11.0** when you version)

## After merge

1. `yarn run version` (consumes the changeset → 4.11.0)
2. Publish from `main`
3. `/sync-main` so `staging` matches the squash commit on `main`
