### PR TITLE
test: production-cap e2e helpers and MA v2 funded UserOp fixture

### DIFF
--- a/.env.railway.example
+++ b/.env.railway.example
@@ -18,9 +18,12 @@ TEST_PRIVATE_KEY=<REPLACE-WITH-TEST-EOA-PRIVATE-KEY>
 
 # Partner assertion (Ed25519) for partner-gated reads (GET /tokens/*).
 # Must match gateway partners[].public_keys and partner_assertion_audience.
-# PARTNER_ASSERTION_PRIVATE_KEY=<base64-ed25519-seed>
+# Production: audience is avs-gateway-prod; the private key is Studio's
+# GATEWAY_STUDIO_PARTNER_KEY (same PEM as partners[studio].public_keys).
+# GET /tokens also requires partners[].scopes to include `read`.
+# PARTNER_ASSERTION_PRIVATE_KEY=<base64-ed25519-pkcs8-pem>
 # PARTNER_ASSERTION_ISSUER=studio
-# PARTNER_ASSERTION_AUDIENCE=avs-gateway-staging
+# PARTNER_ASSERTION_AUDIENCE=avs-gateway-prod
 
 # Chain RPC for block-trigger tests (executions/getExecution.test.ts).
 # Use the Sepolia endpoint the gateway's workers use.

--- a/docs/changes/20260820-production-e2e-wallet-cap-partner-funded.md
+++ b/docs/changes/20260820-production-e2e-wallet-cap-partner-funded.md
@@ -1,9 +1,9 @@
 # Production e2e: wallet cap, partner assertion, funded salt-2
 
 - **Date**: 2026-08-20
-- **Status**: In progress — step 1 (avs-infra `read` grant) shipped, deployed and verified 2026-08-20; steps 2–3 implemented in the working tree; step 4 (full re-run) pending
+- **Status**: Implemented — production helpers green 2026-08-20 (45/9/0 suites); local e2e **closed** 2026-08-21 against gateway `4.17.0` + EigenLayer-AVS #761 (`0c8aa185`): **54/54 suites, 385/385 tests, 0 failed, 0 skipped**
 - **Branch**: staging
-- **Related**: full v4 suite against `https://api.avaprotocol.org/api/v1` (`4.17.0`); log `logs/20260820-162128-full-e2e-prod.log`; avs-infra `railway/configs/gateway-railway.yaml`; Studio `GATEWAY_STUDIO_PARTNER_KEY`
+- **Related**: production `https://api.avaprotocol.org/api/v1` (`4.17.0`); local `http://localhost:8080/api/v1`; EigenLayer-AVS [#761](https://github.com/AvaProtocol/EigenLayer-AVS/issues/761) / staging `0c8aa185`; avs-infra `railway/configs/gateway-railway.yaml`; logs `logs/20260820-170300-full-e2e-prod-final.log`, `logs/20260821-000558-full-e2e-local-761.log`
 
 ## Problem
 
@@ -182,14 +182,137 @@ artifact carrying the bad value.
 
 ## Verification
 
-- Repeat the salt `0,1,2,3` / salt-0 reuse / 3-salt lex probes (must stay true).
-- `TEST_ENV=railway` single-file: `auth.test.ts` (was 4 fails after 3 creates) green with salt-0 reuse.
-- `TEST_ENV=railway` `wallet.test.ts` lex test green with 3 salts.
-- `TEST_ENV=railway` `getToken.test.ts` green after gateway `read` scope.
-- `withdraw` validation (amount 0) on isolated client; on-chain withdraw uses listed salt-2 and either confirms or skip-on-insufficient.
-- Full `TEST_ENV=railway yarn test` logged under `logs/`. Watch for a **real** 429 rate-limit (`title: Too Many Requests` with a rate-limit detail) — production is 10 req/s burst 50. Wallet-cap 429s use the same HTTP status today.
+2026-08-20 `TEST_ENV=railway yarn test` against production `4.17.0` after this change: **45 passed / 9 skipped / 0 failed** suites, **359 passed / 35 skipped** tests (`logs/20260820-170300-full-e2e-prod-final.log`). Before: 41 failed / 161 failed tests, almost all `limit=3` or `PARTNER_ASSERTION_INVALID`.
+
+Skipped suites are expected: 7 stub-backed files (production cannot dial `127.0.0.1`) plus `awaitSignal` / `multichain-per-part-chain` (gated). Stub suites still run against the local docker gateway.
+
+## Remote gateway findings (production `4.17.0`)
+
+Log: `logs/20260820-170300-full-e2e-prod-final.log`. Target `https://api.avaprotocol.org/api/v1`.
+
+| Constraint | What it did to the suite |
+|---|---|
+| `max_wallets_per_owner=3` per chain | Unique `nextTestSalt()` dies on the 4th create (`429`). One process-wide EOA is unusable. Per-file isolated EOA + default salt `"0"` is required. Lex sort must use 3 salts (`0,10,2`), not 4. |
+| Isolated throwaway EOA | Has no indexed tokens. Balance-node "list length > 0" would fail unless skipped or pointed at a funded address. |
+| Partner `aud` = `avs-gateway-prod` | Local `.env` key + `avs-gateway-local`/`staging` is `PARTNER_ASSERTION_INVALID` / `PARTNER_ASSERTION_AUDIENCE`. Studio production PEM matches the registry. |
+| Partner scopes must include `read` | `GET /tokens` requires `read`; `simulate` is not enough (`PARTNER_SCOPE_DENIED` until avs-infra grant). |
+| Default factory ≠ funded factory | `create({ salt: "2" })` derives a new unfunded wallet on `0x0000…6fecd` and 429s. Funded salt-2 lives on legacy `0xB99B…2834` with ~0.043 ETH / ~26 USDC. Must **list**, not re-derive. |
+| Gateway cannot dial `127.0.0.1` | 7 stub-backed suites (restApi, loop, simulateWorkflow, stepInput, telegram, recurring-payment, batch-recurring) must skip. They are not product bugs. |
+| HTTP 429 is overloaded | Wallet-cap and rate-limit share status 429. Cap detail is `max smart wallet count reached for owner (limit=3)`. |
+
+Local (`config/gateway.yaml`) does **not** have the cap of 3 (`max_wallets_per_owner: 2000`), so unique salts and the shared test EOA (which has indexed balances) are the right local shape. The 3-salt budget and isolated-EOA balance skip are production-only adaptations and are relaxed when `TEST_ENV` is unset.
+
+## Remote vs local (full v4 suite)
+
+| | Remote production | Local gateway |
+|---|---|---|
+| URL | `https://api.avaprotocol.org/api/v1` | `http://localhost:8080/api/v1` |
+| `/health` version | `4.17.0` | `4.16.0` |
+| `TEST_ENV` | `railway` | unset (`.env` + code default) |
+| Wallet cap | 3 per owner per chain | 2000 (`config/gateway.yaml`) |
+| Identity | isolated EOA per file | shared `TEST_PRIVATE_KEY` |
+| Default `createSmartWallet` salt | `"0"` | `nextTestSalt()` |
+| Lex-sort salts | 3 (`0,10,2`) on the railway run | 4 (`0,1,10,2`, original) |
+| Balance-node "length > 0" | would fail on empty isolated EOA | **asserted** — shared EOA has indexed tokens |
+| Stub suites (restApi, loop, simulate, stepInput, telegram, recurring, batch) | skip (gateway cannot dial `127.0.0.1`) | **run** |
+| `wallets.list({ chainId })` | ran (`TEST_ENV=railway`) | skipped (Sepolia-only stack) |
+| Expansion-chain E2E | ran | skipped |
+| `POLICIES_CHAIN_NOT_SERVED` | asserted (4.17.0) | no-op skip (4.16.0 still allocates the grant) |
+| Suites passed / skipped / failed | **45 / 9 / 0** | **51 / 3 / 0** |
+| Tests passed / skipped / failed | **359 / 35 / 0** | **372 / 22 / 0** |
+| Duration | 140 s | 102 s |
+| Log | `logs/20260820-170300-full-e2e-prod-final.log` | `logs/20260820-221742-full-e2e-local-2.log` |
+
+Local runs **+6 suites / +13 tests** vs remote because the 7 stub-backed files actually execute. Remote runs expansion-chain + `list({chainId})` that local skips. First local pass had **1 fail**: `policiesLive` unserved-chain refusal — `4.16.0` still returns a prepared grant for chain `999999`. That test now returns early unless `/health` is `>= 4.17.0`.
+
+## Local re-run after rebuild (`4.17.0`)
+
+Log: `logs/20260820-222509-local-417-corresponding.log`. Same binary version as production; local `chains[]` is Sepolia + Ethereum + Base (`config/gateway.yaml`), no Base Sepolia worker, no expansion-chain workers.
+
+| Test | Production `4.17.0` | Local `4.16.0` (pre-rebuild) | Local `4.17.0` (rebuilt) |
+|---|---|---|---|
+| `POLICIES_CHAIN_NOT_SERVED` on prepare(`999999`) | **pass** (400) | prepare **succeeded** (old behaviour) | **pass** (400, 9 ms) |
+| `wallets.list({ chainId: 84532 })` | **pass** (gated on `TEST_ENV=railway`) | skipped (flag off) | **fail** on Base Sepolia (not in local `chains[]`). Retargeted to Base (`8453`). |
+| Expansion-chain JWT `aud=56/42161/10/130/4663` | **pass** | skipped | **pass** (auth only) |
+| Expansion-chain `nodes.run` / simulate WETH `symbol()` | **pass** | skipped | **fail** on BNB/Arb/OP/Unichain/Robinhood (no local workers). Local run now uses Ethereum + Base. |
+
+After retargeting to the local `chains[]` (Sepolia JWT aud, Ethereum `:50053`, Base `:50054`), `MULTICHAIN_TEST=1` against local `4.17.0`:
+
+- `POLICIES_CHAIN_NOT_SERVED` — pass
+- `wallets.list({ chainId: 8453 })` scopes off the Sepolia aud list — pass
+- Ethereum + Base WETH `symbol()` via `nodes.run` and simulate — pass (6/6)
+
+`TEST_ENV=railway` still runs the Wave A/B/Robinhood expansion set. Log: `logs/20260820-223226-local-served-chains.log`.
 
 ## Resolved questions
 
 - **Sequence:** avs-infra `read` scope first (deploy), then SDK env + helpers + test migration. getToken is expected green only after the gateway grant is live.
 - **Partner key:** copy Studio production `GATEWAY_STUDIO_PARTNER_KEY` into gitignored `.env.railway` as `PARTNER_ASSERTION_PRIVATE_KEY`. Example file documents `PARTNER_ASSERTION_AUDIENCE=avs-gateway-prod` without the secret.
+
+## UserOp fixture: MA v2 + session grant (2026-08-20 evening)
+
+The remaining local UserOp/trigger “skips” were not an empty-balance problem. Gateway log:
+
+```
+no session authorization for smart wallet 0x5a8A…8856
+MA v2 execution requires a session grant — the gateway cannot sign as the owner fallback
+```
+
+`0x5a8A…` is salt-2 on the **legacy SimpleAccount** factory `0xB99BC2…2834`. `policies:prepare` refuses that runner (`SESSION_WALLET_NOT_MA_V2`). Tenderly sims do not need a grant; real bundler sends do.
+
+Fix in `tests/utils/client.ts` + `tests/utils/sessionGrant.ts`:
+
+- Funded fixture is **always** salt `"0"` on MA v2 factory `0x0000…6fecd` (CREATE2-stable for `TEST_PRIVATE_KEY`). That row is already in production's 3-wallet cap.
+- Address to fund (Sepolia): **`0x209eb31c199bEB4c386eF83CF442DE1a00667a1F`**. Owner EOA `0x804e…1557`. As of 2026-08-20 evening: ~0.22 ETH + ~56 USDC, deployed.
+- `getFundedFixture()` registers that wallet and submits a one-year session grant (`agentLabel: e2e-funded-wallet`) covering USDC `approve`/`transfer`. Native ETH rows in the allowlist do **not** make native sends work (see #761).
+- `policiesLive` uses `getIsolatedClient()` so its grant-then-revoke cannot tear down the fixture.
+
+Do **not** fund the legacy SimpleAccount `0x5a8A…8856` (factory `0xB99BC2…2834`) — `policies:prepare` refuses it with `SESSION_WALLET_NOT_MA_V2`.
+
+## EigenLayer-AVS #761 — local live check (2026-08-21)
+
+Gateway rebuilt from staging `0c8aa185` (`./out/ap` 2026-08-20 23:57, `/health` still reports `4.17.0`). Both parts of the issue are **correct**. The two design calls in the push (not running `MissingGrantCalls` on `ETHTransfer`; refusing native ETH whether or not a grant exists) are the right ones — a coverage “miss” would send people to re-grant a shape that cannot work.
+
+### Part 1 — native ETH typed refusal
+
+| Probe | Result |
+|---|---|
+| `POST …:withdraw` token=`ETH` | **400** `SESSION_POLICY_NATIVE_NOT_ALLOWED`, ~1 ms, no bundler |
+| Block-triggered `ethTransfer` | execution **failed**; **step** error contains `SESSION_POLICY_NATIVE_NOT_ALLOWED` (trigger envelope only says `1 of 2 steps failed: transfer`) |
+| `ethTransfer` `nodes.run` / `workflows.simulate` | **success** (Tenderly; preflight sits only on `executeRealETHTransfer`) |
+| 1000 ETH withdraw on a **fresh** salt-0 MA v2 wallet (no grant) | still **400** native refusal, not `no session authorization` |
+| Bundler AA23 | **absent** on these paths |
+
+SDK tests now **assert** the code instead of skipping.
+
+### Part 2 — withdraw sends in-process
+
+`ExecuteWithdraw` → `preset.SendUserOpAuto` with gateway-resolved session grant. Worker `ExecuteUserOp` is gone. Live Sepolia on `0x209eb31…`:
+
+| What | Result |
+|---|---|
+| 0.01 USDC to owner | mined `0x80c788f5…` / later full-suite runs also mined |
+| 0.01 USDC to alternate recipient `0x7E5F…5Bdf` | mined `0xfc16444e…` |
+| `no session authorization` / `worker ExecuteUserOp` | **gone** |
+
+Balance reads remain worker-routed; only the send moved. Sponsorship-neutral as stated in the push.
+
+### Full local suite after #761 (closes this investigation)
+
+`env -u TEST_ENV MULTICHAIN_TEST=1 yarn test` against `http://localhost:8080/api/v1`.
+
+| | Production (2026-08-20 helpers) | Local (2026-08-21, #761) |
+|---|---|---|
+| `/health` | `4.17.0` | `4.17.0` (`0c8aa185`) |
+| Suites passed / skipped / failed | 45 / 9 / 0 | **54 / 0 / 0** |
+| Tests passed / skipped / failed | 359 / 35 / 0 | **385 / 0 / 0** |
+| Duration | 140 s | 177 s |
+| Log | `logs/20260820-170300-full-e2e-prod-final.log` | `logs/20260821-000558-full-e2e-local-761.log` |
+
+Local +9 suites vs that production run are the stub-backed files (gateway can dial `127.0.0.1`) plus the UserOp/native-refusal tests that production never executed for real. No `Skipping —` lines in the local log.
+
+**Not in this close-out:** re-running `TEST_ENV=railway` against production. Production still needs the #761 binary deployed before ERC-20 withdraw / native-refusal assertions will match. Expansion-chain Wave A/B/Robinhood remain railway-only.
+
+### Remaining product limit (asserted, not a test hole)
+
+REST session grants **cannot** authorize native ETH (`execute(to, value, 0x)`). That is option C of #761, not an SDK bug. ERC-20 approve/transfer/withdraw on the MA v2 fixture do mine. To actually move ETH, send with the owner key outside the session.

--- a/docs/changes/20260820-production-e2e-wallet-cap-partner-funded.md
+++ b/docs/changes/20260820-production-e2e-wallet-cap-partner-funded.md
@@ -1,0 +1,185 @@
+# Production e2e: wallet cap, partner assertion, funded salt-2
+
+- **Date**: 2026-08-20
+- **Status**: In progress — step 1 (avs-infra `read` grant) shipped, deployed and verified 2026-08-20; steps 2–3 implemented in the working tree; step 4 (full re-run) pending
+- **Branch**: staging
+- **Related**: full v4 suite against `https://api.avaprotocol.org/api/v1` (`4.17.0`); log `logs/20260820-162128-full-e2e-prod.log`; avs-infra `railway/configs/gateway-railway.yaml`; Studio `GATEWAY_STUDIO_PARTNER_KEY`
+
+## Problem
+
+The 2026-08-20 production run of `TEST_ENV=railway yarn test` was **41 failed / 11 passed / 2 skipped** suites (161 failed / 227 passed tests in 78s). Every failure collapsed into two wire errors, plus a third class of tests that never got a chance to run their on-chain path:
+
+1. `429 max smart wallet count reached for owner (limit=3)` — 226 times
+2. `401 PARTNER_ASSERTION_INVALID` on `GET /tokens/*` — 36 times, all `getToken.test.ts`
+3. Funded UserOp tests (`withdraw`, `contractWrite` trigger, `ethTransfer` trigger) share `TEST_PRIVATE_KEY` + salt `"2"`, but `create({ salt: "2" })` without a factory does not resolve that funded wallet on production.
+
+CI still passes because `config/gateway.yaml` sets `max_wallets_per_owner: 2000` and the local partner key + `avs-gateway-local` audience match the docker gateway. Production is a different contract.
+
+## Evidence (live probes against production 4.17.0)
+
+### 1. Wallet cap is per-chain unique addresses, and 4 > 3
+
+Config: every chain in `avs-infra/railway/configs/gateway-railway.yaml` has `max_wallets_per_owner: 3`. Engine enforces it only on **new** DB rows, counting unique addresses for `(chainId, owner)` (`EigenLayer-AVS/core/taskengine/engine.go`). Idempotent re-create of an existing `(factory, salt)` is uncapped.
+
+Probes on a throwaway EOA:
+
+| Experiment | Result |
+|---|---|
+| create salts `0,1,2,3` on Sepolia | `0,1,2` OK; `3` → 429 limit=3 |
+| recreate salt `0` after hitting the cap | OK (same address) |
+| create salt `0` on Base Sepolia (84532) after Sepolia is full | OK — quota is per chain |
+| `wallet.test.ts` lex order salts `10,2,0,1` | 4th salt (`1`) 429 |
+| rewritten lex salts `10,2,0` | all OK; list order `0,10,2` is lexicographic |
+| 6 unique salts | 3 failures starting at index 3 |
+| 6× salt `"0"` | 0 failures |
+
+A **process-wide** isolated `TEST_PRIVATE_KEY` does not fix a full `yarn test`: the first few files burn the 3 slots, later files fail. `getIsolatedClient()` per file is also not enough by itself: `wallet.test.ts` has 19 create sites / 9 `nextTestSalt()`; `workflow.test.ts` and `getExecutions.test.ts` already isolate **and still failed** because they keep minting unique salts on that one EOA.
+
+`createSmartWallet()` defaults to `nextTestSalt()` (`tests/utils/client.ts`) — unique per worker **and** per run, designed for CI's 2000 cap. That default is the production-incompatible part.
+
+### 2. Partner: wrong key, wrong audience, and production does not grant `read`
+
+Signature verification runs **before** audience and scope (`aggregator/rest/partner.go`). Error codes therefore diagnose the first failing check:
+
+| Key | `aud` | `scope` | Live result |
+|---|---|---|---|
+| ava-sdk-js `.env` (local) | local / staging / prod | `read` | `401 PARTNER_ASSERTION_INVALID` |
+| Studio `.env.production` / `.env.preview` | `avs-gateway-staging` | `read` | `401 PARTNER_ASSERTION_AUDIENCE` — `aud` must include `avs-gateway-prod` |
+| Studio production key | `avs-gateway-prod` | `read` | `403 PARTNER_SCOPE_DENIED` — partner `"studio"` is **not granted** `read` |
+| Studio production key | `avs-gateway-prod` | `simulate` or `read,simulate` | still `403 PARTNER_SCOPE_DENIED` for `read` (`GET /tokens` requires `read`) |
+
+Public-key fingerprint of Studio production/preview `GATEWAY_STUDIO_PARTNER_KEY` matches the registry entry `6+YmyiVFzBGhuVnvYwUr595wxcrngdT6BzcI2jjQjU4=` in `gateway-railway.yaml`. The ava-sdk-js `.env` key is a **different** key (local docker partner).
+
+`gateway-railway.yaml` currently has `partners[studio].scopes: [simulate]` and `partner_assertion_audience: "avs-gateway-prod"`. Studio's own `STUDIO_PARTNER_READ_ADOPTION.md` already says production must grant `read` (simulate no longer authorizes token metadata). The live 403 confirms the yaml is what is deployed.
+
+So `getToken.test.ts` cannot go green on production from an SDK env change alone.
+
+### 3. Funded salt-2 exists, but `create({ salt: "2" })` does not hit it
+
+Shared test EOA `0x804e…1557` Sepolia list (4 unique addresses, already **over** the cap of 3):
+
+- salt `0` on factory `0x0000…6fecd` (current default)
+- salt `0`, `1`, `2` on factory `0xB99B…2834` (legacy)
+
+On-chain at salt-2 `0x5a8A…8856` (legacy factory): **0.043 ETH**, **25.92 USDC**. Funded.
+
+A **fresh** EOA's `wallets.create({ salt: "0" })` uses default factory `0x0000…6fecd`. `create({ salt: "2" })` on the shared EOA therefore derives a **new** address on the default factory, misses the funded row, trips 429.
+
+Isolated empty wallet:
+
+- Tenderly `nodes.run` `approve(..., 0)` → `success=true`, `is_simulated=true`, `provider=tenderly` (no funds needed)
+- `withdraw` amount `0` → `400 WITHDRAW_BAD_AMOUNT` (validation works)
+- `withdraw` 0.001 ETH → `400 insufficient balance` — `submitWithdrawOrSkip` already treats 400 as a skip
+
+Real UserOps must use the **existing** salt-2 + **legacy factory** on the shared EOA. Simulate/validation must not.
+
+## Decision
+
+Three layered changes. Do not raise production `max_wallets_per_owner` — that cap is a product constraint.
+
+### A. Tight-cap identity (SDK tests) — fixes 226 of 161 failures
+
+When `TEST_ENV=railway` (or an explicit `TIGHT_WALLET_CAP=1`):
+
+1. **Per-file isolated EOA** via `getIsolatedClient()` (or a `getSuiteClient()` wrapper). Jest `runInBand` is one process; isolation must be per file, not one env var for the whole run.
+2. **Default `createSmartWallet` salt is `"0"`** in tight-cap mode (idempotent ensure-exists). Keep `nextTestSalt()` for CI (`max_wallets=2000`) so parallel workers on the shared key still do not collide.
+3. Tests that need **N distinct wallets on one owner** pass explicit salts and stay at **N ≤ 3**. Rewrite the lex-order test from `["10","2","0","1"]` to `["10","2","0"]` (proved lexicographic and under the cap).
+4. Tests that need **owner-scoped isolation** (exact list counts, pagination) already use `getIsolatedClient`; switch those creates to salt `"0"` / `"1"` / `"2"` instead of `nextTestSalt()`.
+
+Mechanical surface: `tests/utils/client.ts` (`createSmartWallet`, `getSuiteClient`) plus every `beforeAll` that currently does `getClient(); authenticateClient(client)`. Files that already isolate keep doing so.
+
+### B. Partner reads — SDK env + gateway scope
+
+1. **ava-sdk-js (gitignored):** `.env.railway` sets `PARTNER_ASSERTION_AUDIENCE=avs-gateway-prod` and `PARTNER_ASSERTION_PRIVATE_KEY` to the Studio production partner key (same PEM as `GATEWAY_STUDIO_PARTNER_KEY`). Update `.env.railway.example` comments: audience is `avs-gateway-prod`, not `avs-gateway-staging`.
+2. **avs-infra (required):** `partners[studio].scopes` in `gateway-railway.yaml` must include `read` (keep `simulate` if anything still claims it; `GET /tokens` will not accept simulate). Until that deploys, getToken stays 403 even with the right key.
+3. Tests: if partner key is missing or the gateway returns `PARTNER_SCOPE_DENIED`, fail with a one-line "gateway studio partner needs scope read" rather than 36 duplicate retrieve errors. Do not skip silently on railway — that would hide a production Studio break.
+
+### C. Funded UserOps — look up, don't re-derive
+
+1. Add `getFundedWallet(client)` that **lists** the shared EOA's wallets, picks salt `"2"` on factory `0xB99B…2834` (or the salt-2 row that actually holds ETH/USDC). Never `create({ salt: "2" })` without `factoryAddress` on railway.
+2. Only **on-chain UserOp** tests use `getFundedClient()` (shared `TEST_PRIVATE_KEY`) + `getFundedWallet()`. Confirmed: `withdraw` happy-path, `contractWrite` deploy+trigger, `ethTransfer` trigger. Keep the existing 400/insufficient skip so an unfunded chain still does not fail the suite.
+3. **Simulate / `nodes.run` / validation** switch to the isolated suite wallet (salt `"0"`). Proved: Tenderly approve succeeds with 0 ETH / 0 USDC. Drop the salt-`"2"` habit from `contractWrite` sim tests, `runNodeWithInputs`, `approve-with-simulation`, `uniswapv3_stoploss` simulate, `workflow-usdc-read-write-customcode` simulate.
+
+## Alternatives considered
+
+- **Raise production cap to 2000.** Rejected. Production yaml is explicit ("Production cap") on every chain; tests should not require a product-limit change.
+- **One random `TEST_PRIVATE_KEY` for the whole `yarn test` process.** Tried. Burns 3 slots in `auth.test.ts` and the rest of the suite dies.
+- **Per-file isolated EOA only, keep `nextTestSalt()`.**** Insufficient. Any file with ≥4 unique creates still 429s (`wallet.test.ts`, `workflow.test.ts`, `getExecutions.test.ts`).
+- **Per-test isolated EOA everywhere.** Would work for single-wallet tests; the lex test still needs 3 salts on one owner. Too much SIWE overhead; default salt `"0"` per file is enough.
+- **SDK-only partner fix (env key + `avs-gateway-prod`).** Proved insufficient: live 403 `PARTNER_SCOPE_DENIED`. Gateway yaml must grant `read`.
+- **Hard-code funded wallet address.** Brittle across factory rotations. List + match salt/factory/balance is the same lookup the gateway already serves.
+
+## PR plan
+
+1. ~~**avs-infra:** add `read` to `partners[studio].scopes` on `gateway-railway.yaml`. Deploy. Probe.~~ **Done** — see "Step 1 outcome" below.
+2. **ava-sdk-js env + helpers (this repo):** tight-cap `createSmartWallet` default; `getSuiteClient` / `getFundedClient` / `getFundedWallet`; `.env.railway` partner audience + key; example file comments.
+3. **ava-sdk-js test migration:** convert `beforeAll` to suite client; rewrite ≥4-salt tests; move sim tests off salt `"2"`; keep UserOp tests on funded lookup. Can land as one PR or split core helpers vs mechanical file conversion.
+4. **Re-run** `TEST_ENV=railway yarn test` against production. Expect getToken green only after PR 1 is live.
+
+## Step 1 outcome (avs-infra, 2026-08-20)
+
+`partners[studio].scopes` on `railway/configs/gateway-railway.yaml` changed
+`[simulate]` → `[read]` (avs-infra `a97dc40`), synced with
+`./railway/sync-configs.sh gateway --apply`.
+
+`simulate` was not merely insufficient — it is **dead**. The gateway calls
+`verifyPartnerAssertion` with exactly one required scope, `read`, from two
+sites in `aggregator/rest/permission.go` (`authPartnerRead`,
+`authPartnerWalletPreview`). No code path anywhere requires `simulate`, so the
+deployed registry entry granted studio nothing at all. It was left over from
+the pre-permission-map design where partner delegation covered the simulate
+family. `[read]` replaces it rather than being appended to it.
+
+Before applying, the deployed `AP_CONFIG_YAML` was fetched and diffed against
+repo HEAD: byte-identical, so no dashboard-side edit was clobbered.
+
+Live verification against `api.avaprotocol.org` (gateway `4.17.0`), Studio
+production key, `aud=avs-gateway-prod`:
+
+| Probe | Before | After |
+|---|---|---|
+| `GET /tokens/{usdc}?chainId=11155111`, `scope=read` | `403 PARTNER_SCOPE_DENIED` | **`200`** `USD Coin / USDC / 6` |
+| `GET /wallets?chainId=11155111` with `sub` = test EOA | (blocked) | **`200`**, 4 rows |
+| `aud=avs-gateway-staging` | `401 PARTNER_ASSERTION_AUDIENCE` | `401 PARTNER_ASSERTION_AUDIENCE` (unchanged) |
+| assertion declaring only `scope=simulate` | — | `403 PARTNER_TOKEN_SCOPE` (registry grant alone is not enough) |
+| no `X-Partner-Assertion` header | `401` partner required | `401` partner required (unchanged) |
+
+`TEST_ENV=railway npx jest tests/v4/core/getToken.test.ts` → **24 passed / 24**,
+including `user JWT alone is rejected (partner required)`. That closes all 36
+`getToken` failures.
+
+Two collateral confirmations:
+
+- **Studio production was itself broken**, not just the test suite. Its Vercel
+  `GATEWAY_PARTNER_AUDIENCE` is `avs-gateway-prod` and its
+  `GATEWAY_STUDIO_PARTNER_KEY` fingerprints to the registry key, so token
+  metadata and partner-only preview-wallet resolve were 403ing in production
+  for real users until this deploy.
+- **Issue 3's wallet list is confirmed from the wire.** The partner
+  `GET /wallets` for `0x804e…1557` on Sepolia returns exactly the 4 rows the
+  cap analysis predicted — salt `0` on default factory `0x0000…6fecd`, and
+  salts `0`/`1`/`2` on legacy factory `0xB99B…2834`, with funded salt-2 at
+  `0x5a8A8a79DdF433756D4D97DCCE33334D9E218856`. `getFundedWallet()` can match
+  on `(salt, factoryAddress)` straight from this response.
+
+`.env.railway` already carries the Studio production key, `iss=studio`, and
+`PARTNER_ASSERTION_AUDIENCE=avs-gateway-prod`, so no SDK-side partner work
+remains — 2B.1 is satisfied.
+
+Still stale elsewhere: `EigenLayer-AVS config/gateway-sepolia.yaml` has the
+same dead `scopes: [simulate]`. Local-dev-only (audience `avs-gateway-local`),
+but it will bite the next person who runs the suite against it.
+
+## Verification
+
+- Repeat the salt `0,1,2,3` / salt-0 reuse / 3-salt lex probes (must stay true).
+- `TEST_ENV=railway` single-file: `auth.test.ts` (was 4 fails after 3 creates) green with salt-0 reuse.
+- `TEST_ENV=railway` `wallet.test.ts` lex test green with 3 salts.
+- `TEST_ENV=railway` `getToken.test.ts` green after gateway `read` scope.
+- `withdraw` validation (amount 0) on isolated client; on-chain withdraw uses listed salt-2 and either confirms or skip-on-insufficient.
+- Full `TEST_ENV=railway yarn test` logged under `logs/`. Watch for a **real** 429 rate-limit (`title: Too Many Requests` with a rate-limit detail) — production is 10 req/s burst 50. Wallet-cap 429s use the same HTTP status today.
+
+## Resolved questions
+
+- **Sequence:** avs-infra `read` scope first (deploy), then SDK env + helpers + test migration. getToken is expected green only after the gateway grant is live.
+- **Partner key:** copy Studio production `GATEWAY_STUDIO_PARTNER_KEY` into gitignored `.env.railway` as `PARTNER_ASSERTION_PRIVATE_KEY`. Example file documents `PARTNER_ASSERTION_AUDIENCE=avs-gateway-prod` without the secret.

--- a/docs/changes/20260820-production-e2e-wallet-cap-partner-funded.md
+++ b/docs/changes/20260820-production-e2e-wallet-cap-partner-funded.md
@@ -166,9 +166,19 @@ Two collateral confirmations:
 `PARTNER_ASSERTION_AUDIENCE=avs-gateway-prod`, so no SDK-side partner work
 remains — 2B.1 is satisfied.
 
-Still stale elsewhere: `EigenLayer-AVS config/gateway-sepolia.yaml` has the
-same dead `scopes: [simulate]`. Local-dev-only (audience `avs-gateway-local`),
-but it will bite the next person who runs the suite against it.
+The same dead `scopes: [simulate]` was also sitting in
+`EigenLayer-AVS config/gateway-sepolia.yaml` — fixed to `[read]`, with the
+comment block realigned to the wording already used in `config/gateway.yaml`
+(it still pointed at the retired `PLAN_PARTNER_PAYMENTS.md`). That file needs
+no PR: every real `config/*.yaml` is gitignored and symlinked into the local
+`ClaudeSync/EigenLayer-AVS-env/config/` store, so only the `*.example.yaml`
+files are tracked, and `config/gateway.example.yaml` already said `read`. All
+four gateway configs — local, local-sepolia, example, and prod — now parse to
+`scopes=[read]` through `config.PartnerConfig`.
+
+One consequence of that layout: any *other* machine with a stale local
+`gateway-sepolia.yaml` has to be fixed by hand, since there is no repo-side
+artifact carrying the bad value.
 
 ## Verification
 

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -1,0 +1,9 @@
+# ava-sdk-js change log
+
+Long-form notes for changes worth remembering after the PR merges. Filename: `YYYYMMDD-kebab-case-title.md`. Each entry opens with a header block (Date, Status, Branch, Related) and a body adapted to the change (typically Problem / Decision / Alternatives / Verification).
+
+## Project-specific notes
+
+- Production gateway is Railway `eigenlayer-avs` / environment `production`, public URL `https://api.avaprotocol.org/api/v1`.
+- Partner assertions: Studio private key in Vercel `GATEWAY_STUDIO_PARTNER_KEY`; gateway public key + audience live in `avs-infra/railway/configs/gateway-railway.yaml`.
+- v4 e2e against production: `TEST_ENV=railway` (after `.env` no longer pins `AVS_REST_URL`).

--- a/tests/utils/client.ts
+++ b/tests/utils/client.ts
@@ -384,7 +384,7 @@ export async function getFundedFixture(
 
 /** Fail a trigger that bounced instead of treating UserOp errors as skips. */
 export function assertUserOpTriggerOk(
-  trig: { status?: string; error?: string },
+  trig: Pick<v4.TriggerWorkflowResponse, "status" | "error">,
   walletAddress: string,
 ): void {
   if (trig.status === "failed" || trig.status === "error" || trig.error) {

--- a/tests/utils/client.ts
+++ b/tests/utils/client.ts
@@ -25,10 +25,20 @@ import {
 } from "@avaprotocol/sdk-js";
 
 import { TEST_REST_URL, requireEnv } from "./env";
+import { ensureE2eSessionGrant } from "./sessionGrant";
 
 /** Returns the configured test EOA private key. */
 export function testPrivateKey(): string {
   return requireEnv("TEST_PRIVATE_KEY");
+}
+
+/**
+ * Production (and any `TIGHT_WALLET_CAP=1` gateway) allows 3 smart
+ * wallets per owner per chain. CI's docker gateway allows 2000, which
+ * is why `nextTestSalt()` was a fine default there and a 429 here.
+ */
+export function tightWalletCap(): boolean {
+  return process.env.TIGHT_WALLET_CAP === "1" || process.env.TEST_ENV === "railway";
 }
 
 /**
@@ -58,7 +68,7 @@ export function decodeJwtPayload(token: string): Record<string, unknown> {
  *
  * It is NOT for suites that need funds. A fresh EOA owns nothing, so anything
  * sending a real UserOp, spending gas, or touching a pre-funded fixture wallet
- * must keep using {@link authenticateClient} with the shared key.
+ * must use {@link getFundedFixture}.
  */
 export async function getIsolatedClient(
   overrides?: Partial<ClientOptions>,
@@ -67,6 +77,41 @@ export async function getIsolatedClient(
   const client = getClient(overrides);
   await authenticateClient(client, wallet.privateKey);
   return { client, owner: wallet.address, privateKey: wallet.privateKey };
+}
+
+/**
+ * Client for a typical suite. On a tight-cap gateway this is a throwaway
+ * EOA so the file does not share the process-wide `TEST_PRIVATE_KEY` quota.
+ * On CI it authenticates as the shared test key (cap 2000).
+ *
+ * Always use the returned `owner` — {@link getEOAAddress} still reads
+ * `TEST_PRIVATE_KEY` and is the wrong subject for an isolated client.
+ */
+export async function getSuiteClient(
+  overrides?: Partial<ClientOptions>,
+): Promise<{ client: Client; owner: string; privateKey: string }> {
+  if (tightWalletCap()) {
+    return getIsolatedClient(overrides);
+  }
+  const client = getClient(overrides);
+  await authenticateClient(client);
+  return { client, owner: getEOAAddress(), privateKey: testPrivateKey() };
+}
+
+/**
+ * Shared `TEST_PRIVATE_KEY` client. Only for tests that need the
+ * pre-funded MA v2 salt-0 wallet. Does not isolate.
+ *
+ * Prefer {@link getFundedFixture} for real UserOps — that helper also
+ * ensures the session grant the gateway requires to sign.
+ */
+export async function getFundedClient(
+  overrides?: Partial<ClientOptions>,
+): Promise<{ client: Client; owner: string; privateKey: string }> {
+  const client = getClient(overrides);
+  const privateKey = testPrivateKey();
+  await authenticateClient(client, privateKey);
+  return { client, owner: getEOAAddress(privateKey), privateKey };
 }
 
 /** Returns a fresh, unauthenticated v4 Client pointed at the test stack. */
@@ -215,9 +260,9 @@ export async function buildAuthPayload(
  *     cannot land on yesterday's wallets.
  *
  * Salts stay above 1_000 so they never collide with user-driven wallets in
- * dev. Note `max_wallets_per_owner` is 2_000 per chain — unique salts mean
- * wallet records accumulate, so a long-lived shared test EOA needs an
- * occasional sweep rather than being assumed infinite.
+ * dev. Note CI `max_wallets_per_owner` is 2_000 per chain; production is 3,
+ * which is why {@link createSmartWallet} defaults to salt `"0"` under
+ * {@link tightWalletCap} rather than minting a unique salt every call.
  */
 // The two strides must not be able to alias. Worker occupies the low digits
 // and cannot exceed its stride (10k wallets from one worker in one run is far
@@ -258,23 +303,122 @@ export interface CreateSmartWalletOptions {
 }
 
 /**
+ * Alchemy Modular Account v2 factory. Session grants (and therefore
+ * every real UserOp) only attach to this account type. The legacy
+ * SimpleAccount factory `0xB99BC2…2834` still holds historical ETH on
+ * salt-2, but `policies:prepare` refuses it with SESSION_WALLET_NOT_MA_V2.
+ *
+ * Salt `"0"`: the owner's default MA v2 wallet. It is already in
+ * production's 3-wallet cap, and CREATE2(owner, factory, 0) is the
+ * address to fund once. `policiesLive.test.ts` uses an isolated EOA
+ * so its grant-then-revoke cannot tear this fixture down.
+ *
+ * Address is CREATE2(owner, factory, salt) — stable across runs for a
+ * given `TEST_PRIVATE_KEY`. Fund that address, not a fresh salt.
+ */
+export const FUNDED_WALLET_SALT = "0";
+export const FUNDED_FACTORY_ADDRESS =
+  "0x00000000000017c61b5bEe81050EC8eFc9c6fecd";
+
+/**
+ * Resolve the MA v2 salt-0 wallet on the authenticated owner.
+ *
+ * Looks up the existing (factory, salt) row and only creates if none
+ * exists. Never falls back to the legacy SimpleAccount factory.
+ * Returns `undefined` when create is refused (cap) — caller should
+ * skip on-chain.
+ */
+export async function getFundedWallet(
+  client: Client,
+): Promise<v4.Wallet | undefined> {
+  const listed = await client.wallets.list();
+  const existing = listed.data.find(
+    (w) =>
+      w.salt === FUNDED_WALLET_SALT &&
+      w.factoryAddress?.toLowerCase() ===
+        FUNDED_FACTORY_ADDRESS.toLowerCase(),
+  );
+  if (existing) return existing;
+
+  try {
+    return await client.wallets.create({
+      salt: FUNDED_WALLET_SALT,
+      factoryAddress: FUNDED_FACTORY_ADDRESS,
+    });
+  } catch (error) {
+    if (error instanceof APIError && error.status === 429) return undefined;
+    throw error;
+  }
+}
+
+/**
+ * The funded UserOp fixture: shared EOA + MA v2 salt-0 runner + a
+ * covering session grant. Every real-bundler test should take the
+ * wallet from here so funding one address covers the suite.
+ */
+export async function getFundedFixture(
+  overrides?: Partial<ClientOptions>,
+): Promise<{
+  client: Client;
+  owner: string;
+  privateKey: string;
+  wallet: v4.Wallet;
+}> {
+  const { client, owner, privateKey } = await getFundedClient(overrides);
+  const wallet = await getFundedWallet(client);
+  if (!wallet) {
+    throw new Error(
+      `MA v2 funded wallet is not registered (salt ${FUNDED_WALLET_SALT}, factory ${FUNDED_FACTORY_ADDRESS}). ` +
+        `Create it once for this owner, fund it on Sepolia with ETH and USDC, then re-run.`,
+    );
+  }
+  await ensureE2eSessionGrant(
+    client,
+    wallet.address,
+    privateKey,
+    owner,
+    TEST_AUTH_CHAIN_ID,
+  );
+  return { client, owner, privateKey, wallet };
+}
+
+/** Fail a trigger that bounced instead of treating UserOp errors as skips. */
+export function assertUserOpTriggerOk(
+  trig: { status?: string; error?: string },
+  walletAddress: string,
+): void {
+  if (trig.status === "failed" || trig.status === "error" || trig.error) {
+    throw new Error(
+      `UserOp failed for MA v2 funded wallet ${walletAddress} ` +
+        `(salt ${FUNDED_WALLET_SALT}, factory ${FUNDED_FACTORY_ADDRESS}): ` +
+        `${trig.status ?? ""}${trig.error ? `: ${trig.error}` : ""}. ` +
+        `Fund this address on Sepolia with ETH (and USDC for ERC-20 tests).`,
+    );
+  }
+}
+
+/**
  * Mints (or re-resolves) a smart wallet via `POST /wallets`, which
  * is the v4 REST API's idempotent ensure-exists endpoint. Returns
  * the Wallet envelope as the spec defines it (lowercase strings,
  * `factoryAddress` not `factory`).
  *
- * Default behaviour: `nextTestSalt()` returns a fresh salt each call,
- * so each invocation derives a distinct CREATE2 address and registers
- * a brand-new wallet record — that's why the name is `create`, not
- * `get`. Callers that need a stable wallet across re-runs pass an
- * explicit `saltValue`, and the same (owner, salt) always returns the
- * same address — get-or-create semantics under the hood.
+ * Default salt:
+ *   - tight-cap (`TEST_ENV=railway` / `TIGHT_WALLET_CAP=1`): `"0"`,
+ *     so a suite can call this many times without burning the 3-wallet
+ *     quota. Distinct wallets must pass `saltValue` (`"1"` / `"2"`, at
+ *     most two extra on one owner).
+ *   - CI / local: `nextTestSalt()`, unique per worker and run, matching
+ *     the 2000-wallet docker quota.
+ *
+ * For the funded UserOp fixture use {@link getFundedFixture}, not a
+ * unique salt from this helper.
  */
 export async function createSmartWallet(
   client: Client,
   options: CreateSmartWalletOptions = {},
 ): Promise<v4.Wallet> {
-  const salt = options.saltValue ?? nextTestSalt();
+  const salt = options.saltValue ?? (tightWalletCap() ? "0" : nextTestSalt());
   return client.wallets.create({
     salt,
     ...(options.factoryAddress ? { factoryAddress: options.factoryAddress } : {}),

--- a/tests/utils/env.ts
+++ b/tests/utils/env.ts
@@ -1,20 +1,20 @@
 /**
- * Test env helpers. Loads .env first (then .env.$TEST_ENV if set)
- * so test runs pick up the same configuration the v3 suite used
- * without each spec file having to call dotenv on its own.
+ * Test env helpers. Loads `.env.$TEST_ENV` first (when set), then `.env`
+ * as fallback. `override: false` so process env / CLI always wins.
+ *
+ * Specific-first matters for `TEST_ENV=railway`: `.env` holds local
+ * partner audience/key, `.env.railway` holds production's. Loading
+ * `.env` first used to pin those and ignore the railway file.
  */
 
 import * as path from "node:path";
 import * as fs from "node:fs";
 import * as dotenv from "dotenv";
 
-// Load in priority order: process env wins, then .env, then
-// .env.$TEST_ENV (defaults to "dev"). Quietly skip files that
-// don't exist — local devs keep different combinations.
 (function loadEnv(): void {
   const repoRoot = path.resolve(__dirname, "..", "..");
   const target = process.env.TEST_ENV ?? "dev";
-  const candidates = [path.join(repoRoot, ".env"), path.join(repoRoot, `.env.${target}`)];
+  const candidates = [path.join(repoRoot, `.env.${target}`), path.join(repoRoot, ".env")];
   for (const file of candidates) {
     if (fs.existsSync(file)) {
       dotenv.config({ path: file, override: false });
@@ -54,5 +54,5 @@ export const TEST_API_KEY = (): string | undefined => process.env.AVS_API_KEY;
  *
  * - PARTNER_ASSERTION_PRIVATE_KEY — base64 Ed25519 private seed
  * - PARTNER_ASSERTION_ISSUER — default "studio"
- * - PARTNER_ASSERTION_AUDIENCE — e.g. "avs-gateway-local"
+ * - PARTNER_ASSERTION_AUDIENCE — local: avs-gateway-local; production: avs-gateway-prod
  */

--- a/tests/utils/sessionGrant.ts
+++ b/tests/utils/sessionGrant.ts
@@ -107,7 +107,7 @@ function stillValid(policy: v4.SessionPolicy): boolean {
   );
 }
 
-let inflight: Promise<v4.SessionPolicy> | undefined;
+const inflight = new Map<string, Promise<v4.SessionPolicy>>();
 
 /**
  * Reuse a covering pending/active grant on this runner, or submit one.
@@ -120,6 +120,10 @@ export async function ensureE2eSessionGrant(
   ownerAddress: string,
   chainId: number,
 ): Promise<v4.SessionPolicy> {
+  const key = `${chainId}:${ownerAddress.toLowerCase()}:${walletAddress.toLowerCase()}`;
+  const existing = inflight.get(key);
+  if (existing) return existing;
+
   const run = async (): Promise<v4.SessionPolicy> => {
     const required = e2eSessionActions(ownerAddress);
     const listed = await client.policies.list(walletAddress, { chainId });
@@ -160,10 +164,9 @@ export async function ensureE2eSessionGrant(
     }
   };
 
-  if (!inflight) {
-    inflight = run().finally(() => {
-      inflight = undefined;
-    });
-  }
-  return inflight;
+  const pending = run().finally(() => {
+    inflight.delete(key);
+  });
+  inflight.set(key, pending);
+  return pending;
 }

--- a/tests/utils/sessionGrant.ts
+++ b/tests/utils/sessionGrant.ts
@@ -1,0 +1,169 @@
+/**
+ * Long-lived session grant for the MA v2 funded UserOp fixture.
+ *
+ * Real bundler sends refuse to sign without a grant, and grants only
+ * attach to Modular Account v2. This is the single place the e2e
+ * suite compiles that grant, so every UserOp test hits the same
+ * runner with the same allowlist.
+ */
+
+import { Wallet as EthersWallet } from "ethers";
+
+import {
+  Chains,
+  SessionPolicyActions,
+  Tokens,
+  actionsCover,
+  type Client,
+} from "@avaprotocol/sdk-js";
+import type { v4 } from "@avaprotocol/types";
+
+/** Native value transfer (empty calldata) as the allowlist records it. */
+export const SELECTOR_NATIVE_VALUE = "0x00000000";
+
+/**
+ * Gateway problem+json `code` for a native ETH send under a REST
+ * session grant (EigenLayer-AVS #761). Every REST grant is
+ * selector-scoped, so `execute(to, value, 0x)` cannot validate.
+ * Re-granting does not fix it.
+ */
+export const SESSION_POLICY_NATIVE_NOT_ALLOWED =
+  "SESSION_POLICY_NATIVE_NOT_ALLOWED";
+
+/** Stable label so later runs reuse this grant instead of replacing it. */
+export const E2E_SESSION_AGENT_LABEL = "e2e-funded-wallet";
+
+/** One year — the fixture is meant to be funded once and left alone. */
+export const E2E_GRANT_TTL_SECONDS = 365 * 24 * 60 * 60;
+
+/** 1000 USDC (6 decimals). Approve(0) is free; withdraw spends 0.01. */
+export const E2E_USDC_SPEND_CAP = "1000000000";
+
+/**
+ * Same key `withdraw.test.ts` uses for the alternate-recipient case.
+ * Native ETH to that address must be on the grant or the UserOp AA23s.
+ */
+export const E2E_WITHDRAW_ALTERNATE_KEY =
+  "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+export function e2eWithdrawAlternateRecipient(): string {
+  return new EthersWallet(E2E_WITHDRAW_ALTERNATE_KEY).address;
+}
+
+export function signTypedDataWithEthers(privateKey: string) {
+  const signer = new EthersWallet(privateKey);
+  return async (
+    typedData: Readonly<Record<string, unknown>>,
+  ): Promise<string> => {
+    const { domain, types, message } = typedData as {
+      domain: Record<string, unknown>;
+      types: Record<string, unknown>;
+      message: Record<string, unknown>;
+    };
+    const { EIP712Domain: _ignored, ...rest } = types as Record<
+      string,
+      unknown
+    >;
+    return signer.signTypedData(
+      domain as never,
+      rest as never,
+      message as never,
+    );
+  };
+}
+
+export function e2eSessionActions(owner: string): v4.AllowedAction[] {
+  const usdc = Tokens.USDC[Chains.Sepolia]!.address;
+  return SessionPolicyActions.merge([
+    SessionPolicyActions.erc20Approve(usdc),
+    SessionPolicyActions.erc20Transfer(usdc),
+    SessionPolicyActions.custom(owner, [SELECTOR_NATIVE_VALUE]),
+    SessionPolicyActions.custom(e2eWithdrawAlternateRecipient(), [
+      SELECTOR_NATIVE_VALUE,
+    ]),
+  ]);
+}
+
+function e2eGrantRequest(
+  owner: string,
+  chainId: number,
+): v4.PreparePolicyRequest {
+  const usdc = Tokens.USDC[Chains.Sepolia]!.address;
+  return {
+    chainId,
+    agentLabel: E2E_SESSION_AGENT_LABEL,
+    justification:
+      "ava-sdk-js e2e UserOp fixture — USDC approve/transfer and native ETH",
+    allowedActions: e2eSessionActions(owner),
+    erc20SpendCap: { token: usdc, amount: E2E_USDC_SPEND_CAP },
+    expiresInSeconds: E2E_GRANT_TTL_SECONDS,
+  };
+}
+
+function stillValid(policy: v4.SessionPolicy): boolean {
+  return (
+    (policy.status === "pending" || policy.status === "active") &&
+    policy.validUntil > Date.now() + 24 * 60 * 60 * 1000
+  );
+}
+
+let inflight: Promise<v4.SessionPolicy> | undefined;
+
+/**
+ * Reuse a covering pending/active grant on this runner, or submit one.
+ * Does not revoke — the fixture grant is meant to outlive a single test.
+ */
+export async function ensureE2eSessionGrant(
+  client: Client,
+  walletAddress: string,
+  ownerPrivateKey: string,
+  ownerAddress: string,
+  chainId: number,
+): Promise<v4.SessionPolicy> {
+  const run = async (): Promise<v4.SessionPolicy> => {
+    const required = e2eSessionActions(ownerAddress);
+    const listed = await client.policies.list(walletAddress, { chainId });
+    const usable = listed.items.filter(stillValid);
+
+    const labeled = usable.find(
+      (p) => p.agentLabel === E2E_SESSION_AGENT_LABEL,
+    );
+    if (labeled) {
+      if (
+        !labeled.allowedActions ||
+        labeled.allowedActions.length === 0 ||
+        actionsCover(required, labeled.allowedActions)
+      ) {
+        return labeled;
+      }
+    }
+
+    const covering = usable.find((p) =>
+      actionsCover(required, p.allowedActions ?? []),
+    );
+    if (covering) return covering;
+
+    try {
+      return await client.policies.grant(
+        walletAddress,
+        e2eGrantRequest(ownerAddress, chainId),
+        signTypedDataWithEthers(ownerPrivateKey),
+      );
+    } catch (err) {
+      const e = err as { status?: number };
+      if (e.status === 409) {
+        const retry = await client.policies.list(walletAddress, { chainId });
+        const won = retry.items.find(stillValid);
+        if (won) return won;
+      }
+      throw err;
+    }
+  };
+
+  if (!inflight) {
+    inflight = run().finally(() => {
+      inflight = undefined;
+    });
+  }
+  return inflight;
+}

--- a/tests/utils/stubServer.ts
+++ b/tests/utils/stubServer.ts
@@ -30,6 +30,24 @@ import type { AddressInfo } from "node:net";
 
 import type { Client } from "@avaprotocol/sdk-js";
 
+/** True when the gateway is this machine and can dial 127.0.0.1. */
+export function isLocalGateway(): boolean {
+  const raw = process.env.AVS_REST_URL ?? "http://localhost:8080/api/v1";
+  try {
+    const host = new URL(raw).hostname;
+    return host === "localhost" || host === "127.0.0.1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stub-backed suites need the gateway to dial this process. Skip them
+ * against a remote gateway (`TEST_ENV=railway`) instead of failing every
+ * test with a connection-refused probe.
+ */
+export const describeIfGatewayCanReachStub = isLocalGateway() ? describe : describe.skip;
+
 export interface StubServer {
   /** Base URL the gateway should call, e.g. http://127.0.0.1:53124 */
   readonly baseUrl: string;

--- a/tests/v4/core/auth.test.ts
+++ b/tests/v4/core/auth.test.ts
@@ -18,7 +18,6 @@ import { APIError, Client } from "@avaprotocol/sdk-js";
 import {
   TEST_AUTH_CHAIN_ID,
   TEST_AUTH_URI,
-  authenticateClient,
   buildAuthPayload,
   decodeJwtPayload,
   generateSignature,

--- a/tests/v4/core/auth.test.ts
+++ b/tests/v4/core/auth.test.ts
@@ -24,8 +24,8 @@ import {
   generateSignature,
   getClient,
   getEOAAddress,
+  getSuiteClient,
   createSmartWallet,
-  nextTestSalt,
   removeCreatedWorkflows,
   testPrivateKey,
 } from "../../utils/client";
@@ -42,15 +42,13 @@ describe("Authentication Tests", () => {
     let client: Client;
 
     beforeAll(async () => {
-      client = getClient();
-      await authenticateClient(client);
+      ({ client } = await getSuiteClient());
     });
 
     test("wallets.create works with the authenticated client", async () => {
-      const salt = nextTestSalt();
-      const result = await createSmartWallet(client, { saltValue: salt });
+      const result = await createSmartWallet(client, { saltValue: "0" });
       expect(result.address).toHaveLength(42);
-      expect(result.salt).toEqual(salt);
+      expect(result.salt).toEqual("0");
       expect(result.factoryAddress).toBeTruthy();
     });
 

--- a/tests/v4/core/getToken.test.ts
+++ b/tests/v4/core/getToken.test.ts
@@ -17,7 +17,7 @@
  * passes.
  */
 
-import { Chains, Client, Tokens, type TokenChainEntry } from "@avaprotocol/sdk-js";
+import { APIError, Chains, Client, Tokens, type TokenChainEntry } from "@avaprotocol/sdk-js";
 
 import { authenticateClient, getClient } from "../../utils/client";
 import { hasPartnerAssertionKey, testPartnerHeaders } from "../../utils/partner";
@@ -92,9 +92,21 @@ function retrieve(client: Client, address: string) {
 describeOrSkip("getToken Tests", () => {
   let client: Client;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     // Partner-only — no user JWT (matches gateway LevelPartnerRead).
     client = getClient({ headers: testPartnerHeaders() });
+    try {
+      await retrieve(client, TOKENS.USDC.address);
+    } catch (error) {
+      if (error instanceof APIError && error.code === "PARTNER_SCOPE_DENIED") {
+        throw new Error(
+          'Gateway studio partner is not granted scope "read". ' +
+            "avs-infra gateway-railway.yaml partners[studio].scopes must include read " +
+            "(GET /tokens requires read; simulate is not enough).",
+        );
+      }
+      throw error;
+    }
   });
 
   if (!hasPartnerAssertionKey()) {

--- a/tests/v4/core/policiesLive.test.ts
+++ b/tests/v4/core/policiesLive.test.ts
@@ -11,8 +11,6 @@
  * costs no gas and needs no funded account.
  */
 
-import { Wallet as EthersWallet } from "ethers";
-
 import { Client, SessionPolicyActions } from "@avaprotocol/sdk-js";
 import type { v4 } from "@avaprotocol/types";
 
@@ -20,38 +18,11 @@ import {
   getIsolatedClient,
   TEST_AUTH_CHAIN_ID,
 } from "../../utils/client";
+import { signTypedDataWithEthers } from "../../utils/sessionGrant";
 
 // Sepolia test USDC — the same token the Uniswap fixtures use.
 const TOKEN = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238";
 const APPROVE_SELECTOR = "0x095ea7b3";
-
-/**
- * ethers signs typed data from (domain, types, message) and rejects the
- * EIP712Domain entry that eth_signTypedData_v4 payloads carry — it derives
- * that from the domain itself. Browser wallets take the whole envelope, which
- * is why the SDK passes it through untouched rather than destructuring.
- */
-function signTypedDataWithEthers(privateKey: string) {
-  const signer = new EthersWallet(privateKey);
-  return async (
-    typedData: Readonly<Record<string, unknown>>
-  ): Promise<string> => {
-    const { domain, types, message } = typedData as {
-      domain: Record<string, unknown>;
-      types: Record<string, unknown>;
-      message: Record<string, unknown>;
-    };
-    const { EIP712Domain: _ignored, ...rest } = types as Record<
-      string,
-      unknown
-    >;
-    return signer.signTypedData(
-      domain as never,
-      rest as never,
-      message as never
-    );
-  };
-}
 
 describe("policies (live gateway)", () => {
   let client: Client;

--- a/tests/v4/core/policiesLive.test.ts
+++ b/tests/v4/core/policiesLive.test.ts
@@ -11,6 +11,8 @@
  * costs no gas and needs no funded account.
  */
 
+import { Wallet as EthersWallet } from "ethers";
+
 import { Client, SessionPolicyActions } from "@avaprotocol/sdk-js";
 import type { v4 } from "@avaprotocol/types";
 

--- a/tests/v4/core/policiesLive.test.ts
+++ b/tests/v4/core/policiesLive.test.ts
@@ -17,9 +17,7 @@ import { Client, SessionPolicyActions } from "@avaprotocol/sdk-js";
 import type { v4 } from "@avaprotocol/types";
 
 import {
-  getClient,
-  authenticateClient,
-  testPrivateKey,
+  getIsolatedClient,
   TEST_AUTH_CHAIN_ID,
 } from "../../utils/client";
 
@@ -57,13 +55,14 @@ function signTypedDataWithEthers(privateKey: string) {
 
 describe("policies (live gateway)", () => {
   let client: Client;
+  let ownerKey: string;
   let wallet: string;
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client, privateKey: ownerKey } = await getIsolatedClient());
 
-    // Salt 0 is the owner's default wallet; ensure-and-register is idempotent.
+    // Isolated EOA so grant-then-revoke cannot tear down the funded
+    // UserOp fixture (shared TEST_PRIVATE_KEY, MA v2 salt 0).
     const w = await client.wallets.create({ salt: "0" });
     wallet = w.address;
   }, 120_000);
@@ -88,7 +87,7 @@ describe("policies (live gateway)", () => {
     const policy = await client.policies.grant(
       wallet,
       request(),
-      signTypedDataWithEthers(testPrivateKey())
+      signTypedDataWithEthers(ownerKey)
     );
 
     try {
@@ -151,7 +150,7 @@ describe("policies (live gateway)", () => {
     const policy = await client.policies.grant(
       wallet,
       { ...request("ChipBuiltBot"), allowedActions },
-      signTypedDataWithEthers(testPrivateKey())
+      signTypedDataWithEthers(ownerKey)
     );
     try {
       expect(policy.status).toBe("pending");
@@ -169,6 +168,16 @@ describe("policies (live gateway)", () => {
   // 999_999 is not a real chain, so no stack this suite runs against serves
   // it — unlike Base or Sepolia, which the Railway gateway does serve.
   test("a chain the gateway does not serve is refused at prepare", async () => {
+    // v4.17.0+ (EigenLayer-AVS #760). 4.16.x still allocates the grant.
+    const { version } = await client.health.check();
+    const [maj, min] = (version ?? "0.0.0").split(".").map((n) => Number(n) || 0);
+    if (maj < 4 || (maj === 4 && min < 17)) {
+      console.log(
+        `Skipping — POLICIES_CHAIN_NOT_SERVED needs aggregator >= 4.17.0 (this gateway is ${version})`,
+      );
+      return;
+    }
+
     const unserved = 999_999;
 
     await expect(

--- a/tests/v4/core/secret.test.ts
+++ b/tests/v4/core/secret.test.ts
@@ -27,6 +27,7 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 import {
   authenticateClient,
   getClient,
+  getIsolatedClient,
   getEOAAddress,
   createSmartWallet,
   removeCreatedWorkflows,
@@ -69,8 +70,7 @@ describe("secret Tests", () => {
   const createdSecrets: Array<{ name: string; workflowId?: string; orgId?: string }> = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getIsolatedClient());
 
     client2 = getClient();
     await authenticateClient(client2, otherPrivateKey);

--- a/tests/v4/core/wallet.test.ts
+++ b/tests/v4/core/wallet.test.ts
@@ -26,8 +26,7 @@
 import { Chains, Client, Triggers } from "@avaprotocol/sdk-js";
 
 import {
-  authenticateClient,
-  getClient,
+  getSuiteClient,
   createSmartWallet,
   nextTestSalt,
   removeCreatedWorkflows,
@@ -45,8 +44,7 @@ describe("Wallet Management Tests", () => {
   let client: Client;
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   describe("wallets.create (v3 getWallet)", () => {
@@ -203,18 +201,20 @@ describe("Wallet Management Tests", () => {
       }
     });
 
-    // Needs a gateway serving a SECOND chain. The CI stack in config/
-    // gateway.yaml is Sepolia-only, so there this would fail for lack of a
-    // configured chain rather than for the behaviour under test — the same
-    // reason the expansion-chain suite gates itself. The gateway-side
+    // Needs a gateway serving a SECOND chain. The ava-sdk-js CI compose
+    // file is Sepolia-only; the local EigenLayer-AVS gateway serves
+    // Sepolia + Ethereum + Base. Base Sepolia (84532) was retired from
+    // that config. Gate on the same MULTICHAIN_TEST / TEST_ENV=railway
+    // flags expansion-chains-e2e.test.ts uses. The gateway-side
     // guarantee is pinned hard in EigenLayer-AVS
     // (TestListWalletsUsesQueryChainIdOverJwtAud); this is the wire check
     // that the SDK actually sends `?chainId=`.
     testMultichain("scopes the listing to chainId, not the JWT audience chain", async () => {
       // Wallet records are per chain. This is the cross-chain read the
       // Studio grant flow needs: one Sepolia-audience token reaching a
-      // second chain's wallets, with no second SIWE.
-      const otherChain = Chains.BaseSepolia;
+      // second chain's wallets, with no second SIWE. Base (8453) is in
+      // the local gateway chains[] and on production; JWT aud is Sepolia.
+      const otherChain = Chains.BaseMainnet;
       expect(otherChain).not.toEqual(TEST_AUTH_CHAIN_ID);
 
       const salt = nextTestSalt();

--- a/tests/v4/core/withdraw.test.ts
+++ b/tests/v4/core/withdraw.test.ts
@@ -26,6 +26,7 @@ import { Chains, Client, Tokens, type v4 } from "@avaprotocol/sdk-js";
 
 import {
   getClient,
+  getFundedClient,
   getFundedFixture,
   FUNDED_FACTORY_ADDRESS,
   FUNDED_WALLET_SALT,
@@ -128,10 +129,28 @@ describe("Withdraw Funds Tests", () => {
   const chainEndpoint = optionalEnv("CHAIN_ENDPOINT", "");
 
   beforeAll(async () => {
-    const fx = await getFundedFixture();
-    client = fx.client;
-    eoaAddress = fx.owner;
-    if (!SKIP_ON_CHAIN) fundedWallet = fx.wallet;
+    // Validation tests still need an authenticated client. Skip the
+    // grant+UserOp fixture when WITHDRAW_SKIP_ON_CHAIN is set, and
+    // keep running those tests if the funded wallet cannot be created.
+    if (SKIP_ON_CHAIN) {
+      const fx = await getFundedClient();
+      client = fx.client;
+      eoaAddress = fx.owner;
+      return;
+    }
+    try {
+      const fx = await getFundedFixture();
+      client = fx.client;
+      eoaAddress = fx.owner;
+      fundedWallet = fx.wallet;
+    } catch (err) {
+      const fx = await getFundedClient();
+      client = fx.client;
+      eoaAddress = fx.owner;
+      console.log(
+        `Skipping on-chain withdraws — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   });
 
   describe("withdraw: native ETH (session-grant refusal)", () => {

--- a/tests/v4/core/withdraw.test.ts
+++ b/tests/v4/core/withdraw.test.ts
@@ -15,10 +15,9 @@
  * carries a single client-scoped Bearer JWT, so per-request auth
  * overrides don't exist.
  *
- * The funded-wallet helper uses salt "2" (same as v3), which is
- * pre-funded on the long-lived dev/sepolia smart wallet. If the
- * wallet is unfunded (running against a fresh chain), the
- * on-chain tests skip cleanly; the validation tests still run.
+ * The funded-wallet helper looks up MA v2 salt "0" (see
+ * getFundedFixture). If the wallet is unfunded, on-chain tests skip
+ * with the address to fund; the validation tests still run.
  */
 
 import { ethers } from "ethers";
@@ -26,11 +25,16 @@ import { ethers } from "ethers";
 import { Chains, Client, Tokens, type v4 } from "@avaprotocol/sdk-js";
 
 import {
-  authenticateClient,
   getClient,
-  getEOAAddress,
+  getFundedFixture,
+  FUNDED_FACTORY_ADDRESS,
+  FUNDED_WALLET_SALT,
   createSmartWallet,
 } from "../../utils/client";
+import {
+  e2eWithdrawAlternateRecipient,
+  SESSION_POLICY_NATIVE_NOT_ALLOWED,
+} from "../../utils/sessionGrant";
 import { optionalEnv } from "../../utils/env";
 
 // Real UserOp round-trips can take ~3 minutes (bundler → EntryPoint
@@ -40,7 +44,6 @@ import { optionalEnv } from "../../utils/env";
 jest.setTimeout(240_000);
 
 const WITHDRAW_TIMEOUT_MS = 200_000;
-const FUNDED_WALLET_SALT = "2";
 
 // Optional override — if the dev chain endpoint isn't sepolia or the
 // funded wallet doesn't exist, callers can flip this to skip the
@@ -67,16 +70,18 @@ async function pollReceipt(
   return { success: false, receipt: null };
 }
 
-async function tryFundedWallet(client: Client): Promise<v4.Wallet | undefined> {
-  if (SKIP_ON_CHAIN) return undefined;
-  return createSmartWallet(client, { saltValue: FUNDED_WALLET_SALT });
+function fundedSkipMessage(address: string, detail: string): string {
+  return (
+    `Skipping — ${detail}. Fund MA v2 salt-${FUNDED_WALLET_SALT} wallet ` +
+    `${address} (factory ${FUNDED_FACTORY_ADDRESS}) on Sepolia with ETH and USDC.`
+  );
 }
 
 /**
  * Submit a withdrawal against the funded test wallet. Returns the
  * response on success; returns undefined and logs a skip note when
- * the wallet is unfunded (server either throws 400/insufficient or
- * returns `{status: "failed"}`).
+ * the wallet is unfunded. Session-grant / bundler errors fail the
+ * test — those are not a funding gap.
  */
 async function submitWithdrawOrSkip(
   client: Client,
@@ -87,19 +92,28 @@ async function submitWithdrawOrSkip(
   try {
     response = await client.wallets.withdraw(address, req);
   } catch (err: unknown) {
-    const errObj = err as { status?: number; message?: string };
-    if (errObj.status === 400 || /insufficient/i.test(errObj.message ?? "")) {
-      console.log("Skipping — funded wallet not funded on this chain");
+    const errObj = err as { status?: number; code?: string; message?: string };
+    // Native ETH is a typed 400 (SESSION_POLICY_NATIVE_NOT_ALLOWED), not
+    // a funding miss — let those tests assert the code.
+    if (
+      errObj.status === 400 &&
+      errObj.code !== SESSION_POLICY_NATIVE_NOT_ALLOWED &&
+      /insufficient/i.test(`${errObj.code ?? ""} ${errObj.message ?? ""}`)
+    ) {
+      console.log(fundedSkipMessage(address, "wallet not funded on this chain"));
       return undefined;
     }
     throw err;
   }
   if (response.status === "failed") {
-    // The dev wallet (salt:2) isn't funded on this chain — bundler
-    // bounced the UserOp. Treat as a soft skip so the validation
-    // tests still cover their cases without requiring real ETH.
-    console.log(`Skipping — UserOp returned failed status${response.message ? `: ${response.message}` : ""}`);
-    return undefined;
+    const msg = response.message ?? "";
+    if (/insufficient/i.test(msg)) {
+      console.log(fundedSkipMessage(address, msg || "insufficient funds"));
+      return undefined;
+    }
+    throw new Error(
+      `UserOp withdraw failed for MA v2 funded wallet ${address}: ${msg || "failed"}`,
+    );
   }
   return response;
 }
@@ -107,70 +121,45 @@ async function submitWithdrawOrSkip(
 describe("Withdraw Funds Tests", () => {
   let client: Client;
   let eoaAddress: string;
+  let fundedWallet: v4.Wallet | undefined;
   // Lazily resolve the chain endpoint — only the on-chain tests
   // need it, and the validation tests must keep running when
   // CHAIN_ENDPOINT is absent.
   const chainEndpoint = optionalEnv("CHAIN_ENDPOINT", "");
 
   beforeAll(async () => {
-    eoaAddress = getEOAAddress();
-    client = getClient();
-    await authenticateClient(client);
+    const fx = await getFundedFixture();
+    client = fx.client;
+    eoaAddress = fx.owner;
+    if (!SKIP_ON_CHAIN) fundedWallet = fx.wallet;
   });
 
-  describe("withdraw: basic ETH happy path", () => {
-    test("submits an ETH withdrawal and confirms receipt", async () => {
-      const wallet = await tryFundedWallet(client);
+  describe("withdraw: native ETH (session-grant refusal)", () => {
+    test("refuses an ETH withdrawal with SESSION_POLICY_NATIVE_NOT_ALLOWED", async () => {
+      const wallet = fundedWallet;
       if (!wallet) {
-        console.log("Skipping — WITHDRAW_SKIP_ON_CHAIN=true");
-        return;
-      }
-      if (!chainEndpoint) {
-        console.log("Skipping — CHAIN_ENDPOINT not set");
+        console.log("Skipping — WITHDRAW_SKIP_ON_CHAIN=true or funded wallet unavailable");
         return;
       }
 
-      const provider = new ethers.JsonRpcProvider(
-        chainEndpoint.startsWith("http") ? chainEndpoint : `https://${chainEndpoint}`,
-      );
-      const initialBalance = await provider.getBalance(eoaAddress);
-
-      const req: v4.WithdrawRequest = {
-        recipientAddress: eoaAddress,
-        amount: "1000000000000000", // 0.001 ETH
-        token: "ETH",
-      };
-
-      const response = await submitWithdrawOrSkip(client, wallet.address, req);
-      if (!response) return;
-      expect(response.status).not.toBe("failed");
-      expect(response.smartWalletAddress?.toLowerCase()).toBe(
-        wallet.address.toLowerCase(),
-      );
-      expect(response.transactionHash).toBeTruthy();
-
-      const check = await pollReceipt(response.transactionHash!, provider);
-      expect(check.success).toBe(true);
-      expect(check.receipt?.status).toBe(1);
-
-      const expectedDelta = BigInt(req.amount);
-      let finalBalance = await provider.getBalance(eoaAddress);
-      let delta = finalBalance - initialBalance;
-      const deadline = Date.now() + 30_000;
-      while (delta < expectedDelta && Date.now() < deadline) {
-        await new Promise((r) => setTimeout(r, 1000));
-        finalBalance = await provider.getBalance(eoaAddress);
-        delta = finalBalance - initialBalance;
-      }
-      expect(delta).toBe(expectedDelta);
-    }, WITHDRAW_TIMEOUT_MS);
+      await expect(
+        client.wallets.withdraw(wallet.address, {
+          recipientAddress: eoaAddress,
+          amount: "1000000000000000", // 0.001 ETH
+          token: "ETH",
+        }),
+      ).rejects.toMatchObject({
+        status: 400,
+        code: SESSION_POLICY_NATIVE_NOT_ALLOWED,
+      });
+    });
   });
 
   describe("withdraw: ERC-20", () => {
     test("submits a USDC withdrawal when the token is configured", async () => {
-      const wallet = await tryFundedWallet(client);
+      const wallet = fundedWallet;
       if (!wallet) {
-        console.log("Skipping — WITHDRAW_SKIP_ON_CHAIN=true");
+        console.log("Skipping — WITHDRAW_SKIP_ON_CHAIN=true or funded wallet unavailable");
         return;
       }
 
@@ -218,20 +207,20 @@ describe("Withdraw Funds Tests", () => {
     });
 
     test("accepts an alternate recipient address", async () => {
-      const wallet = await tryFundedWallet(client);
+      const wallet = fundedWallet;
       if (!wallet) {
-        console.log("Skipping — WITHDRAW_SKIP_ON_CHAIN=true");
+        console.log("Skipping — WITHDRAW_SKIP_ON_CHAIN=true or funded wallet unavailable");
         return;
       }
 
-      const otherRecipient = getEOAAddress(
-        "0x0000000000000000000000000000000000000000000000000000000000000001",
-      );
-
+      const otherRecipient = e2eWithdrawAlternateRecipient();
+      const usdcAddress = Tokens.USDC[Chains.Sepolia]!.address;
+      // Native ETH is refused under REST session grants; ERC-20 transfer
+      // to a different recipient is the path that can still mine.
       const req: v4.WithdrawRequest = {
         recipientAddress: otherRecipient,
-        amount: "100000000000000", // 0.0001 ETH
-        token: "ETH",
+        amount: "10000", // 0.01 USDC
+        token: usdcAddress,
       };
 
       const response = await submitWithdrawOrSkip(client, wallet.address, req);
@@ -292,16 +281,16 @@ describe("Withdraw Funds Tests", () => {
 
   describe("withdraw: response shape", () => {
     test("returns the documented v4.WithdrawResponse shape", async () => {
-      const wallet = await tryFundedWallet(client);
+      const wallet = fundedWallet;
       if (!wallet) {
-        console.log("Skipping — WITHDRAW_SKIP_ON_CHAIN=true");
+        console.log("Skipping — WITHDRAW_SKIP_ON_CHAIN=true or funded wallet unavailable");
         return;
       }
 
       const req: v4.WithdrawRequest = {
         recipientAddress: eoaAddress,
-        amount: "1000000000000000",
-        token: "ETH",
+        amount: "10000",
+        token: Tokens.USDC[Chains.Sepolia]!.address,
       };
 
       const response = await submitWithdrawOrSkip(client, wallet.address, req);
@@ -330,10 +319,10 @@ describe("Withdraw Funds Tests", () => {
   });
 
   describe("paymaster reimbursement check", () => {
-    test("internal txs all succeed on paymaster-sponsored ETH withdrawal", async () => {
-      const wallet = await tryFundedWallet(client);
+    test("internal txs all succeed on a session-granted ERC-20 withdrawal", async () => {
+      const wallet = fundedWallet;
       if (!wallet) {
-        console.log("Skipping — WITHDRAW_SKIP_ON_CHAIN=true");
+        console.log("Skipping — WITHDRAW_SKIP_ON_CHAIN=true or funded wallet unavailable");
         return;
       }
       if (!chainEndpoint) {
@@ -347,8 +336,8 @@ describe("Withdraw Funds Tests", () => {
 
       const req: v4.WithdrawRequest = {
         recipientAddress: eoaAddress,
-        amount: "2000000000000000",
-        token: "ETH",
+        amount: "10000",
+        token: Tokens.USDC[Chains.Sepolia]!.address,
       };
 
       const response = await submitWithdrawOrSkip(client, wallet.address, req);
@@ -359,10 +348,6 @@ describe("Withdraw Funds Tests", () => {
       const check = await pollReceipt(response.transactionHash!, provider);
       expect(check.success).toBe(true);
       expect(check.receipt?.status).toBe(1);
-      // Withdrawals run with SkipReimbursement=true server-side (the
-      // paymaster absorbs gas so the user can withdraw their full
-      // balance). No reimbursement transfer is added to the UserOp
-      // for withdrawals — non-withdrawal operations do reimburse.
     }, WITHDRAW_TIMEOUT_MS);
   });
 });

--- a/tests/v4/executions/awaitSignal.test.ts
+++ b/tests/v4/executions/awaitSignal.test.ts
@@ -26,8 +26,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
 } from "../../utils/client";

--- a/tests/v4/executions/awaitSignal.test.ts
+++ b/tests/v4/executions/awaitSignal.test.ts
@@ -17,26 +17,15 @@
  * 4. The returned execution is terminal (`"success"`) and carries the
  *    downstream step.
  *
- * GATED: this exercises brand-new server behaviour and live timing, so
- * it only runs when `DURABLE_E2E=1` is set (e.g.
- * `AVS_REST_URL=http://localhost:8080/api/v1 DURABLE_E2E=1 \
- *   yarn jest tests/v4/executions/awaitSignal.test.ts`).
- * Left off by default until the target gateway is confirmed to carry
- * the durable-execution engine.
- *
- * Verified passing 2026-06-28 against a local `make dev-stack`
- * (EigenLayer-AVS staging). Gateway logs for the run show the full
- * lifecycle: `execution suspended (durable) resume_node: gate` →
- * `POST /executions/{id}:signal -> 200` → `execution resumed to
- * terminal status: EXECUTION_STATUS_SUCCESS`. (An earlier gateway
- * build 404'd the POST `:signal` route — the generated echo route
- * `/executions/:id:signal` was unmatchable for POST; fixed server-side
- * before this run.)
+ * Durable execution shipped in EigenLayer-AVS #643–#648 (verified
+ * 2026-06-28 against local `make dev-stack`). Always runs — the
+ * `DURABLE_E2E=1` opt-in was a rollout flag and is no longer needed.
  */
 
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -44,11 +33,6 @@ import {
 } from "../../utils/client";
 
 jest.setTimeout(180_000);
-
-const DURABLE_E2E = process.env.DURABLE_E2E === "1";
-// Use describe.skip when the opt-in flag is absent so the suite is a
-// no-op in default CI rather than authenticating + failing.
-const describeMaybe = DURABLE_E2E ? describe : describe.skip;
 
 /** Poll getStatus until `predicate` is true or the deadline passes. */
 async function waitForStatus(
@@ -69,13 +53,12 @@ async function waitForStatus(
   throw new Error(`execution ${execId} never reached the expected status (last: "${last}")`);
 }
 
-describeMaybe("durable execution — await(channel:'api') + executions.signal", () => {
+describe("durable execution — await(channel:'api') + executions.signal", () => {
   let client: Client;
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/executions/errorCodeConsistency.test.ts
+++ b/tests/v4/executions/errorCodeConsistency.test.ts
@@ -13,8 +13,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   settingsFor,
 } from "../../utils/client";

--- a/tests/v4/executions/errorCodeConsistency.test.ts
+++ b/tests/v4/executions/errorCodeConsistency.test.ts
@@ -12,6 +12,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -24,8 +25,7 @@ describe("Error code consistency between nodes.run and workflows.simulate", () =
   let client: Client;
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   test("empty customCode source surfaces the same error code on both paths", async () => {

--- a/tests/v4/executions/estimateFees.test.ts
+++ b/tests/v4/executions/estimateFees.test.ts
@@ -11,6 +11,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -46,8 +47,7 @@ describe("workflows.estimateFees Tests", () => {
   let smartWalletAddress: string;
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
     const wallet = await createSmartWallet(client);
     smartWalletAddress = wallet.address;
   });

--- a/tests/v4/executions/estimateFees.test.ts
+++ b/tests/v4/executions/estimateFees.test.ts
@@ -12,8 +12,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   settingsForChain,
 } from "../../utils/client";

--- a/tests/v4/executions/execution.test.ts
+++ b/tests/v4/executions/execution.test.ts
@@ -16,7 +16,6 @@ import {
   getIsolatedClient,
   getCurrentBlockNumber,
   createSmartWallet,
-  nextTestSalt,
   removeCreatedWorkflows,
 } from "../../utils/client";
 import { createFromTemplate } from "../../utils/templates";
@@ -42,7 +41,7 @@ describe("Execution Management Tests", () => {
       console.log("Skipping — CHAIN_ENDPOINT not set");
       return;
     }
-    const wallet = await createSmartWallet(client, { saltValue: nextTestSalt() });
+    const wallet = await createSmartWallet(client);
     const blockNumber = await getCurrentBlockNumber();
 
     const created = await client.workflows.create({
@@ -75,7 +74,7 @@ describe("Execution Management Tests", () => {
   });
 
   test("non-blocking trigger returns immediate executionId with index assigned", async () => {
-    const wallet = await createSmartWallet(client, { saltValue: nextTestSalt() });
+    const wallet = await createSmartWallet(client);
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),
       maxExecution: 10,
@@ -98,7 +97,7 @@ describe("Execution Management Tests", () => {
       console.log("Skipping — CHAIN_ENDPOINT not set");
       return;
     }
-    const wallet = await createSmartWallet(client, { saltValue: nextTestSalt() });
+    const wallet = await createSmartWallet(client);
     const blockNumber = await getCurrentBlockNumber();
     const created = await client.workflows.create({
       ...createFromTemplate(wallet.address),

--- a/tests/v4/executions/gasTracking.test.ts
+++ b/tests/v4/executions/gasTracking.test.ts
@@ -13,12 +13,12 @@
  * holds.
  */
 
-import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
+import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
 
 import {
-  authenticateClient,
-  getClient,
-  getEOAAddress,
+  getSuiteClient,
+  getFundedFixture,
+  assertUserOpTriggerOk,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,
@@ -44,9 +44,7 @@ describe("Gas tracking", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
   });
 
   afterEach(async () => {
@@ -82,57 +80,59 @@ describe("Gas tracking", () => {
       console.log("Skipping — CHAIN_ENDPOINT not set");
       return;
     }
-    const wallet = await createSmartWallet(client, { saltValue: "2" });
-    const blockNumber = (await import("ethers")).JsonRpcProvider
-      ? await (async () => {
-          const { JsonRpcProvider } = await import("ethers");
-          const ep = process.env.CHAIN_ENDPOINT ?? "";
-          return new JsonRpcProvider(ep.startsWith("http") ? ep : `https://${ep}`).getBlockNumber();
-        })()
-      : 0;
+    // Native ETH execute(to, value, 0x) AA23s under REST session grants
+    // (AllowlistModule NoSelectorSpecified). An ERC-20 approve has a real
+    // selector and still produces execution.cogs on a mined UserOp.
+    const { client: funded, owner: fundedOwner, wallet } = await getFundedFixture();
+    const usdc = Tokens.USDC[Chains.Sepolia]!.address;
+    const erc20Abi = [...Protocols.erc20.transferAbi, ...Protocols.erc20.approveAbi];
+    const blockNumber = await (async () => {
+      const { JsonRpcProvider } = await import("ethers");
+      const ep = process.env.CHAIN_ENDPOINT ?? "";
+      return new JsonRpcProvider(ep.startsWith("http") ? ep : `https://${ep}`).getBlockNumber();
+    })();
 
-    const created = await client.workflows.create({
+    const created = await funded.workflows.create({
       ...createFromTemplate(wallet.address),
       maxExecution: 1,
       trigger: Triggers.block({ id: "trigger", name: "blockTrigger", chainId: 11_155_111, interval: 5 }),
       nodes: [
-        Nodes.ethTransfer({
-          id: "transfer",
-          name: "transfer",
+        Nodes.contractWrite({
+          id: "approve",
+          name: "approve",
           chainId: 11_155_111,
-          destination: eoaAddress,
-          amountWei: "100000000000000",
+          contractAddress: usdc,
+          contractAbi: erc20Abi,
+          methodCalls: [{ methodName: "approve", methodParams: [fundedOwner, "0"] }],
         }),
       ],
-      edges: [{ id: "e1", source: "trigger", target: "transfer" }],
+      edges: [{ id: "e1", source: "trigger", target: "approve" }],
     });
     const wfId = created.id as string;
-    createdWorkflowIds.push(wfId);
+    try {
+      const trig = await funded.workflows.trigger(wfId, {
+        triggerType: "block",
+        triggerOutput: { blockNumber: blockNumber + 5 },
+        isBlocking: true,
+      });
+      assertUserOpTriggerOk(trig, wallet.address);
 
-    const trig = await client.workflows.trigger(wfId, {
-      triggerType: "block",
-      triggerOutput: { blockNumber: blockNumber + 5 },
-      isBlocking: true,
-    });
-    if (trig.status === "failed" || trig.status === "error" || trig.error) {
-      console.log(`Skipping — trigger returned ${trig.status}`);
-      return;
-    }
+      const exec = await funded.executions.retrieve(trig.executionId, { workflowId: wfId });
+      expect(Array.isArray(exec.cogs)).toBe(true);
+      for (const c of exec.cogs ?? []) {
+        expect(typeof c.nodeId).toBe("string");
+        expect(c.fee.unit).toBe("WEI");
+        expect(typeof c.fee.amount).toBe("string");
+      }
 
-    const exec = await client.executions.retrieve(trig.executionId, { workflowId: wfId });
-    expect(Array.isArray(exec.cogs)).toBe(true);
-    for (const c of exec.cogs ?? []) {
-      expect(typeof c.nodeId).toBe("string");
-      expect(c.fee.unit).toBe("WEI");
-      expect(typeof c.fee.amount).toBe("string");
-    }
-
-    // The step itself carries its own gas metadata.
-    const step = exec.steps?.find((s) => s.id === "transfer") as unknown as StepWithMeta | undefined;
-    if (step?.metadata) {
-      expect(typeof step.metadata.gasUsed).toBe("string");
-      expect(typeof step.metadata.gasPrice).toBe("string");
-      expect(typeof step.metadata.totalGasCost).toBe("string");
+      const step = exec.steps?.find((s) => s.id === "approve") as unknown as StepWithMeta | undefined;
+      if (step?.metadata) {
+        expect(typeof step.metadata.gasUsed).toBe("string");
+        expect(typeof step.metadata.gasPrice).toBe("string");
+        expect(typeof step.metadata.totalGasCost).toBe("string");
+      }
+    } finally {
+      await removeCreatedWorkflows(funded, [wfId]);
     }
   });
 

--- a/tests/v4/executions/getExecution.test.ts
+++ b/tests/v4/executions/getExecution.test.ts
@@ -17,6 +17,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getCurrentBlockNumber,
@@ -32,8 +33,7 @@ describe("executions.retrieve Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/executions/getExecution.test.ts
+++ b/tests/v4/executions/getExecution.test.ts
@@ -18,8 +18,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   getCurrentBlockNumber,
   createSmartWallet,
   removeCreatedWorkflows,

--- a/tests/v4/executions/inputVariables.test.ts
+++ b/tests/v4/executions/inputVariables.test.ts
@@ -9,6 +9,7 @@
 import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -23,8 +24,7 @@ describe("Input Variables", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/executions/inputVariables.test.ts
+++ b/tests/v4/executions/inputVariables.test.ts
@@ -10,8 +10,6 @@ import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/executions/partialSuccess.test.ts
+++ b/tests/v4/executions/partialSuccess.test.ts
@@ -10,6 +10,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getCurrentBlockNumber,
@@ -25,8 +26,7 @@ describe("Execution Status — partial / mixed step outcomes", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/executions/partialSuccess.test.ts
+++ b/tests/v4/executions/partialSuccess.test.ts
@@ -11,8 +11,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   getCurrentBlockNumber,
   createSmartWallet,
   removeCreatedWorkflows,

--- a/tests/v4/executions/runNodeWithInputs.test.ts
+++ b/tests/v4/executions/runNodeWithInputs.test.ts
@@ -14,9 +14,6 @@ import { Chains, Client, Nodes, Protocols, Tokens } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
-  getEOAAddress,
   createSmartWallet,
   settingsFor,
 } from "../../utils/client";

--- a/tests/v4/executions/runNodeWithInputs.test.ts
+++ b/tests/v4/executions/runNodeWithInputs.test.ts
@@ -13,6 +13,7 @@
 import { Chains, Client, Nodes, Protocols, Tokens } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getEOAAddress,
@@ -30,9 +31,7 @@ describe("nodes.run (provider routing)", () => {
   let eoaAddress: string;
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
   });
 
   test("Balance node always uses chain_rpc (read-only)", async () => {
@@ -58,7 +57,7 @@ describe("nodes.run (provider routing)", () => {
   });
 
   test("ContractWrite routes through Tenderly (is_simulated=true)", async () => {
-    const wallet = await createSmartWallet(client, { saltValue: "2" });
+    const wallet = await createSmartWallet(client);
     const result = await client.nodes.run({
       node: Nodes.contractWrite({
         id: "w",

--- a/tests/v4/executions/simulateWorkflow.test.ts
+++ b/tests/v4/executions/simulateWorkflow.test.ts
@@ -12,8 +12,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   settingsFor,
 } from "../../utils/client";

--- a/tests/v4/executions/simulateWorkflow.test.ts
+++ b/tests/v4/executions/simulateWorkflow.test.ts
@@ -11,12 +11,17 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
   settingsFor,
 } from "../../utils/client";
-import { startStubServerFor, type StubServer } from "../../utils/stubServer";
+import {
+  describeIfGatewayCanReachStub,
+  startStubServerFor,
+  type StubServer,
+} from "../../utils/stubServer";
 
 jest.setTimeout(60_000);
 
@@ -24,12 +29,11 @@ jest.setTimeout(60_000);
 let STUB = "";
 let stub: StubServer;
 
-describe("workflows.simulate Tests", () => {
+describeIfGatewayCanReachStub("workflows.simulate Tests", () => {
   let client: Client;
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
 
     // A local stub replaces httpbin.org here: the gateway makes this request,
     // not the test, so client-side mocking cannot intercept it — only a server

--- a/tests/v4/executions/stepInput.test.ts
+++ b/tests/v4/executions/stepInput.test.ts
@@ -14,13 +14,18 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,
 } from "../../utils/client";
-import { startStubServerFor, type StubServer } from "../../utils/stubServer";
+import {
+  describeIfGatewayCanReachStub,
+  startStubServerFor,
+  type StubServer,
+} from "../../utils/stubServer";
 
 jest.setTimeout(60_000);
 
@@ -28,13 +33,12 @@ jest.setTimeout(60_000);
 let STUB = "";
 let stub: StubServer;
 
-describe("Step Input Tests", () => {
+describeIfGatewayCanReachStub("Step Input Tests", () => {
   let client: Client;
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
 
     // A local stub replaces httpbin.org here: the gateway makes this request,
     // not the test, so client-side mocking cannot intercept it — only a server

--- a/tests/v4/executions/stepInput.test.ts
+++ b/tests/v4/executions/stepInput.test.ts
@@ -15,8 +15,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/nodes/balanceNode.test.ts
+++ b/tests/v4/nodes/balanceNode.test.ts
@@ -22,9 +22,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
-  getEOAAddress,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/nodes/balanceNode.test.ts
+++ b/tests/v4/nodes/balanceNode.test.ts
@@ -21,6 +21,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getEOAAddress,
@@ -46,9 +47,7 @@ describe("BalanceNode Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/nodes/branchNode.test.ts
+++ b/tests/v4/nodes/branchNode.test.ts
@@ -13,6 +13,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getCurrentBlockNumber,
@@ -36,8 +37,7 @@ describe("BranchNode Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/nodes/branchNode.test.ts
+++ b/tests/v4/nodes/branchNode.test.ts
@@ -14,8 +14,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   getCurrentBlockNumber,
   createSmartWallet,
   removeCreatedWorkflows,

--- a/tests/v4/nodes/contractRead.test.ts
+++ b/tests/v4/nodes/contractRead.test.ts
@@ -19,8 +19,6 @@ import { Chains, Client, Nodes, Protocols, Triggers } from "@avaprotocol/sdk-js"
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/nodes/contractRead.test.ts
+++ b/tests/v4/nodes/contractRead.test.ts
@@ -18,6 +18,7 @@
 import { Chains, Client, Nodes, Protocols, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -59,8 +60,7 @@ describe("ContractRead Node Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/nodes/contractWrite.test.ts
+++ b/tests/v4/nodes/contractWrite.test.ts
@@ -15,17 +15,20 @@
  *     value (bool for approve/transfer, struct for tuple returns).
  *   - `result.executionContext.is_simulated = true` for sim paths.
  *
- * The funded smart wallet (salt:2) is required for the real
- * deploy+trigger path. If it's unfunded the test skips cleanly.
+ * The MA v2 salt-0 funded wallet + session grant is required for
+ * the real deploy+trigger path. Simulation of `transfer` also uses
+ * that wallet because Tenderly does not override ERC-20 balances.
  */
 
 import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
 
 import {
-  authenticateClient,
-  getClient,
   getCurrentBlockNumber,
-  getEOAAddress,
+  getSuiteClient,
+  getFundedClient,
+  getFundedWallet,
+  getFundedFixture,
+  assertUserOpTriggerOk,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,
@@ -44,9 +47,7 @@ describe("ContractWrite Node Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
   });
 
   afterEach(async () => {
@@ -55,7 +56,7 @@ describe("ContractWrite Node Tests", () => {
 
   describe("nodes.run (Tenderly simulation)", () => {
     test("simulates an approve(spender, 0) call", async () => {
-      const wallet = await createSmartWallet(client, { saltValue: "2" });
+      const wallet = await createSmartWallet(client);
       const result = await client.nodes.run({
         node: Nodes.contractWrite({
           id: "w",
@@ -76,29 +77,31 @@ describe("ContractWrite Node Tests", () => {
     });
 
     test("simulates a transfer call against the funded wallet", async () => {
-      const wallet = await createSmartWallet(client, { saltValue: "2" });
-      const result = await client.nodes.run({
+      // MA v2 salt-0 holds Sepolia USDC. A suite wallet (fresh salt /
+      // isolated EOA) has none, and Tenderly does not override ERC-20
+      // balances — transfer would revert with "amount exceeds balance".
+      const { client: funded, owner } = await getFundedClient();
+      const wallet = await getFundedWallet(funded);
+      expect(wallet).toBeTruthy();
+      const result = await funded.nodes.run({
         node: Nodes.contractWrite({
           id: "w",
           name: "w",
           chainId: 11_155_111,
           contractAddress: USDC_SEPOLIA,
           contractAbi: ERC20_ABI,
-          methodCalls: [{ methodName: "transfer", methodParams: [eoaAddress, "1"] }],
+          methodCalls: [{ methodName: "transfer", methodParams: [owner, "1"] }],
         }),
-        inputVariables: { settings: settingsFor(wallet.address) },
+        inputVariables: { settings: settingsFor(wallet!.address) },
       });
-      // If the funded wallet has no USDC, the simulation reverts.
-      if (!result.success) {
-        console.log(`Skipping — transfer sim failed (likely no USDC): ${result.error}`);
-        return;
-      }
+      expect(result.success).toBe(true);
       const data = (result.output as { data: Record<string, any> }).data;
       expect(data.transfer).toBe(true);
+      expect((result.executionContext as Record<string, unknown>).is_simulated).toBe(true);
     });
 
     test("simulates multiple method calls in one node", async () => {
-      const wallet = await createSmartWallet(client, { saltValue: "2" });
+      const wallet = await createSmartWallet(client);
       const result = await client.nodes.run({
         node: Nodes.contractWrite({
           id: "w",
@@ -121,7 +124,7 @@ describe("ContractWrite Node Tests", () => {
     });
 
     test("rejects a method that doesn't exist in the ABI", async () => {
-      const wallet = await createSmartWallet(client, { saltValue: "2" });
+      const wallet = await createSmartWallet(client);
       const result = await client.nodes.run({
         node: Nodes.contractWrite({
           id: "w",
@@ -140,7 +143,7 @@ describe("ContractWrite Node Tests", () => {
 
   describe("workflows.simulate", () => {
     test("simulates an approve workflow step", async () => {
-      const wallet = await createSmartWallet(client, { saltValue: "2" });
+      const wallet = await createSmartWallet(client);
       const sim = await client.workflows.simulate({
         trigger: Triggers.cron({ id: "trigger", name: "cron", schedule: ["0 * * * *"] }),
         nodes: [
@@ -164,12 +167,24 @@ describe("ContractWrite Node Tests", () => {
   });
 
   describe("deploy + trigger (real bundler round-trip)", () => {
+    let funded: Client;
+    let fundedOwner: string;
+    let wallet: Awaited<ReturnType<typeof getFundedFixture>>["wallet"];
+    const fundedWorkflowIds: string[] = [];
+
+    beforeAll(async () => {
+      ({ client: funded, owner: fundedOwner, wallet } = await getFundedFixture());
+    });
+
+    afterEach(async () => {
+      await removeCreatedWorkflows(funded, fundedWorkflowIds.splice(0));
+    });
+
     test("submits an approve through a block-triggered workflow", async () => {
       if (!process.env.CHAIN_ENDPOINT) {
         console.log("Skipping — CHAIN_ENDPOINT not set");
         return;
       }
-      const wallet = await createSmartWallet(client, { saltValue: "2" });
       const blockNumber = await getCurrentBlockNumber();
 
       const wfReq = {
@@ -187,25 +202,22 @@ describe("ContractWrite Node Tests", () => {
             chainId: 11_155_111,
             contractAddress: USDC_SEPOLIA,
             contractAbi: ERC20_ABI,
-            methodCalls: [{ methodName: "approve", methodParams: [eoaAddress, "0"] }],
+            methodCalls: [{ methodName: "approve", methodParams: [fundedOwner, "0"] }],
           }),
         ],
         edges: [{ id: "e1", source: "trigger", target: "w" }],
       };
-      const created = await client.workflows.create(wfReq);
+      const created = await funded.workflows.create(wfReq);
       const wfId = created.id as string;
-      createdWorkflowIds.push(wfId);
+      fundedWorkflowIds.push(wfId);
 
-      const trig = await client.workflows.trigger(wfId, {
+      const trig = await funded.workflows.trigger(wfId, {
         triggerType: "block",
         triggerOutput: { blockNumber: blockNumber + 5 },
         isBlocking: true,
       });
-      if (trig.status === "failed" || trig.status === "error" || trig.error) {
-        console.log(`Skipping — trigger returned ${trig.status}${trig.error ? ": " + trig.error : ""}`);
-        return;
-      }
-      const exec = await client.executions.retrieve(trig.executionId, { workflowId: wfId });
+      assertUserOpTriggerOk(trig, wallet.address);
+      const exec = await funded.executions.retrieve(trig.executionId, { workflowId: wfId });
       const step = exec.steps?.find((s) => s.id === "w");
       expect(step?.success).toBe(true);
       // After real submission, approve still returns true. The

--- a/tests/v4/nodes/customCode.test.ts
+++ b/tests/v4/nodes/customCode.test.ts
@@ -25,8 +25,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   getCurrentBlockNumber,
   createSmartWallet,
   removeCreatedWorkflows,

--- a/tests/v4/nodes/customCode.test.ts
+++ b/tests/v4/nodes/customCode.test.ts
@@ -24,6 +24,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getCurrentBlockNumber,
@@ -47,8 +48,7 @@ describe("CustomCode Node Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/nodes/ethTransfer.test.ts
+++ b/tests/v4/nodes/ethTransfer.test.ts
@@ -4,6 +4,9 @@
  * v3 had many near-duplicate variations of "with/without isSimulated".
  * v4 simplifies: nodes.run is always a simulation (no UserOp goes
  * out), and the only on-chain execution path is workflows.trigger.
+ * Real ETH transfer under a REST session grant is refused with
+ * SESSION_POLICY_NATIVE_NOT_ALLOWED (EigenLayer-AVS #761) — empty
+ * inner calldata cannot pass a selector-scoped allowlist.
  * The port keeps one assertion per scenario rather than re-asserting
  * the same response shape three different ways.
  *
@@ -19,15 +22,15 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
-  authenticateClient,
-  getClient,
   getCurrentBlockNumber,
-  getEOAAddress,
+  getSuiteClient,
+  getFundedFixture,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,
 } from "../../utils/client";
 import { createFromTemplate } from "../../utils/templates";
+import { SESSION_POLICY_NATIVE_NOT_ALLOWED } from "../../utils/sessionGrant";
 
 // deploy+trigger block matches a future block (blockNumber+5) then waits for the
 // bundler/UserOp receipt — ~45s against a fresh gateway. The jest budget is set
@@ -46,9 +49,7 @@ describe("ETHTransfer Node Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
   });
 
   afterEach(async () => {
@@ -169,15 +170,24 @@ describe("ETHTransfer Node Tests", () => {
   });
 
   describe("deploy + trigger (real bundler round-trip)", () => {
-    test("submits an ETH transfer through a block-triggered workflow", async () => {
+    let funded: Client;
+    let fundedOwner: string;
+    let wallet: Awaited<ReturnType<typeof getFundedFixture>>["wallet"];
+    const fundedWorkflowIds: string[] = [];
+
+    beforeAll(async () => {
+      ({ client: funded, owner: fundedOwner, wallet } = await getFundedFixture());
+    });
+
+    afterEach(async () => {
+      await removeCreatedWorkflows(funded, fundedWorkflowIds.splice(0));
+    });
+
+    test("refuses a native ETH transfer with SESSION_POLICY_NATIVE_NOT_ALLOWED", async () => {
       if (!process.env.CHAIN_ENDPOINT) {
         console.log("Skipping — CHAIN_ENDPOINT not set");
         return;
       }
-      // This test uses the funded salt:2 wallet. If it's unfunded
-      // (fresh chain), the trigger returns failed and we skip the
-      // assertion block.
-      const wallet = await createSmartWallet(client, { saltValue: "2" });
       const blockNumber = await getCurrentBlockNumber();
       const triggerInterval = 5;
 
@@ -194,7 +204,7 @@ describe("ETHTransfer Node Tests", () => {
             id: "transfer",
             name: "transfer",
             chainId: 11_155_111,
-            destination: eoaAddress,
+            destination: fundedOwner,
             amountWei: "100000000000000",
           }),
         ],
@@ -203,31 +213,27 @@ describe("ETHTransfer Node Tests", () => {
         // a compile error from the engine.
         edges: [{ id: "e1", source: "trigger", target: "transfer" }],
       };
-      const created = await client.workflows.create(workflowReq);
+      const created = await funded.workflows.create(workflowReq);
       const workflowId = created.id as string;
-      createdWorkflowIds.push(workflowId);
+      fundedWorkflowIds.push(workflowId);
 
-      const trig = await client.workflows.trigger(workflowId, {
+      const trig = await funded.workflows.trigger(workflowId, {
         triggerType: "block",
         triggerOutput: { blockNumber: blockNumber + triggerInterval },
         isBlocking: true,
       });
-      // The bundler returns "error" (not "failed") when the UserOp
-      // can't be submitted — treat both as skip-conditions since the
-      // funded wallet may not actually be funded in dev.
-      if (trig.status === "failed" || trig.status === "error" || trig.error) {
-        console.log(`Skipping — trigger returned ${trig.status}${trig.error ? ": " + trig.error : ""}`);
-        return;
-      }
+      // Option C of EigenLayer-AVS #761: REST session grants cannot
+      // cover execute(to, value, 0x). The gateway refuses before the
+      // bundler instead of returning opaque AA23. The trigger envelope
+      // only says "1 of 2 steps failed: transfer"; the code is on the
+      // step.
+      expect(trig.status).toBe("failed");
 
-      const execution = await client.executions.retrieve(trig.executionId, { workflowId });
+      const execution = await funded.executions.retrieve(trig.executionId, { workflowId });
       const step = execution.steps?.find((s) => s.id === "transfer");
-      expect(step?.success).toBe(true);
-      const transfer = (step?.output as { data: { transfer: any } }).data.transfer;
-      expect(transfer.to.toLowerCase()).toBe(eoaAddress.toLowerCase());
-      expect(transfer.value).toBe("100000000000000");
-      const meta = (step as unknown as { metadata: Record<string, string> }).metadata;
-      expect(meta.transactionHash).toBeTruthy();
+      expect(step?.success).toBe(false);
+      const stepErr = `${step?.error ?? ""} ${step?.errorCode ?? ""}`;
+      expect(stepErr).toContain(SESSION_POLICY_NATIVE_NOT_ALLOWED);
     });
   });
 });

--- a/tests/v4/nodes/filterNode.test.ts
+++ b/tests/v4/nodes/filterNode.test.ts
@@ -13,8 +13,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   getCurrentBlockNumber,
   createSmartWallet,
   removeCreatedWorkflows,

--- a/tests/v4/nodes/filterNode.test.ts
+++ b/tests/v4/nodes/filterNode.test.ts
@@ -12,6 +12,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getCurrentBlockNumber,
@@ -34,8 +35,7 @@ describe("FilterNode Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/nodes/graphqlQuery.test.ts
+++ b/tests/v4/nodes/graphqlQuery.test.ts
@@ -14,8 +14,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/nodes/graphqlQuery.test.ts
+++ b/tests/v4/nodes/graphqlQuery.test.ts
@@ -13,6 +13,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -29,8 +30,7 @@ describe("GraphQL Query Node Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/nodes/loopNode.test.ts
+++ b/tests/v4/nodes/loopNode.test.ts
@@ -24,8 +24,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/nodes/loopNode.test.ts
+++ b/tests/v4/nodes/loopNode.test.ts
@@ -23,13 +23,18 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,
 } from "../../utils/client";
-import { startStubServerFor, type StubServer } from "../../utils/stubServer";
+import {
+  describeIfGatewayCanReachStub,
+  startStubServerFor,
+  type StubServer,
+} from "../../utils/stubServer";
 import { createFromTemplate } from "../../utils/templates";
 
 jest.setTimeout(60_000);
@@ -48,13 +53,12 @@ function loopWithCustomCode(input: string, source: string, iterVar = "value") {
 let STUB = "";
 let stub: StubServer;
 
-describe("LoopNode Tests", () => {
+describeIfGatewayCanReachStub("LoopNode Tests", () => {
   let client: Client;
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
 
     // A local stub replaces httpbin.org here: the gateway makes this request,
     // not the test, so client-side mocking cannot intercept it — only a server

--- a/tests/v4/nodes/restApi.test.ts
+++ b/tests/v4/nodes/restApi.test.ts
@@ -40,13 +40,18 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,
 } from "../../utils/client";
-import { startStubServerFor, type StubServer } from "../../utils/stubServer";
+import {
+  describeIfGatewayCanReachStub,
+  startStubServerFor,
+  type StubServer,
+} from "../../utils/stubServer";
 
 jest.setTimeout(60_000);
 
@@ -62,13 +67,12 @@ interface RestMetadata {
 let STUB = "";
 let stub: StubServer;
 
-describe("RestAPI Node Tests", () => {
+describeIfGatewayCanReachStub("RestAPI Node Tests", () => {
   let client: Client;
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
 
     // Same helper the other stub-backed suites use: it starts the server, proves
     // the gateway can reach it, and closes the listener before throwing if it

--- a/tests/v4/nodes/restApi.test.ts
+++ b/tests/v4/nodes/restApi.test.ts
@@ -41,8 +41,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/templates/aave-health-factor-alert.test.ts
+++ b/tests/v4/templates/aave-health-factor-alert.test.ts
@@ -43,9 +43,6 @@ import { Chains, Nodes, Protocols, Triggers, type Client } from "@avaprotocol/sd
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
-  getEOAAddress,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsForChain,

--- a/tests/v4/templates/aave-health-factor-alert.test.ts
+++ b/tests/v4/templates/aave-health-factor-alert.test.ts
@@ -42,6 +42,7 @@
 import { Chains, Nodes, Protocols, Triggers, type Client } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getEOAAddress,
@@ -86,9 +87,7 @@ describe("Template: AAVE health factor alert", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/templates/approve-with-simulation.test.ts
+++ b/tests/v4/templates/approve-with-simulation.test.ts
@@ -11,8 +11,6 @@ import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsForChain,

--- a/tests/v4/templates/approve-with-simulation.test.ts
+++ b/tests/v4/templates/approve-with-simulation.test.ts
@@ -10,6 +10,7 @@
 import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -28,8 +29,7 @@ describe("Template: single approve with Tenderly simulation", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {
@@ -37,7 +37,7 @@ describe("Template: single approve with Tenderly simulation", () => {
   });
 
   test("simulates a manual-trigger workflow that approves USDC for the Uniswap router", async () => {
-    const wallet = await createSmartWallet(client, { saltValue: "2" });
+    const wallet = await createSmartWallet(client);
     const sim = await client.workflows.simulate({
       trigger: Triggers.manual({
         id: "trigger",

--- a/tests/v4/templates/batch-recurring-payment-with-email.test.ts
+++ b/tests/v4/templates/batch-recurring-payment-with-email.test.ts
@@ -11,6 +11,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getEOAAddress,
@@ -18,7 +19,11 @@ import {
   removeCreatedWorkflows,
   settingsFor,
 } from "../../utils/client";
-import { startStubServerFor, type StubServer } from "../../utils/stubServer";
+import {
+  describeIfGatewayCanReachStub,
+  startStubServerFor,
+  type StubServer,
+} from "../../utils/stubServer";
 
 jest.setTimeout(60_000);
 
@@ -26,15 +31,13 @@ jest.setTimeout(60_000);
 let STUB = "";
 let stub: StubServer;
 
-describe("Template: batch recurring payment with email", () => {
+describeIfGatewayCanReachStub("Template: batch recurring payment with email", () => {
   let client: Client;
   let eoaAddress: string;
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
 
     // A local stub replaces httpbin.org here: the gateway makes this request,
     // not the test, so client-side mocking cannot intercept it — only a server

--- a/tests/v4/templates/batch-recurring-payment-with-email.test.ts
+++ b/tests/v4/templates/batch-recurring-payment-with-email.test.ts
@@ -12,9 +12,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
-  getEOAAddress,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/templates/expansion-chains-e2e.test.ts
+++ b/tests/v4/templates/expansion-chains-e2e.test.ts
@@ -1,24 +1,24 @@
 /**
- * Wave A / Wave B / Robinhood read-only E2E against a multi-chain gateway.
+ * Multi-chain read-only E2E: JWT aud + WETH `symbol()` via the chain worker
+ * and Tenderly simulate.
  *
- * Local docker-compose only wires Sepolia, so this file no-ops unless
- * TEST_ENV=railway (or MULTICHAIN_TEST=1). Against Railway it:
+ * Gated on TEST_ENV=railway or MULTICHAIN_TEST=1.
  *
- *   1. Mints a JWT whose `aud` is the target chain on the isolated
- *      client's transport (gateway has the chain in chains[]).
- *   2. `nodes.run` a WETH/WBNB `symbol()` contractRead under that
- *      chain-scoped token — real RPC through that chain's worker.
- *   3. `workflows.simulate` the same read — Tenderly Simulation API
- *      for that chain id (Phase 6 of Adding_A_New_Chain.md).
+ * Local EigenLayer-AVS gateway `chains[]` is Sepolia + Ethereum + Base
+ * (workers :50051 / :50053 / :50054). Against that stack this file
+ * exercises Ethereum and Base (Sepolia is the JWT default).
  *
- * No UserOp is submitted. Uses an isolated EOA so production
+ * Against Railway it also covers Wave A / Wave B / Robinhood:
+ *
+ *   1. Mints a JWT whose `aud` is the target chain.
+ *   2. `nodes.run` a WETH/WBNB `symbol()` contractRead on that worker.
+ *   3. `workflows.simulate` the same read (Tenderly for that chain id).
+ *
+ * No UserOp is submitted. Isolated EOA so production
  * `max_wallets_per_owner` on the shared test key is not a problem.
  *
- * `.env` wins over `.env.railway` (override:false), so point at
- * production explicitly:
- *
- *   TEST_ENV=railway AVS_REST_URL=https://api.avaprotocol.org/api/v1 \
- *     yarn jest tests/v4/templates/expansion-chains-e2e.test.ts
+ *   MULTICHAIN_TEST=1 yarn jest tests/v4/templates/expansion-chains-e2e.test.ts
+ *   TEST_ENV=railway yarn jest tests/v4/templates/expansion-chains-e2e.test.ts
  */
 
 import { Chains, Client, Nodes, Protocols, Triggers } from "@avaprotocol/sdk-js";
@@ -39,7 +39,27 @@ const describeExpansion = MULTICHAIN_STACK ? describe : describe.skip;
 
 const SYMBOL_ABI = [...Protocols.erc20.symbolAbi];
 
-const CHAINS: ReadonlyArray<{
+const LOCAL_SERVED_CHAINS: ReadonlyArray<{
+  name: string;
+  chainId: number;
+  weth: string;
+  symbol: string;
+}> = [
+  {
+    name: "Ethereum",
+    chainId: Chains.EthereumMainnet,
+    weth: Protocols.wrapped.weth[Chains.EthereumMainnet]!,
+    symbol: "WETH",
+  },
+  {
+    name: "Base",
+    chainId: Chains.BaseMainnet,
+    weth: Protocols.wrapped.weth[Chains.BaseMainnet]!,
+    symbol: "WETH",
+  },
+];
+
+const EXPANSION_CHAINS: ReadonlyArray<{
   name: string;
   chainId: number;
   weth: string;
@@ -76,6 +96,9 @@ const CHAINS: ReadonlyArray<{
     symbol: "WETH",
   },
 ];
+
+const CHAINS =
+  process.env.TEST_ENV === "railway" ? EXPANSION_CHAINS : LOCAL_SERVED_CHAINS;
 
 describeExpansion("Expansion chains E2E (auth + WETH read + simulate)", () => {
   let client: Client;

--- a/tests/v4/templates/exported-workflow-consistency.test.ts
+++ b/tests/v4/templates/exported-workflow-consistency.test.ts
@@ -15,6 +15,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -31,8 +32,7 @@ describe("Template: exported workflow consistency", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/templates/exported-workflow-consistency.test.ts
+++ b/tests/v4/templates/exported-workflow-consistency.test.ts
@@ -16,8 +16,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/templates/guardian-wallet-risk-monitor.test.ts
+++ b/tests/v4/templates/guardian-wallet-risk-monitor.test.ts
@@ -21,8 +21,6 @@
 import { Triggers, Nodes, type v4 } from "@avaprotocol/sdk-js";
 import {
   getSuiteClient,
-  getClient,
-  authenticateClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsForChain,

--- a/tests/v4/templates/guardian-wallet-risk-monitor.test.ts
+++ b/tests/v4/templates/guardian-wallet-risk-monitor.test.ts
@@ -13,12 +13,14 @@
  *     the test — so there's no drift, and this locks in the exact GoPlus v2 field
  *     names (approved_contract, address_info.trust_list, token- AND spender-level
  *     malicious_behavior).
- *  2. Live e2e (gated behind RUN_GUARDIAN_LIVE): deploy + trigger + assert the run.
- *     Skipped until a gateway with the two extensions (REST options.auth + the
- *     {{state.*}} binding) exists.
+ *  2. Live e2e: deploy + trigger + assert the run. The gateway extensions
+ *     (REST options.auth + {{state.*}} + guardian_ruleset) shipped; the
+ *     RUN_GUARDIAN_LIVE opt-in is no longer needed. Cleanup cancels the
+ *     workflow after each test so it does not keep scanning.
  */
 import { Triggers, Nodes, type v4 } from "@avaprotocol/sdk-js";
 import {
+  getSuiteClient,
   getClient,
   authenticateClient,
   createSmartWallet,
@@ -437,25 +439,17 @@ describe("buildWalletRiskMonitor — workflow shape", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// 3. Live e2e — deploy + trigger against a real gateway (needs TEST_PRIVATE_KEY /
-//    AVS_REST_URL, like every other template test). Gated behind RUN_GUARDIAN_LIVE=1
-//    so default/CI runs skip it (it deploys and triggers a real workflow). When run it
-//    hard-asserts: deploy + retrieve, then the triggered run must reach the verdict node
-//    with success — a failed trigger throws with the failing step's error. Requires the
-//    gateway extensions (REST options.auth + the {{state.*}} binding) AND the
-//    guardian_ruleset configVar. Verified live 2026-07-17 against prod (v4.3.0,
-//    api.avaprotocol.org): deploy succeeds and the verdict step passes.
-//    Run with: RUN_GUARDIAN_LIVE=1 AVS_REST_URL=<gateway> yarn jest guardian.
+// 3. Live e2e — deploy + trigger. Hard-asserts: deploy + retrieve, then the
+//    triggered run must reach the verdict node. A failed trigger throws with
+//    the failing step's error. Verified live 2026-07-17 against prod v4.3.0.
 // ────────────────────────────────────────────────────────────────────────────
-const RUN_GUARDIAN_LIVE = process.env.RUN_GUARDIAN_LIVE === "1";
-(RUN_GUARDIAN_LIVE ? describe : describe.skip)("Guardian wallet-risk monitor (live gateway)", () => {
+describe("Guardian wallet-risk monitor (live gateway)", () => {
   jest.setTimeout(60_000);
   let client: Client;
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
   afterEach(async () => {
     await removeCreatedWorkflows(client, createdWorkflowIds.splice(0));

--- a/tests/v4/templates/multichain-per-part-chain.test.ts
+++ b/tests/v4/templates/multichain-per-part-chain.test.ts
@@ -16,12 +16,11 @@
  *      chain round-trips through create → retrieve. This is the forward-
  *      compatible shape G5 will make mandatory — writing it now is
  *      no-regret.
- *   2. Cross-chain (gated on a multi-chain stack — Railway, or
- *      MULTICHAIN_TEST=1): trigger on Sepolia, contract read on Base
- *      Sepolia, in ONE workflow. Proves the two-axis model (watch X /
- *      act Y) survives the wire. A Sepolia-only stack rejects the Base
- *      Sepolia part (backend G4 — unconfigured explicit chain), so this
- *      case only runs where both chains are configured.
+ *   2. Cross-chain (gated on a multi-chain stack — local EigenLayer-AVS
+ *      with Ethereum/Base workers, Railway, or MULTICHAIN_TEST=1):
+ *      trigger on Sepolia, contract read on Base, in ONE workflow.
+ *      A Sepolia-only stack (ava-sdk-js CI compose) rejects the Base
+ *      part, so that case stays behind the stack gate.
  *
  * NOTE (intentional, per the renovation plan): this suite sets an
  * explicit `chainId` on every chain-aware part and sends NO
@@ -33,6 +32,7 @@
 import { APIError, Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -42,31 +42,20 @@ import {
 
 jest.setTimeout(60_000);
 
-// READINESS GATE — the deployed server must honor an explicit per-node
-// `chainId` on the *persisted* create() path (backend G3). The current
-// `avs-dev:latest` image does NOT: a per-node `chainId` on contractRead
-// is rejected at create() in every representation —
-//   `cannot unmarshal string into ... ContractReadNodeConfig.chainId of
-//    type int64`
-// — because the node-config decode mixes protojson (int64 → quoted
-// string) with plain encoding/json (rejects the quotes). Verified
-// 2026-06-26; see docs/changes/chain-decoupling-sdk-tracking.md. Set
-// PER_NODE_CHAIN_READY=1 once the renovated backend (G3, incl. the
-// persisted create() path) is deployed to the target stack — then these
-// assertions lock the wire contract for real.
-const PER_NODE_CHAIN_READY = process.env.PER_NODE_CHAIN_READY === "1";
-
-// A multi-chain stack (Railway deploys worker-sepolia + worker-base-
-// sepolia + mainnet/base) is required for the genuine cross-chain case;
-// the local CI compose wires Sepolia only. Gate on an explicit opt-in.
+// Per-part chainId on create() shipped with the chain-decoupling
+// renovation (G3). The PER_NODE_CHAIN_READY opt-in was for the old
+// avs-dev image that rejected quoted int64 — no longer needed.
+//
+// Cross-chain watch/act needs a second chain in the gateway. Local
+// EigenLayer-AVS serves Sepolia + Ethereum + Base; the ava-sdk-js CI
+// compose is Sepolia-only. MULTICHAIN_TEST / TEST_ENV=railway is a
+// *stack* gate, not a feature flag.
 const MULTICHAIN_STACK =
   process.env.MULTICHAIN_TEST === "1" || process.env.TEST_ENV === "railway";
-
-const contractTest = PER_NODE_CHAIN_READY ? test : test.skip;
-const crossChainTest = PER_NODE_CHAIN_READY && MULTICHAIN_STACK ? test : test.skip;
+const crossChainTest = MULTICHAIN_STACK ? test : test.skip;
 
 const USDC_SEPOLIA = Tokens.USDC[Chains.Sepolia]!.address;
-const USDC_BASE_SEPOLIA = Tokens.USDC[Chains.BaseSepolia]!.address;
+const USDC_BASE = Tokens.USDC[Chains.BaseMainnet]!.address;
 const SYMBOL_ABI = Protocols.erc20.symbolAbi;
 
 // A non-anonymous ERC-20 Transfer signature for the event trigger's
@@ -85,15 +74,14 @@ describe("Template: per-part multi-chain wire contract", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {
     await removeCreatedWorkflows(client, createdWorkflowIds.splice(0));
   });
 
-  contractTest("explicit per-part chainId round-trips through create → retrieve", async () => {
+  test("explicit per-part chainId round-trips through create → retrieve", async () => {
     const wallet = await createSmartWallet(client);
 
     const created = await client.workflows.create({
@@ -131,7 +119,7 @@ describe("Template: per-part multi-chain wire contract", () => {
     expect(partChainId(readNode)).toBe(Chains.Sepolia);
   });
 
-  contractTest("rejects a chain-aware node that omits chainId (400)", async () => {
+  test("rejects a chain-aware node that omits chainId (400)", async () => {
     const wallet = await createSmartWallet(client);
 
     // The builder requires `chainId` (TS-enforced), so strip it post-build to
@@ -175,13 +163,13 @@ describe("Template: per-part multi-chain wire contract", () => {
   });
 
   crossChainTest(
-    "watches an event on Sepolia and reads a contract on Base Sepolia (per-part chains)",
+    "watches an event on Sepolia and reads a contract on Base (per-part chains)",
     async () => {
       const wallet = await createSmartWallet(client);
 
       const created = await client.workflows.create({
         smartWalletAddress: wallet.address,
-        name: "Cross-chain watch Sepolia / act Base Sepolia",
+        name: "Cross-chain watch Sepolia / act Base",
         trigger: Triggers.event({
           id: "evt",
           name: "evt",
@@ -193,9 +181,10 @@ describe("Template: per-part multi-chain wire contract", () => {
             id: "read",
             name: "read",
             // The act-on chain differs from the watch chain — the whole
-            // point of the decoupling.
-            chainId: Chains.BaseSepolia,
-            contractAddress: USDC_BASE_SEPOLIA,
+            // point of the decoupling. Base (8453) is in the local
+            // gateway chains[]; Base Sepolia was retired from it.
+            chainId: Chains.BaseMainnet,
+            contractAddress: USDC_BASE,
             contractAbi: SYMBOL_ABI,
             methodCalls: [{ methodName: "symbol", methodParams: [] }],
           }),
@@ -208,7 +197,7 @@ describe("Template: per-part multi-chain wire contract", () => {
       const retrieved = await client.workflows.retrieve(created.id);
       expect(partChainId(retrieved.trigger)).toBe(Chains.Sepolia);
       const readNode = retrieved.nodes?.find((n) => n.id === "read");
-      expect(partChainId(readNode)).toBe(Chains.BaseSepolia);
+      expect(partChainId(readNode)).toBe(Chains.BaseMainnet);
     },
   );
 });

--- a/tests/v4/templates/multichain-per-part-chain.test.ts
+++ b/tests/v4/templates/multichain-per-part-chain.test.ts
@@ -33,8 +33,6 @@ import { APIError, Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@a
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsForChain,

--- a/tests/v4/templates/recurring-payment-with-report.test.ts
+++ b/tests/v4/templates/recurring-payment-with-report.test.ts
@@ -18,9 +18,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
-  getEOAAddress,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/templates/recurring-payment-with-report.test.ts
+++ b/tests/v4/templates/recurring-payment-with-report.test.ts
@@ -17,6 +17,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getEOAAddress,
@@ -24,7 +25,11 @@ import {
   removeCreatedWorkflows,
   settingsFor,
 } from "../../utils/client";
-import { startStubServerFor, type StubServer } from "../../utils/stubServer";
+import {
+  describeIfGatewayCanReachStub,
+  startStubServerFor,
+  type StubServer,
+} from "../../utils/stubServer";
 
 jest.setTimeout(60_000);
 
@@ -32,15 +37,13 @@ jest.setTimeout(60_000);
 let STUB = "";
 let stub: StubServer;
 
-describe("Template: recurring payment with report", () => {
+describeIfGatewayCanReachStub("Template: recurring payment with report", () => {
   let client: Client;
   let eoaAddress: string;
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
 
     // A local stub replaces httpbin.org here: the gateway makes this request,
     // not the test, so client-side mocking cannot intercept it — only a server

--- a/tests/v4/templates/telegram-alert-on-transfer.test.ts
+++ b/tests/v4/templates/telegram-alert-on-transfer.test.ts
@@ -14,9 +14,6 @@ import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
-  getEOAAddress,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/templates/telegram-alert-on-transfer.test.ts
+++ b/tests/v4/templates/telegram-alert-on-transfer.test.ts
@@ -13,6 +13,7 @@
 import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getEOAAddress,
@@ -20,7 +21,11 @@ import {
   removeCreatedWorkflows,
   settingsFor,
 } from "../../utils/client";
-import { startStubServerFor, type StubServer } from "../../utils/stubServer";
+import {
+  describeIfGatewayCanReachStub,
+  startStubServerFor,
+  type StubServer,
+} from "../../utils/stubServer";
 
 jest.setTimeout(60_000);
 
@@ -35,15 +40,13 @@ function padTopic(addr: string): string {
 let STUB = "";
 let stub: StubServer;
 
-describe("Template: Telegram alert on transfer", () => {
+describeIfGatewayCanReachStub("Template: Telegram alert on transfer", () => {
   let client: Client;
   let eoaAddress: string;
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
 
     // A local stub replaces httpbin.org here: the gateway makes this request,
     // not the test, so client-side mocking cannot intercept it — only a server

--- a/tests/v4/templates/uniswapv3_stoploss.test.ts
+++ b/tests/v4/templates/uniswapv3_stoploss.test.ts
@@ -13,6 +13,7 @@
 import { Chains, Nodes, Protocols, Triggers, type Client } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -37,8 +38,7 @@ describe("Template: Uniswap V3 stop-loss", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {
@@ -110,7 +110,7 @@ describe("Template: Uniswap V3 stop-loss", () => {
   }
 
   test("simulates the cron->priceRead->branch->swap workflow shape", async () => {
-    const wallet = await createSmartWallet(client, { saltValue: "2" });
+    const wallet = await createSmartWallet(client);
     const wf = buildWorkflow(wallet.address);
 
     const sim = await client.workflows.simulate({
@@ -130,7 +130,7 @@ describe("Template: Uniswap V3 stop-loss", () => {
   });
 
   test("deploys + retrieves the workflow with the cron trigger type", async () => {
-    const wallet = await createSmartWallet(client, { saltValue: "2" });
+    const wallet = await createSmartWallet(client);
     const wf = buildWorkflow(wallet.address);
 
     const created = await client.workflows.create({

--- a/tests/v4/templates/uniswapv3_stoploss.test.ts
+++ b/tests/v4/templates/uniswapv3_stoploss.test.ts
@@ -14,8 +14,6 @@ import { Chains, Nodes, Protocols, Triggers, type Client } from "@avaprotocol/sd
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsForChain,

--- a/tests/v4/templates/workflow-usdc-read-write-customcode.test.ts
+++ b/tests/v4/templates/workflow-usdc-read-write-customcode.test.ts
@@ -12,9 +12,9 @@
 import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
 
 import {
-  authenticateClient,
-  getClient,
-  getEOAAddress,
+  getSuiteClient,
+  getFundedClient,
+  getFundedWallet,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsForChain,
@@ -33,9 +33,7 @@ describe("Template: USDC read+write+customCode", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
   });
 
   afterEach(async () => {
@@ -98,10 +96,18 @@ describe("Template: USDC read+write+customCode", () => {
   }
 
   test("simulates the workflow with both contractReads + contractWrite + customCode", async () => {
-    const wallet = await createSmartWallet(client, { saltValue: "2" });
+    // Tenderly does not override ERC-20 balances; the transfer step
+    // needs the MA v2 salt-0 wallet that actually holds Sepolia USDC.
+    const { client: funded, owner } = await getFundedClient();
+    const wallet = await getFundedWallet(funded);
+    if (!wallet) {
+      console.log("Skipping — funded MA v2 salt-0 wallet not available");
+      return;
+    }
+    eoaAddress = owner;
     const wf = buildWorkflow(wallet.address);
 
-    const sim = await client.workflows.simulate({
+    const sim = await funded.workflows.simulate({
       trigger: wf.trigger,
       nodes: wf.nodes,
       edges: wf.edges,
@@ -126,7 +132,7 @@ describe("Template: USDC read+write+customCode", () => {
   });
 
   test("deploys + retrieves the workflow with the cron trigger type", async () => {
-    const wallet = await createSmartWallet(client, { saltValue: "2" });
+    const wallet = await createSmartWallet(client);
     const wf = buildWorkflow(wallet.address);
 
     const created = await client.workflows.create({

--- a/tests/v4/triggers/block.test.ts
+++ b/tests/v4/triggers/block.test.ts
@@ -21,8 +21,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   getCurrentBlockNumber,
   createSmartWallet,
   removeCreatedWorkflows,

--- a/tests/v4/triggers/block.test.ts
+++ b/tests/v4/triggers/block.test.ts
@@ -20,6 +20,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getCurrentBlockNumber,
@@ -46,8 +47,7 @@ describe("BlockTrigger Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/triggers/cron.test.ts
+++ b/tests/v4/triggers/cron.test.ts
@@ -13,8 +13,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   getCurrentBlockNumber,
   createSmartWallet,
   removeCreatedWorkflows,

--- a/tests/v4/triggers/cron.test.ts
+++ b/tests/v4/triggers/cron.test.ts
@@ -12,6 +12,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getCurrentBlockNumber,
@@ -28,8 +29,7 @@ describe("CronTrigger Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/triggers/eventTrigger.test.ts
+++ b/tests/v4/triggers/eventTrigger.test.ts
@@ -21,6 +21,7 @@
 import { Chains, Client, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getEOAAddress,
@@ -43,9 +44,7 @@ describe("EventTrigger Tests", () => {
   let eoaAddress: string;
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
   });
 
   describe("triggers.run", () => {

--- a/tests/v4/triggers/eventTrigger.test.ts
+++ b/tests/v4/triggers/eventTrigger.test.ts
@@ -22,9 +22,6 @@ import { Chains, Client, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
-  getEOAAddress,
 } from "../../utils/client";
 
 jest.setTimeout(60_000);

--- a/tests/v4/triggers/manual.test.ts
+++ b/tests/v4/triggers/manual.test.ts
@@ -17,6 +17,7 @@
 import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -32,8 +33,7 @@ describe("ManualTrigger Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/triggers/manual.test.ts
+++ b/tests/v4/triggers/manual.test.ts
@@ -18,8 +18,6 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,

--- a/tests/v4/workflows/createWorkflow.test.ts
+++ b/tests/v4/workflows/createWorkflow.test.ts
@@ -14,9 +14,6 @@ import { Chains, Client, Nodes, Protocols, Tokens, Triggers, type v4 } from "@av
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
-  getEOAAddress,
   createSmartWallet,
   removeCreatedWorkflows,
 } from "../../utils/client";

--- a/tests/v4/workflows/createWorkflow.test.ts
+++ b/tests/v4/workflows/createWorkflow.test.ts
@@ -13,6 +13,7 @@
 import { Chains, Client, Nodes, Protocols, Tokens, Triggers, type v4 } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getEOAAddress,
@@ -37,9 +38,7 @@ describe("createWorkflow Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/workflows/deleteWorkflow.test.ts
+++ b/tests/v4/workflows/deleteWorkflow.test.ts
@@ -10,8 +10,6 @@ import { Client } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
 } from "../../utils/client";
 import { createFromTemplate } from "../../utils/templates";

--- a/tests/v4/workflows/deleteWorkflow.test.ts
+++ b/tests/v4/workflows/deleteWorkflow.test.ts
@@ -9,6 +9,7 @@
 import { Client } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -21,8 +22,7 @@ describe("deleteWorkflow Tests", () => {
   let client: Client;
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   test("cancels a workflow and removes it from the list", async () => {

--- a/tests/v4/workflows/setWorkflowEnabled.test.ts
+++ b/tests/v4/workflows/setWorkflowEnabled.test.ts
@@ -11,6 +11,7 @@
 import { Client } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   createSmartWallet,
@@ -25,8 +26,7 @@ describe("pause/resume Workflow Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/workflows/setWorkflowEnabled.test.ts
+++ b/tests/v4/workflows/setWorkflowEnabled.test.ts
@@ -12,8 +12,6 @@ import { Client } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   createSmartWallet,
   removeCreatedWorkflows,
 } from "../../utils/client";

--- a/tests/v4/workflows/triggerWorkflow.test.ts
+++ b/tests/v4/workflows/triggerWorkflow.test.ts
@@ -21,6 +21,7 @@
 import { Client, Protocols, Triggers } from "@avaprotocol/sdk-js";
 
 import {
+  getSuiteClient,
   authenticateClient,
   getClient,
   getCurrentBlockNumber,
@@ -36,8 +37,7 @@ describe("workflows.trigger Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    client = getClient();
-    await authenticateClient(client);
+    ({ client } = await getSuiteClient());
   });
 
   afterEach(async () => {

--- a/tests/v4/workflows/triggerWorkflow.test.ts
+++ b/tests/v4/workflows/triggerWorkflow.test.ts
@@ -22,8 +22,6 @@ import { Client, Protocols, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
-  authenticateClient,
-  getClient,
   getCurrentBlockNumber,
   createSmartWallet,
   removeCreatedWorkflows,

--- a/tests/v4/workflows/workflow.test.ts
+++ b/tests/v4/workflows/workflow.test.ts
@@ -15,7 +15,6 @@ import { Client } from "@avaprotocol/sdk-js";
 
 import {
   getIsolatedClient,
-  getEOAAddress,
   createSmartWallet,
   nextTestSalt,
   removeCreatedWorkflows,
@@ -32,8 +31,7 @@ describe("Workflow Management Tests", () => {
   beforeAll(async () => {
     // A private EOA for this suite. Salts alone do not isolate an
     // owner-scoped query, and this suite asserts on exact counts.
-    ({ client } = await getIsolatedClient());
-    eoaAddress = getEOAAddress();
+    ({ client, owner: eoaAddress } = await getIsolatedClient());
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Follow-up to the production `TEST_ENV=railway` triage (wallet cap 3, partner `read`, funded UserOps) and the local MA v2 session-grant work. No published package API change — tests, helpers, and the change-log only.

Client-side of EigenLayer-AVS [#761](https://github.com/AvaProtocol/EigenLayer-AVS/issues/761) (staging `0c8aa185`): typed native-ETH refusal and in-process withdraw send.

## What changed

**Production cap.** `getSuiteClient()` uses a throwaway EOA when `TEST_ENV=railway` / `TIGHT_WALLET_CAP=1`; local keeps the shared key + unique salts (cap 2000). dotenv loads `.env.$TEST_ENV` before `.env` so the railway partner audience/key actually apply. Stub HTTP suites skip when the gateway cannot dial `127.0.0.1`.

**Funded UserOps.** Real bundler tests use `getFundedFixture()`: MA v2 factory `0x0000…6fecd`, salt `"0"`, address `0x209eb31c199bEB4c386eF83CF442DE1a00667a1F` for the shared test EOA. A one-year session grant is submitted (and reused) covering USDC `approve`/`transfer`. The legacy SimpleAccount salt-2 (`0x5a8A…` / `0xB99BC2…`) cannot host grants.

**#761.** Native ETH trigger/withdraw assert `SESSION_POLICY_NATIVE_NOT_ALLOWED` (400 / failed step) instead of skipping or waiting for AA23. ERC-20 `wallets.withdraw` is a real UserOp now that the gateway sends in-process. `ethTransfer` sims stay Tenderly-green.

**Local `chains[]`.** `wallets.list({ chainId })` and expansion e2e target Sepolia + Ethereum + Base when not on railway. Leftover `DURABLE_E2E` / `PER_NODE_CHAIN_READY` / `RUN_GUARDIAN_LIVE` gates dropped; `MULTICHAIN_TEST` remains a stack gate. `policiesLive` uses an isolated EOA so it cannot revoke the funded fixture grant.

Plan and evidence: `docs/changes/20260820-production-e2e-wallet-cap-partner-funded.md`.

## Verification

- Production after helpers (pre-#761 binary): 45 passed / 9 skipped / 0 failed suites — `logs/20260820-170300-full-e2e-prod-final.log`
- Local after #761 rebuild (`/health` 4.17.0): **54/54 suites, 385/385 tests, 0 failed, 0 skipped** (177s) — `logs/20260821-000558-full-e2e-local-761.log`
- Live Sepolia on `0x209eb31…`: approve trigger mined; USDC withdraw mined; ETH withdraw 400 `SESSION_POLICY_NATIVE_NOT_ALLOWED` in ~1ms

## Ordering

Merging this does not publish npm. Production `TEST_ENV=railway` will only match the native-refusal / ERC-20 withdraw assertions after EigenLayer-AVS #761 is deployed there.