### PR TITLE
test: bound e2e salts to the production wallet cap, fix balanceNode fixture

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "publish:bash": "bash ./scripts/publish-packages.sh",
     "publish:bash:dry-run": "bash ./scripts/publish-packages.sh --dry-run",
     "publish:help": "bash ./scripts/publish-packages.sh --help",
-    "lint": "eslint packages/*/src --ext .ts && eslint scripts/**/*.ts",
+    "lint": "eslint packages/*/src --ext .ts",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "publish:bash": "bash ./scripts/publish-packages.sh",
     "publish:bash:dry-run": "bash ./scripts/publish-packages.sh --dry-run",
     "publish:help": "bash ./scripts/publish-packages.sh --help",
-    "lint": "eslint packages/*/src --ext .ts",
+    "lint": "eslint packages/*/src --ext .ts && eslint scripts/**/*.ts",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/inspect-fixture-grant.ts
+++ b/scripts/inspect-fixture-grant.ts
@@ -1,0 +1,46 @@
+/**
+ * Diagnostic: list the session policies the gateway holds for the MA v2
+ * funded e2e runner, so we can see why a UserOp is being signed with an
+ * expired grant.
+ *
+ * Read-only. Run with: TEST_ENV=railway npx tsx scripts/inspect-fixture-grant.ts
+ */
+import { getFundedClient, getFundedWallet } from "../tests/utils/client";
+
+const CHAIN_ID = Number(process.env.CHAIN_ID || 11155111);
+
+async function main() {
+  const { client, owner } = await getFundedClient();
+  const wallet = await getFundedWallet(client);
+  if (!wallet) {
+    console.log("no funded wallet resolved for owner", owner);
+    return;
+  }
+  console.log(`owner:  ${owner}`);
+  console.log(`runner: ${wallet.address} (salt ${wallet.salt}, factory ${wallet.factoryAddress})`);
+  console.log("");
+
+  const listed = await client.policies.list(wallet.address, { chainId: CHAIN_ID });
+  console.log(`policies on this runner: ${listed.items.length}`);
+  const now = Date.now();
+  for (const p of listed.items) {
+    const until = Number(p.validUntil);
+    const live = until > now;
+    console.log(
+      [
+        `  id=${p.id}`,
+        `status=${p.status}`,
+        `entity=${p.entityId ?? "-"}`,
+        `label=${p.agentLabel ?? "-"}`,
+        `validUntil=${new Date(until).toISOString()}`,
+        live ? "LIVE" : "EXPIRED",
+        `actions=${(p.allowedActions ?? []).length}`,
+      ].join("  "),
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error("failed:", err);
+  process.exit(1);
+});

--- a/scripts/inspect-fixture-grant.ts
+++ b/scripts/inspect-fixture-grant.ts
@@ -1,42 +1,61 @@
 /**
- * Diagnostic: list the session policies the gateway holds for the MA v2
- * funded e2e runner, so we can see why a UserOp is being signed with an
- * expired grant.
+ * Diagnostic: list the session policies the gateway holds for the MA v2 funded
+ * e2e runner, so an operator can see at a glance whether the fixture can still
+ * sign — and if not, why.
  *
- * Read-only. Run with: TEST_ENV=railway npx tsx scripts/inspect-fixture-grant.ts
+ * STRICTLY READ-ONLY. It resolves the runner from `wallets.list()` rather than
+ * `getFundedWallet()`: that helper is an ensure-helper, and when the salt-0 row
+ * is missing it falls through to `wallets.create()`, which would consume one of
+ * the owner's three production wallet slots. A tool you reach for when
+ * something already looks wrong must not change what it is inspecting.
+ *
+ * Run: TEST_ENV=railway npx tsx scripts/inspect-fixture-grant.ts
  */
-import { getFundedClient, getFundedWallet } from "../tests/utils/client";
+import { getFundedClient } from "../tests/utils/client";
+import {
+  FUNDED_FIXTURE_FACTORY,
+  FUNDED_FIXTURE_SALT,
+  describePolicy,
+  isUsableNow,
+} from "../tests/utils/fixtureGrantDisplay";
 
 const CHAIN_ID = Number(process.env.CHAIN_ID || 11155111);
 
-async function main() {
+async function main(): Promise<void> {
   const { client, owner } = await getFundedClient();
-  const wallet = await getFundedWallet(client);
-  if (!wallet) {
-    console.log("no funded wallet resolved for owner", owner);
+
+  const wallets = await client.wallets.list({ chainId: CHAIN_ID });
+  const runner = wallets.data.find(
+    (w) =>
+      w.salt === FUNDED_FIXTURE_SALT &&
+      w.factoryAddress?.toLowerCase() === FUNDED_FIXTURE_FACTORY.toLowerCase(),
+  );
+
+  console.log(`owner:  ${owner}`);
+  if (!runner) {
+    console.log(
+      `runner: NOT FOUND (salt ${FUNDED_FIXTURE_SALT}, factory ${FUNDED_FIXTURE_FACTORY})\n` +
+        `        Not creating it — this script is read-only. Run the e2e suite or\n` +
+        `        refresh-fixture-grant.ts if the fixture needs provisioning.`,
+    );
     return;
   }
-  console.log(`owner:  ${owner}`);
-  console.log(`runner: ${wallet.address} (salt ${wallet.salt}, factory ${wallet.factoryAddress})`);
-  console.log("");
+  console.log(`runner: ${runner.address} (salt ${runner.salt}, factory ${runner.factoryAddress})\n`);
 
-  const listed = await client.policies.list(wallet.address, { chainId: CHAIN_ID });
+  const listed = await client.policies.list(runner.address, { chainId: CHAIN_ID });
   console.log(`policies on this runner: ${listed.items.length}`);
   const now = Date.now();
-  for (const p of listed.items) {
-    const until = Number(p.validUntil);
-    const live = until > now;
-    console.log(
-      [
-        `  id=${p.id}`,
-        `status=${p.status}`,
-        `entity=${p.entityId ?? "-"}`,
-        `label=${p.agentLabel ?? "-"}`,
-        `validUntil=${new Date(until).toISOString()}`,
-        live ? "LIVE" : "EXPIRED",
-        `actions=${(p.allowedActions ?? []).length}`,
-      ].join("  "),
-    );
+  for (const policy of listed.items) {
+    console.log("  " + describePolicy(policy, now));
+  }
+
+  const usable = listed.items.filter((p) => isUsableNow(p, now));
+  console.log(`\nusable right now: ${usable.length}`);
+  if (usable.length === 0) {
+    console.log("  -> the fixture cannot sign; run refresh-fixture-grant.ts");
+  } else if (usable.length > 1) {
+    // The gateway refuses to pick between them (SESSION_POLICY_AMBIGUOUS).
+    console.log("  -> MORE THAN ONE usable grant; the send path will refuse as ambiguous");
   }
 }
 

--- a/scripts/refresh-fixture-grant.ts
+++ b/scripts/refresh-fixture-grant.ts
@@ -1,66 +1,138 @@
 /**
- * Refresh the MA v2 funded e2e fixture grant onto a CLEAN validation entity.
+ * Move the MA v2 funded e2e fixture grant onto a CLEAN validation entity.
  *
- * Why this is needed rather than just re-granting: the gateway's DB record and
- * the account's on-chain hooks had drifted. Entity 2 held a stored grant with
- * validUntil 2027, while the account's installed TimeRangeValidationHook for
- * that entity still carried validUntil 2026-08-13 — so every UserOp signed for
- * entity 2 was rejected by the chain as expired no matter what the DB said.
- * NextSessionEntityID picks max(stored entity)+1, so revoking the current grant
- * and granting again moves the fixture to the next entity, which the account
- * has never had installed.
+ * Why moving entity, rather than just re-granting: the gateway's DB record and
+ * the account's on-chain hooks can drift. Entity 2 once held a stored grant
+ * valid to 2027 while the account's installed TimeRangeValidationHook for that
+ * same entity still carried validUntil 2026-08-13, so every UserOp was rejected
+ * as expired no matter what storage said. NextSessionEntityID picks
+ * max(stored entity)+1, so revoking every stored grant first pushes the next
+ * one past all of them, onto an entity the account has never had installed.
+ *
+ * This is a WORKAROUND for EigenLayer-AVS #763, not a fix.
  *
  * Run: TEST_ENV=railway npx tsx scripts/refresh-fixture-grant.ts
  */
+import type { v4 } from "@avaprotocol/types";
+
 import { getFundedClient, getFundedWallet } from "../tests/utils/client";
 import { ensureE2eSessionGrant } from "../tests/utils/sessionGrant";
+import { describePolicy, isUsableNow } from "../tests/utils/fixtureGrantDisplay";
 
 const CHAIN_ID = Number(process.env.CHAIN_ID || 11155111);
 
-function describe(p: { id: string; status?: string; entityId?: unknown; agentLabel?: string; validUntil?: unknown }) {
-  const until = Number(p.validUntil);
-  return `id=${p.id} status=${p.status} entity=${p.entityId ?? "-"} label=${p.agentLabel ?? "-"} validUntil=${
-    Number.isFinite(until) ? new Date(until).toISOString() : "-"
-  }`;
+interface OnChainCleanup {
+  readonly entityId?: number;
+  readonly target?: string;
+  readonly callData?: string;
+  readonly chainId?: number;
 }
 
-async function main() {
+/**
+ * Report what revoking left behind on chain.
+ *
+ * A revoke is only a storage change. When the grant was already applied the
+ * account KEEPS its installed validation until the owner sends
+ * `uninstallValidation` — the gateway controller cannot self-uninstall, because
+ * production grants are policied.
+ *
+ * This script does not send that call. Cleanup is NOT idempotent (re-sending
+ * after the entity is already clear reverts on chain, see EigenLayer-AVS
+ * #731/#717), so firing it blind from an operator script is the wrong trade:
+ * a mistaken send costs a reverted transaction and a confusing state, while
+ * leaving it uninstalled costs nothing as long as the operator knows.
+ *
+ * So: print the payload, and be explicit about whether the leftover still has
+ * authority. An entity whose window has already closed is inert — it is what
+ * the drift incident left behind, and it is harmless. An entity whose window is
+ * still OPEN retains real signing authority and must be cleaned up.
+ */
+function reportCleanup(policy: v4.SessionPolicy, response: unknown): void {
+  const res = response as { status?: string; onChainCleanupRequired?: boolean; onChainCleanup?: OnChainCleanup };
+  if (!res?.onChainCleanupRequired) {
+    console.log(`    nothing installed on chain for this grant (status=${res?.status})`);
+    return;
+  }
+
+  const until = Number(policy.validUntil);
+  const stillOpen = Number.isFinite(until) && until > Date.now();
+  const cleanup = res.onChainCleanup;
+
+  if (stillOpen) {
+    console.log(
+      `    ⚠  entity ${policy.entityId} REMAINS INSTALLED and its window is still open ` +
+        `(until ${new Date(until).toISOString()}).\n` +
+        `       It keeps on-chain signing authority until the OWNER sends uninstallValidation.\n` +
+        `       Send this once (not idempotent — re-sending after it is clear reverts):`,
+    );
+  } else {
+    console.log(
+      `    entity ${policy.entityId} remains installed but its window already closed ` +
+        `(${Number.isFinite(until) ? new Date(until).toISOString() : "unknown"}), so it is inert.\n` +
+        `    Optional cleanup payload:`,
+    );
+  }
+  console.log(`       ${JSON.stringify(cleanup ?? {})}`);
+}
+
+async function main(): Promise<void> {
   const { client, owner, privateKey } = await getFundedClient();
   const wallet = await getFundedWallet(client);
-  if (!wallet) throw new Error("no funded wallet resolved");
+  if (!wallet) throw new Error("no funded wallet resolved for the fixture owner");
 
   console.log(`owner:  ${owner}`);
   console.log(`runner: ${wallet.address}\n`);
 
   const before = await client.policies.list(wallet.address, { chainId: CHAIN_ID });
   console.log("before:");
-  before.items.forEach((p) => console.log("  " + describe(p as never)));
+  before.items.forEach((p) => console.log("  " + describePolicy(p)));
 
-  // Revoke every non-revoked grant so ensureE2eSessionGrant cannot reuse one,
-  // and so NextSessionEntityID hands out an entity above all of them.
-  for (const p of before.items) {
-    if (p.status === "revoked") continue;
-    const res = await client.policies.revoke(wallet.address, p.id, { chainId: CHAIN_ID });
-    console.log(
-      `\nrevoked ${p.id} -> status=${res.status} onChainCleanupRequired=${
-        (res as { onChainCleanupRequired?: boolean }).onChainCleanupRequired ?? false
-      }`,
-    );
+  // Revoke everything still usable so ensureE2eSessionGrant cannot reuse one
+  // and NextSessionEntityID moves above them all.
+  //
+  // Each revoke is guarded: aborting the loop midway would leave the fixture
+  // PARTIALLY revoked — strictly worse than before this ran, since a surviving
+  // usable grant both keeps its entity low and can collide with the new one.
+  // Revoke as many as possible, then report the failures loudly.
+  const failures: string[] = [];
+  for (const policy of before.items) {
+    if (!isUsableNow(policy)) continue;
+    console.log(`\n  revoking ${policy.id} (entity ${policy.entityId})`);
+    try {
+      const res = await client.policies.revoke(wallet.address, policy.id, { chainId: CHAIN_ID });
+      reportCleanup(policy, res);
+    } catch (err) {
+      const message = (err as Error).message;
+      console.log(`    ✗ revoke FAILED: ${message}`);
+      failures.push(`${policy.id}: ${message}`);
+    }
   }
 
-  const fresh = await ensureE2eSessionGrant(
-    client,
-    wallet.address,
-    privateKey,
-    owner,
-    CHAIN_ID,
-  );
+  if (failures.length > 0) {
+    // Granting now could land on an entity that a surviving grant still holds,
+    // which is the very collision this script exists to escape.
+    console.error(
+      `\n${failures.length} grant(s) could not be revoked; NOT granting a replacement:\n  ` +
+        failures.join("\n  ") +
+        `\n\nRe-run once the gateway is reachable, or revoke these by hand first.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const fresh = await ensureE2eSessionGrant(client, wallet.address, privateKey, owner, CHAIN_ID);
   console.log("\nfresh grant:");
-  console.log("  " + describe(fresh as never));
+  console.log("  " + describePolicy(fresh));
 
   const after = await client.policies.list(wallet.address, { chainId: CHAIN_ID });
   console.log("\nafter:");
-  after.items.forEach((p) => console.log("  " + describe(p as never)));
+  after.items.forEach((p) => console.log("  " + describePolicy(p)));
+
+  const usable = after.items.filter((p) => isUsableNow(p));
+  if (usable.length !== 1) {
+    console.error(`\nexpected exactly one usable grant, found ${usable.length}`);
+    process.exitCode = 1;
+  }
 }
 
 main().catch((err) => {

--- a/scripts/refresh-fixture-grant.ts
+++ b/scripts/refresh-fixture-grant.ts
@@ -1,0 +1,69 @@
+/**
+ * Refresh the MA v2 funded e2e fixture grant onto a CLEAN validation entity.
+ *
+ * Why this is needed rather than just re-granting: the gateway's DB record and
+ * the account's on-chain hooks had drifted. Entity 2 held a stored grant with
+ * validUntil 2027, while the account's installed TimeRangeValidationHook for
+ * that entity still carried validUntil 2026-08-13 — so every UserOp signed for
+ * entity 2 was rejected by the chain as expired no matter what the DB said.
+ * NextSessionEntityID picks max(stored entity)+1, so revoking the current grant
+ * and granting again moves the fixture to the next entity, which the account
+ * has never had installed.
+ *
+ * Run: TEST_ENV=railway npx tsx scripts/refresh-fixture-grant.ts
+ */
+import { getFundedClient, getFundedWallet } from "../tests/utils/client";
+import { ensureE2eSessionGrant } from "../tests/utils/sessionGrant";
+
+const CHAIN_ID = Number(process.env.CHAIN_ID || 11155111);
+
+function describe(p: { id: string; status?: string; entityId?: unknown; agentLabel?: string; validUntil?: unknown }) {
+  const until = Number(p.validUntil);
+  return `id=${p.id} status=${p.status} entity=${p.entityId ?? "-"} label=${p.agentLabel ?? "-"} validUntil=${
+    Number.isFinite(until) ? new Date(until).toISOString() : "-"
+  }`;
+}
+
+async function main() {
+  const { client, owner, privateKey } = await getFundedClient();
+  const wallet = await getFundedWallet(client);
+  if (!wallet) throw new Error("no funded wallet resolved");
+
+  console.log(`owner:  ${owner}`);
+  console.log(`runner: ${wallet.address}\n`);
+
+  const before = await client.policies.list(wallet.address, { chainId: CHAIN_ID });
+  console.log("before:");
+  before.items.forEach((p) => console.log("  " + describe(p as never)));
+
+  // Revoke every non-revoked grant so ensureE2eSessionGrant cannot reuse one,
+  // and so NextSessionEntityID hands out an entity above all of them.
+  for (const p of before.items) {
+    if (p.status === "revoked") continue;
+    const res = await client.policies.revoke(wallet.address, p.id, { chainId: CHAIN_ID });
+    console.log(
+      `\nrevoked ${p.id} -> status=${res.status} onChainCleanupRequired=${
+        (res as { onChainCleanupRequired?: boolean }).onChainCleanupRequired ?? false
+      }`,
+    );
+  }
+
+  const fresh = await ensureE2eSessionGrant(
+    client,
+    wallet.address,
+    privateKey,
+    owner,
+    CHAIN_ID,
+  );
+  console.log("\nfresh grant:");
+  console.log("  " + describe(fresh as never));
+
+  const after = await client.policies.list(wallet.address, { chainId: CHAIN_ID });
+  console.log("\nafter:");
+  after.items.forEach((p) => console.log("  " + describe(p as never)));
+}
+
+main().catch((err) => {
+  console.error("failed:", err);
+  process.exit(1);
+});

--- a/tests/utils/client.ts
+++ b/tests/utils/client.ts
@@ -295,6 +295,34 @@ export function nextTestSalt(): string {
   return String(saltCursor);
 }
 
+/** Production allows this many smart wallets per owner PER CHAIN. */
+export const TIGHT_WALLET_CAP_LIMIT = 3;
+
+let suiteSaltCursor = 0;
+
+/**
+ * A salt from the suite's bounded pool: `"0" | "1" | "2"` under a tight cap,
+ * `nextTestSalt()` otherwise.
+ *
+ * Production caps an owner at {@link TIGHT_WALLET_CAP_LIMIT} wallets per chain
+ * and a suite file runs on ONE isolated EOA, so the file may only ever address
+ * three distinct salts. `nextTestSalt()` is the opposite policy — a value no
+ * other worker or run will reuse — which is right for CI (cap 2000) and fatal
+ * against production: the fourth unique salt on one owner is a 429.
+ *
+ * Consecutive calls return DIFFERENT salts, so a test needing two wallets at
+ * once can call it twice. A test needing MORE than three distinct wallets, or
+ * one that must not collide with a salt an earlier test created (a listing
+ * asserting a salt is absent, say), needs its own `getIsolatedClient()` and a
+ * fresh quota — cycling cannot give it one.
+ */
+export function suiteSalt(): string {
+  if (!tightWalletCap()) return nextTestSalt();
+  const salt = String(suiteSaltCursor % TIGHT_WALLET_CAP_LIMIT);
+  suiteSaltCursor += 1;
+  return salt;
+}
+
 export interface CreateSmartWalletOptions {
   /** Override the salt instead of pulling from the per-process cursor. */
   saltValue?: string;

--- a/tests/utils/fixtureGrantDisplay.ts
+++ b/tests/utils/fixtureGrantDisplay.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared display + classification for the fixture session-grant scripts.
+ *
+ * Lives here rather than in either script so the two cannot drift into
+ * disagreeing about what "live" means — the whole point of these tools is to
+ * tell an operator, at a glance, whether the fixture is usable.
+ */
+import type { v4 } from "@avaprotocol/types";
+
+/** Salt + factory of the MA v2 funded e2e runner. */
+export const FUNDED_FIXTURE_SALT = "0";
+export const FUNDED_FIXTURE_FACTORY =
+  "0x00000000000017c61b5bEe81050EC8eFc9c6fecd";
+
+/**
+ * Whether a policy can actually authorize a UserOp right now.
+ *
+ * BOTH conditions matter and reporting either alone is misleading:
+ *
+ *  - `status` must be pending/active. A revoked grant authorizes nothing no
+ *    matter how far in the future its window runs — and `refresh-fixture-grant`
+ *    deliberately leaves exactly that behind, so labelling on `validUntil`
+ *    alone prints "revoked ... LIVE" on the rows it just retired.
+ *  - the window must still be open. `SESSION_POLICY_EXPIRED` (EigenLayer-AVS
+ *    `cc19bec4`) refuses a grant whose `validUntil` has passed.
+ */
+export function isUsableNow(policy: v4.SessionPolicy, now = Date.now()): boolean {
+  const status = policy.status;
+  const inStatus = status === "pending" || status === "active";
+  return inStatus && Number(policy.validUntil) > now;
+}
+
+/** One aligned console line describing a policy. */
+export function describePolicy(policy: v4.SessionPolicy, now = Date.now()): string {
+  const until = Number(policy.validUntil);
+  const window = Number.isFinite(until) ? new Date(until).toISOString() : "-";
+  const expired = Number.isFinite(until) && until <= now;
+
+  // Report the two axes separately: an operator needs to know WHY a row is
+  // unusable, and "EXPIRED" on a revoked row hides that revocation was the
+  // reason. USABLE is the only label that means "this can sign right now".
+  const verdict = isUsableNow(policy, now)
+    ? "USABLE"
+    : expired
+      ? "unusable(expired)"
+      : `unusable(${policy.status})`;
+
+  return [
+    `id=${policy.id}`,
+    `status=${policy.status}`,
+    `entity=${policy.entityId ?? "-"}`,
+    `label=${policy.agentLabel ?? "-"}`,
+    `validUntil=${window}`,
+    verdict,
+    `actions=${(policy.allowedActions ?? []).length}`,
+  ].join("  ");
+}

--- a/tests/v4/core/suiteSalt.test.ts
+++ b/tests/v4/core/suiteSalt.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit coverage for the tight-cap salt pool. Pure and offline — the e2e suites
+ * exercise it end-to-end, but an off-by-one in the wraparound would silently
+ * reintroduce the production 429s those suites were changed to avoid, and it
+ * would only show up as a wire error against a real gateway.
+ *
+ * Lives under tests/v4/core rather than beside the helper in tests/utils
+ * because Jest's roots is <rootDir>/tests/v4 and CI shards by that directory —
+ * a test outside it is collected by neither, and a test that never runs is
+ * worse than no test. It needs no gateway; it just rides the core shard.
+ */
+import { TIGHT_WALLET_CAP_LIMIT, suiteSalt, tightWalletCap } from "../../utils/client";
+
+describe("suiteSalt", () => {
+  const originalTightCap = process.env.TIGHT_WALLET_CAP;
+  const originalTestEnv = process.env.TEST_ENV;
+
+  afterEach(() => {
+    process.env.TIGHT_WALLET_CAP = originalTightCap;
+    process.env.TEST_ENV = originalTestEnv;
+    if (originalTightCap === undefined) delete process.env.TIGHT_WALLET_CAP;
+    if (originalTestEnv === undefined) delete process.env.TEST_ENV;
+  });
+
+  test("tightWalletCap is on for TEST_ENV=railway and for the explicit flag", () => {
+    process.env.TEST_ENV = "railway";
+    delete process.env.TIGHT_WALLET_CAP;
+    expect(tightWalletCap()).toBe(true);
+
+    process.env.TEST_ENV = "dev";
+    process.env.TIGHT_WALLET_CAP = "1";
+    expect(tightWalletCap()).toBe(true);
+
+    delete process.env.TIGHT_WALLET_CAP;
+    expect(tightWalletCap()).toBe(false);
+  });
+
+  test("under a tight cap it never yields more than the cap's worth of salts", () => {
+    process.env.TIGHT_WALLET_CAP = "1";
+
+    // Well past one wraparound: the constraint is on the SET of values, which
+    // is what the gateway counts, not on how many times it is called.
+    const produced = Array.from({ length: 4 * TIGHT_WALLET_CAP_LIMIT }, () => suiteSalt());
+    const distinct = new Set(produced);
+
+    expect(distinct.size).toBeLessThanOrEqual(TIGHT_WALLET_CAP_LIMIT);
+    for (const salt of distinct) {
+      expect(Number(salt)).toBeGreaterThanOrEqual(0);
+      expect(Number(salt)).toBeLessThan(TIGHT_WALLET_CAP_LIMIT);
+    }
+  });
+
+  test("consecutive calls differ, so a test needing two wallets at once gets two", () => {
+    process.env.TIGHT_WALLET_CAP = "1";
+    const first = suiteSalt();
+    const second = suiteSalt();
+    expect(first).not.toEqual(second);
+  });
+
+  test("without a tight cap it falls through to the unique counter", () => {
+    delete process.env.TIGHT_WALLET_CAP;
+    process.env.TEST_ENV = "dev";
+
+    // CI's cap is 2000 and parallel workers share one owner, so collision —
+    // not the cap — is the risk there. Values must keep climbing.
+    const produced = Array.from({ length: 5 }, () => suiteSalt());
+    expect(new Set(produced).size).toBe(produced.length);
+    const numeric = produced.map(Number);
+    expect(numeric).toEqual([...numeric].sort((a, b) => a - b));
+    expect(Math.max(...numeric)).toBeGreaterThanOrEqual(TIGHT_WALLET_CAP_LIMIT);
+  });
+});

--- a/tests/v4/core/wallet.test.ts
+++ b/tests/v4/core/wallet.test.ts
@@ -27,8 +27,9 @@ import { Chains, Client, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
+  getIsolatedClient,
   createSmartWallet,
-  nextTestSalt,
+  suiteSalt,
   removeCreatedWorkflows,
   TEST_AUTH_CHAIN_ID,
 } from "../../utils/client";
@@ -49,7 +50,7 @@ describe("Wallet Management Tests", () => {
 
   describe("wallets.create (v3 getWallet)", () => {
     test("derives a wallet with the aggregator's default factory", async () => {
-      const salt = nextTestSalt();
+      const salt = suiteSalt();
       const result = await client.wallets.create({ salt });
 
       expect(result.salt).toEqual(salt);
@@ -59,7 +60,7 @@ describe("Wallet Management Tests", () => {
 
     test("workflow lifecycle updates the wallet counts", async () => {
       // Use a fresh salt so the workflow counters start from a known baseline.
-      const salt = nextTestSalt();
+      const salt = suiteSalt();
       let wallet = await client.wallets.create({ salt });
 
       let workflowId1: string | undefined;
@@ -127,8 +128,12 @@ describe("Wallet Management Tests", () => {
     });
 
     test("accepts an explicit salt and echoes it back", async () => {
+      // Its own owner: this salt is deliberately outside the suite pool
+      // ("0"/"1"/"2"), so on the shared owner it would be a fourth distinct
+      // wallet and 429 against production's cap of 3.
+      const { client: echoClient } = await getIsolatedClient();
       const salt = "12345";
-      const result = await client.wallets.create({ salt });
+      const result = await echoClient.wallets.create({ salt });
       expect(result.salt).toEqual(salt);
       expect(result.factoryAddress).toBeTruthy();
       expect(result.address).toHaveLength(42);
@@ -147,7 +152,7 @@ describe("Wallet Management Tests", () => {
     });
 
     test("returns isHidden defaulted to false on a fresh wallet", async () => {
-      const salt = nextTestSalt();
+      const salt = suiteSalt();
       const wallet = await client.wallets.create({ salt });
       expect(wallet).toHaveProperty("isHidden");
       expect(wallet.isHidden ?? false).toBeFalsy();
@@ -156,7 +161,7 @@ describe("Wallet Management Tests", () => {
 
   describe("wallets.list (v3 getWallets)", () => {
     test("includes a freshly created custom-salt wallet", async () => {
-      const salt = nextTestSalt();
+      const salt = suiteSalt();
       await client.wallets.create({ salt });
 
       const list = await client.wallets.list();
@@ -165,8 +170,8 @@ describe("Wallet Management Tests", () => {
     });
 
     test("does not return duplicates for the same salt + factory", async () => {
-      const salt1 = nextTestSalt();
-      const salt2 = nextTestSalt();
+      const salt1 = suiteSalt();
+      const salt2 = suiteSalt();
 
       // Intentionally re-derive the same wallets to exercise
       // idempotency on the create endpoint.
@@ -189,7 +194,7 @@ describe("Wallet Management Tests", () => {
     });
 
     test("includes isHidden=false by default on listed wallets", async () => {
-      const salt = nextTestSalt();
+      const salt = suiteSalt();
       await client.wallets.create({ salt });
 
       const list = await client.wallets.list();
@@ -217,27 +222,39 @@ describe("Wallet Management Tests", () => {
       const otherChain = Chains.BaseMainnet;
       expect(otherChain).not.toEqual(TEST_AUTH_CHAIN_ID);
 
-      const salt = nextTestSalt();
-      const onOtherChain = await client.wallets.create({ salt, chainId: otherChain });
+      // Its own owner: the assertion below is that the aud chain has NEVER
+      // seen this salt, and the suite pool recycles "0"/"1"/"2" — one of
+      // which an earlier test has already created on the aud chain.
+      const { client: crossClient } = await getIsolatedClient();
+      // NOT "0": authenticating already derives the owner's default salt-"0"
+      // wallet on the aud chain, which would defeat the absence assertion
+      // below before this test creates anything.
+      const salt = "1";
+      const onOtherChain = await crossClient.wallets.create({ salt, chainId: otherChain });
       expect(onOtherChain.address).toBeTruthy();
 
-      const namedChain = await client.wallets.list({ chainId: otherChain });
+      const namedChain = await crossClient.wallets.list({ chainId: otherChain });
       expect(namedChain.data.some((w) => w.salt === salt)).toBe(true);
 
       // The same token, no chainId: the aud chain's listing, which has
       // never seen that salt.
-      const audChain = await client.wallets.list();
+      const audChain = await crossClient.wallets.list();
       expect(audChain.data.some((w) => w.salt === salt)).toBe(false);
     });
 
     test("returns wallets sorted by salt (lexicographic)", async () => {
-      // Create four salts whose lexicographic order differs from
-      // numeric order: "0" < "1" < "10" < "2".
-      for (const salt of ["10", "2", "0", "1"]) {
-        await client.wallets.create({ salt });
+      // Its own owner: these salts are not the suite pool's, and a fourth
+      // distinct wallet on one owner is a 429 against production's cap of 3.
+      const { client: lexClient } = await getIsolatedClient();
+
+      // Three salts whose lexicographic order differs from numeric order:
+      // "0" < "10" < "2". A fourth ("1") adds no signal and does not fit
+      // under the cap.
+      for (const salt of ["10", "2", "0"]) {
+        await lexClient.wallets.create({ salt });
       }
 
-      const list = await client.wallets.list();
+      const list = await lexClient.wallets.list();
       const salts = list.data.map((w) => w.salt ?? "");
       const sorted = [...salts].sort((a, b) => a.localeCompare(b));
       expect(salts).toEqual(sorted);
@@ -246,7 +263,7 @@ describe("Wallet Management Tests", () => {
 
   describe("wallets.update (v3 setWallet)", () => {
     test("toggles the isHidden flag through update", async () => {
-      const salt = nextTestSalt();
+      const salt = suiteSalt();
       const created = await createSmartWallet(client, { saltValue: salt });
       expect(created.isHidden ?? false).toBeFalsy();
 

--- a/tests/v4/executions/getExecutions.test.ts
+++ b/tests/v4/executions/getExecutions.test.ts
@@ -16,7 +16,7 @@ import {
   getIsolatedClient,
   getCurrentBlockNumber,
   createSmartWallet,
-  nextTestSalt,
+  suiteSalt,
   removeCreatedWorkflows,
 } from "../../utils/client";
 import { createFromTemplate } from "../../utils/templates";
@@ -63,7 +63,7 @@ describe("executions.list Tests", () => {
       return;
     }
     const total = 4;
-    const wallet = await createSmartWallet(client, { saltValue: nextTestSalt() });
+    const wallet = await createSmartWallet(client, { saltValue: suiteSalt() });
     const blockNumber = await getCurrentBlockNumber();
 
     // Each workflow fires once (maxExecution=1), producing 1 execution.
@@ -133,7 +133,7 @@ describe("executions.list Tests", () => {
       console.log("Skipping — CHAIN_ENDPOINT not set");
       return;
     }
-    const wallet = await createSmartWallet(client, { saltValue: nextTestSalt() });
+    const wallet = await createSmartWallet(client, { saltValue: suiteSalt() });
     const blockNumber = await getCurrentBlockNumber();
     const wfIds: string[] = [];
     for (let i = 0; i < 3; i++) {
@@ -150,7 +150,7 @@ describe("executions.list Tests", () => {
       console.log("Skipping — CHAIN_ENDPOINT not set");
       return;
     }
-    const wallet = await createSmartWallet(client, { saltValue: nextTestSalt() });
+    const wallet = await createSmartWallet(client, { saltValue: suiteSalt() });
     const blockNumber = await getCurrentBlockNumber();
     const wfIds: string[] = [];
     for (let i = 0; i < 4; i++) {

--- a/tests/v4/nodes/balanceNode.test.ts
+++ b/tests/v4/nodes/balanceNode.test.ts
@@ -12,6 +12,11 @@
  *   - Each entry: `{balance, balanceFormatted, decimals, name, symbol, tokenAddress}`
  *   - No double-wrap (filter/graphql have one, balance does not).
  *
+ * The queried address is the shared TEST_PRIVATE_KEY EOA, deliberately NOT
+ * the suite client's owner: under a tight wallet cap that owner is a random
+ * per-file EOA with an empty balance list, which makes every assertion here
+ * either fail or pass for the wrong reason.
+ *
  * Note: this node requires a working Moralis key on the aggregator;
  * a missing/invalid key surfaces as success=false with the Moralis
  * error text. The tests skip on Moralis errors so they don't fail
@@ -22,6 +27,7 @@ import { Client, Nodes, Triggers } from "@avaprotocol/sdk-js";
 
 import {
   getSuiteClient,
+  getEOAAddress,
   createSmartWallet,
   removeCreatedWorkflows,
   settingsFor,
@@ -44,7 +50,16 @@ describe("BalanceNode Tests", () => {
   const createdWorkflowIds: string[] = [];
 
   beforeAll(async () => {
-    ({ client, owner: eoaAddress } = await getSuiteClient());
+    ({ client } = await getSuiteClient());
+    // The balance node READS an address; it never acts as it, so the queried
+    // address is independent of who authenticated. Use the shared funded EOA.
+    //
+    // Taking the suite client's OWN owner is what broke this: under a tight
+    // cap getSuiteClient() hands back a freshly generated random EOA, which
+    // holds no tokens, so Moralis correctly returned an empty list. Only the
+    // one test asserting a non-empty list failed — the other six kept passing
+    // vacuously, asserting shape and filtering against nothing.
+    eoaAddress = getEOAAddress();
   });
 
   afterEach(async () => {

--- a/tests/v4/workflows/workflow.test.ts
+++ b/tests/v4/workflows/workflow.test.ts
@@ -16,7 +16,7 @@ import { Client } from "@avaprotocol/sdk-js";
 import {
   getIsolatedClient,
   createSmartWallet,
-  nextTestSalt,
+  suiteSalt,
   removeCreatedWorkflows,
 } from "../../utils/client";
 import { createFromTemplate } from "../../utils/templates";
@@ -82,7 +82,7 @@ describe("Workflow Management Tests", () => {
       const total = 4;
       const firstLimit = 1;
       // Fresh wallet for predictable counts.
-      const wallet = await createSmartWallet(client, { saltValue: nextTestSalt() });
+      const wallet = await createSmartWallet(client, { saltValue: suiteSalt() });
 
       for (let i = 0; i < total; i++) {
         const created = await client.workflows.create(createFromTemplate(wallet.address));
@@ -148,7 +148,7 @@ describe("Workflow Management Tests", () => {
     test("supports backward pagination via the before cursor", async () => {
       const total = 4;
       const pageSize = 2;
-      const wallet = await createSmartWallet(client, { saltValue: nextTestSalt() });
+      const wallet = await createSmartWallet(client, { saltValue: suiteSalt() });
 
       for (let i = 0; i < total; i++) {
         const created = await client.workflows.create(createFromTemplate(wallet.address));
@@ -185,7 +185,7 @@ describe("Workflow Management Tests", () => {
       // Per-process salt may already have workflows attached from
       // earlier tests' completed-but-not-cancellable runs (e.g., the
       // maxExecution=1 path). Assert on shape rather than emptiness.
-      const wallet = await createSmartWallet(client, { saltValue: nextTestSalt() });
+      const wallet = await createSmartWallet(client, { saltValue: suiteSalt() });
       const list = await client.workflows.list({ smartWalletAddress: [wallet.address] });
       expect(Array.isArray(list.data)).toBe(true);
       expect(list.pageInfo).toBeDefined();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "lib": ["ES2022", "DOM"],
     "types": ["jest", "node"]
   },
-  "include": ["tests", "examples", "config/**/*"],
+  "include": ["tests", "examples", "config/**/*", "scripts/**/*.ts"],
   "ts-node": {
     "esm": true
   }


### PR DESCRIPTION
- **chore: add fixture session-grant inspect/refresh scripts**

The MA v2 funded e2e runner's grant drifts out of usability and every UserOp
test then fails with an on-chain "expired or has an invalid time range" that
names no policy, so the state is not obvious from the test output.

  npx tsx scripts/inspect-fixture-grant.ts   # list grants: status/entity/validUntil
  npx tsx scripts/refresh-fixture-grant.ts   # revoke all, re-grant on a clean entity

Both need TEST_ENV=railway (or whatever env points at the target gateway).

refresh does more than re-grant, and that is the point: it revokes every
non-revoked grant first so NextSessionEntityID moves the fixture to an entity
ABOVE all stored records. Re-granting alone can land back on an entity the
account already has installed with an older time window, which is exactly the
state that made a grant stored as valid-to-2027 fail on chain against a
2026-08-13 hook. Moving entity is the reliable way out until the gateway
verifies that an install actually replaced the hook for a reused entity.


- **test: bound e2e salts to the production wallet cap**

Finishes step A.4 of the production-e2e change doc. The suites already used
isolated per-file EOAs, so nothing shared TEST_PRIVATE_KEY — they just kept
minting unique salts from nextTestSalt(), and the FOURTH distinct wallet on one
owner is a 429 against production's max_wallets_per_owner: 3. That was 8 of the
15 failures in the post-deploy run.

Adds suiteSalt(): cycles "0"/"1"/"2" under a tight cap, stays on nextTestSalt()
in CI where the cap is 2000 and cross-worker collision is the real risk.
wallet.test.ts, workflow.test.ts and getExecutions.test.ts now draw from it.
Recycling a salt is safe in the latter two because both already clear created
workflows in afterEach, so a reused wallet still starts each test clean.

Three tests cannot share that pool and now take their own getIsolatedClient():

  - "returns wallets sorted by salt (lexicographic)" needs salts outside the
    pool. Also drops the fourth salt: ["10","2","0"] already proves lexicographic
    beats numeric ordering, and ["10","2","0","1"] cannot fit under the cap.
  - "accepts an explicit salt and echoes it back" pins the literal "12345",
    which on the shared owner was a fourth wallet — the direct cause of two of
    the 429s.
  - "scopes the listing to chainId" asserts the aud chain has NEVER seen its
    salt. It also moves off "0": authenticating already derives the owner's
    default salt-"0" wallet on the aud chain, so that assertion could not hold
    no matter which client ran it.

Verified against production 4.17.1 (TEST_ENV=railway): the three suites go
28/28 with zero cap 429s, and the full run improves 15 failed / 350 passed ->
1 failed / 364 passed. The remaining failure is BalanceNode, which is
unrelated — the gateway answers 200 with an empty balance array.


- **test: query the funded EOA in balanceNode, not the suite's isolated owner**

The balance suite took its query address from getSuiteClient()'s owner. Under a
tight wallet cap that helper returns getIsolatedClient() — a freshly generated
random EOA — which holds no tokens, so Moralis correctly answered with an empty
list. Not a gateway, Moralis, or RPC fault: probing the same node against three
addresses on production 4.17.1 returned 0 entries for a fresh EOA, 7 for the
shared TEST_PRIVATE_KEY EOA, and 5 for the funded MA v2 wallet.

Only one test asserted a non-empty list, so only one failed. The other six were
passing VACUOUSLY — asserting list shape, zero-balance filtering, chain-alias
handling and template resolution against an empty array, which satisfies all of
them without exercising anything. That is the more damaging half of this bug and
it was invisible in the suite output.

The node reads an address; it never acts as it, so the queried address is
independent of who authenticated. Pointing it at getEOAAddress() restores the
behavior the file's own header already described ("the test EOA ... which is the
wallet the rest of the suite uses") and matches CI, where the shared client's
owner was that address anyway.

All six now pass with real data. Full suite against production is 47 suites /
365 tests, zero failures.