### PR TITLE
feat: UserOp inner calls, JWT retrieve, fixture teardown

### DIFF
--- a/.changeset/userop-typed-unpack.md
+++ b/.changeset/userop-typed-unpack.md
@@ -1,0 +1,8 @@
+---
+"@avaprotocol/sdk-js": minor
+"@avaprotocol/types": minor
+---
+
+Typed UserOp inner calls on execute receipts and a JWT-gated status GET (N14.a / EigenLayer-AVS #774).
+
+`readContractWriteExecutions` now copies `receipt.calls[]` and `receipt.failedCall`. `client.userops.retrieve(userOpHash, { chainId })` re-polls a pending UserOp. OpenAPI types regenerated from AVS staging.

--- a/docs/on-demand-actions.md
+++ b/docs/on-demand-actions.md
@@ -16,7 +16,9 @@ one-time action such as a Uniswap market order.
   build the swap and quote nodes and compute the slippage floor.
 - `readContractWriteExecutions(resp)` — read the normalized per-method outcome
   (`confirmed` / `pending` / `failed`) plus `userOpHash` / `transactionHash`
-  from a `contractWrite` response.
+  and inner `calls[]` / `failedCall` from a `contractWrite` response.
+- `client.userops.retrieve(userOpHash, { chainId })` — re-poll a pending UserOp
+  (JWT-gated; not a public explorer).
 
 ## Market order: quote → preview → execute
 
@@ -69,6 +71,11 @@ const executed = await client.nodes.run(
 for (const r of readContractWriteExecutions(executed)) {
   // r.executionStatus: "confirmed" | "pending" | "failed"
   // r.userOpHash (always for a real execute), r.transactionHash (once mined)
+  // r.calls: [{ to, value, selector, data }] when the gateway is on N14.a
+  if (r.executionStatus === "pending" && r.userOpHash) {
+    const status = await client.userops.retrieve(r.userOpHash, { chainId });
+    // status.executionStatus, status.calls, status.failedCall
+  }
 }
 ```
 
@@ -81,8 +88,9 @@ for (const r of readContractWriteExecutions(executed)) {
 - **Pool / fee tier is the caller's choice.** Pass the `fee` tier for the pool you
   intend to trade; the builders don't discover pools.
 - **Pending ≠ failed.** A submitted-but-unmined UserOp reports `pending` with a
-  `userOpHash` (and no `transactionHash` yet) — poll it rather than treating it as
-  a failure.
+  `userOpHash` (and no `transactionHash` yet) — poll `client.userops.retrieve`
+  rather than treating it as a failure.
 - Reading `executionStatus` / receipts requires a gateway that surfaces
   contractWrite metadata under `metadata.results` (AVS PR #660+); older gateways
-  return an empty list from `readContractWriteExecutions`.
+  return an empty list from `readContractWriteExecutions`. Inner `calls`
+  require a gateway on N14.a (EigenLayer-AVS #774).

--- a/packages/sdk-js/src/v4/client.ts
+++ b/packages/sdk-js/src/v4/client.ts
@@ -8,6 +8,7 @@ import { SecretsResource } from "./resources/secrets";
 import { TokensResource } from "./resources/tokens";
 import { TriggersResource } from "./resources/triggers";
 import { PoliciesResource } from "./resources/policies";
+import { UserOpsResource } from "./resources/userops";
 import { WalletsResource } from "./resources/wallets";
 import { WorkflowsResource } from "./resources/workflows";
 
@@ -36,8 +37,9 @@ export interface ClientOptions {
    * - token metadata (`tokens.retrieve`) — partner `scope: read` required
    * - preview wallet list/create — partner `read` + EOA `sub`, **or** user JWT
    *
-   * Simulate / runNode / runTrigger and fund-moving calls require a user
-   * Bearer JWT from `auth.exchange()`; partner alone is not enough.
+   * Simulate / runNode / runTrigger / userops.retrieve and fund-moving
+   * calls require a user Bearer JWT from `auth.exchange()`; partner
+   * alone is not enough.
    */
   headers?: Record<string, string>;
 }
@@ -65,6 +67,7 @@ export class Client {
   readonly secrets: SecretsResource;
   readonly tokens: TokensResource;
   readonly triggers: TriggersResource;
+  readonly userops: UserOpsResource;
   readonly wallets: WalletsResource;
   readonly workflows: WorkflowsResource;
 
@@ -89,6 +92,7 @@ export class Client {
     this.secrets = new SecretsResource(this.transport);
     this.tokens = new TokensResource(this.transport);
     this.triggers = new TriggersResource(this.transport);
+    this.userops = new UserOpsResource(this.transport);
     this.wallets = new WalletsResource(this.transport);
     this.workflows = new WorkflowsResource(this.transport);
   }

--- a/packages/sdk-js/src/v4/index.ts
+++ b/packages/sdk-js/src/v4/index.ts
@@ -61,9 +61,11 @@ export { NodesResource, type RunNodeOptions } from "./resources/nodes";
 export {
   readContractWriteExecutions,
   type ContractWriteExecutionStatus,
+  type ContractWriteInnerCall,
   type ContractWriteMethodExecution,
 } from "./results/contractWrite";
 export { OperatorsResource } from "./resources/operators";
+export { UserOpsResource } from "./resources/userops";
 export { SecretsResource } from "./resources/secrets";
 export { TokensResource } from "./resources/tokens";
 export { TriggersResource } from "./resources/triggers";

--- a/packages/sdk-js/src/v4/resources/userops.ts
+++ b/packages/sdk-js/src/v4/resources/userops.ts
@@ -1,0 +1,37 @@
+import type { v4 } from "@avaprotocol/types";
+
+import { Transport } from "../internal/transport";
+
+/**
+ * `client.userops.*` — status lookup for UserOps **this user submitted**.
+ * Inverse of the `nodes.run` send path (N14.a). Not a public AA explorer:
+ * the gateway 404s unknown hashes and hashes whose sender is not one of
+ * the caller's smart wallets.
+ *
+ * **Auth:** user Bearer JWT only (same gate as `nodes.run`). Partner
+ * assertion alone is not enough.
+ */
+export class UserOpsResource {
+  constructor(private readonly transport: Transport) {}
+
+  /**
+   * GET /userops/{userOpHash} — re-poll a pending or mined UserOp.
+   *
+   * Pending is not failed. Inner `calls` are unpacked from the submitted
+   * execute / executeBatch calldata (including `executeUserOp`-wrapped
+   * grant UserOps). `failedCall` is present only on an observed inner
+   * revert of a single call.
+   *
+   * Pass `opts.chainId` to pin the bundler chain (JWT `aud` then gateway
+   * default otherwise). An unsupported chain is 400.
+   */
+  retrieve(
+    userOpHash: string,
+    opts?: { chainId?: number },
+  ): Promise<v4.UserOpStatusResponse> {
+    return this.transport.request<v4.UserOpStatusResponse>({
+      path: `/userops/${encodeURIComponent(userOpHash)}`,
+      query: opts,
+    });
+  }
+}

--- a/packages/sdk-js/src/v4/results/contractWrite.ts
+++ b/packages/sdk-js/src/v4/results/contractWrite.ts
@@ -21,6 +21,14 @@ import type { v4 } from "@avaprotocol/types";
  */
 export type ContractWriteExecutionStatus = "confirmed" | "pending" | "failed";
 
+/** One inner execute / executeBatch entry unpacked by the gateway (N14.a). */
+export interface ContractWriteInnerCall {
+  to: string;
+  value: string;
+  selector: string;
+  data: string;
+}
+
 export interface ContractWriteMethodExecution {
   /** ABI method name (e.g. "exactInputSingle", "approve"). */
   methodName: string;
@@ -34,6 +42,18 @@ export interface ContractWriteMethodExecution {
   userOpHash?: string;
   /** On-chain transaction hash — present once mined (absent while pending). */
   transactionHash?: string;
+  /**
+   * Inner `execute` / `executeBatch` calls unpacked from the UserOp we
+   * submitted. Same full array on every method of an atomic batch.
+   * Absent on gateways that predate N14.a.
+   */
+  calls?: ContractWriteInnerCall[];
+  /**
+   * Set only when a UserOperationEvent shows this UserOp's inner call
+   * reverted and there is a single inner call. Not set on AA23 / bundler
+   * reject or an outer tx failure.
+   */
+  failedCall?: ContractWriteInnerCall;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -42,6 +62,30 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+}
+
+function asInnerCall(value: unknown): ContractWriteInnerCall | undefined {
+  const rec = asRecord(value);
+  if (
+    typeof rec.to !== "string" ||
+    !rec.to ||
+    typeof rec.selector !== "string" ||
+    !rec.selector
+  ) {
+    return undefined;
+  }
+  return {
+    to: rec.to,
+    value: typeof rec.value === "string" ? rec.value : "0",
+    selector: rec.selector,
+    data: typeof rec.data === "string" ? rec.data : "0x",
+  };
+}
+
+function asInnerCalls(value: unknown): ContractWriteInnerCall[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const calls = value.map(asInnerCall).filter((c): c is ContractWriteInnerCall => !!c);
+  return calls.length > 0 ? calls : undefined;
 }
 
 /**
@@ -88,6 +132,10 @@ export function readContractWriteExecutions(
     ) {
       out.transactionHash = receipt.transactionHash;
     }
+    const calls = asInnerCalls(receipt.calls);
+    if (calls) out.calls = calls;
+    const failedCall = asInnerCall(receipt.failedCall);
+    if (failedCall) out.failedCall = failedCall;
     executions.push(out);
   }
   return executions;

--- a/packages/types/openapi/openapi.yaml
+++ b/packages/types/openapi/openapi.yaml
@@ -56,6 +56,8 @@ tags:
     description: ERC-20 metadata lookup
   - name: Nodes
     description: Stand-alone node execution
+  - name: UserOps
+    description: Status lookup for UserOps this user submitted (not a public AA explorer)
   - name: Triggers
     description: Stand-alone trigger evaluation
   - name: Operators
@@ -146,6 +148,58 @@ components:
       type: string
       pattern: '^0x[a-fA-F0-9]*$'
       description: Arbitrary-length hex-encoded byte string.
+
+    Bytes32:
+      type: string
+      pattern: '^0x[a-fA-F0-9]{64}$'
+      description: 32-byte hex hash (UserOp hash, transaction hash).
+      example: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+    UserOpInnerCall:
+      type: object
+      required: [to, value, selector, data]
+      properties:
+        to:
+          $ref: '#/components/schemas/EthereumAddress'
+        value:
+          type: string
+          description: Native value in wei (decimal string).
+        selector:
+          type: string
+          pattern: '^0x[a-fA-F0-9]{8}$'
+          description: 4-byte function selector of `data` (`0x00000000` for a value-only call).
+        data:
+          $ref: '#/components/schemas/Hex'
+
+    UserOpStatusResponse:
+      type: object
+      required: [userOpHash, executionStatus]
+      properties:
+        userOpHash:
+          $ref: '#/components/schemas/Bytes32'
+        sender:
+          $ref: '#/components/schemas/EthereumAddress'
+        executionStatus:
+          type: string
+          enum: [pending, confirmed, failed]
+          description: |
+            `pending` means the bundler accepted the op and it is not yet
+            mined. It is not a failure.
+        transactionHash:
+          $ref: '#/components/schemas/Hex'
+        blockNumber:
+          type: string
+          description: Block number as a hex string when mined.
+        success:
+          type: boolean
+          description: Inner UserOp success from the bundler receipt. Absent while pending.
+        calls:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserOpInnerCall'
+        failedCall:
+          $ref: '#/components/schemas/UserOpInnerCall'
+          description: Present when the inner call reverted and there is a single inner call.
 
     Ulid:
       type: string
@@ -2909,6 +2963,40 @@ paths:
               schema: { $ref: '#/components/schemas/RunNodeResponse' }
         '400': { $ref: '#/components/responses/BadRequest' }
         '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /userops/{userOpHash}:
+    get:
+      tags: [UserOps]
+      summary: Look up a UserOp this user submitted
+      description: |
+        Re-poll a UserOp by hash (G3 / N14.a). Same gate as `nodes:run`
+        (user Bearer JWT; partner assertion alone is not sufficient). The
+        sender must be one of the caller's smart wallets — this is **not**
+        a public AA explorer. Unknown hashes and hashes that belong to
+        another user both return 404.
+
+        Inner `calls` are unpacked from the UserOp `callData` via the
+        gateway's existing `UnpackExecuteCalldata` (execute / executeBatch
+        / MA v2). Pending is not failed.
+      operationId: getUserOp
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userOpHash
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Bytes32'
+        - $ref: '#/components/parameters/ChainIdQuery'
+      responses:
+        '200':
+          description: Typed UserOp status and inner calls.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/UserOpStatusResponse' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
 
   /triggers:run:
     post:

--- a/packages/types/src/openapi.gen.ts
+++ b/packages/types/src/openapi.gen.ts
@@ -760,6 +760,34 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/userops/{userOpHash}": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Look up a UserOp this user submitted
+         * @description Re-poll a UserOp by hash (G3 / N14.a). Same gate as `nodes:run`
+         *     (user Bearer JWT; partner assertion alone is not sufficient). The
+         *     sender must be one of the caller's smart wallets — this is **not**
+         *     a public AA explorer. Unknown hashes and hashes that belong to
+         *     another user both return 404.
+         *
+         *     Inner `calls` are unpacked from the UserOp `callData` via the
+         *     gateway's existing `UnpackExecuteCalldata` (execute / executeBatch
+         *     / MA v2). Pending is not failed.
+         */
+        readonly get: operations["getUserOp"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/triggers:run": {
         readonly parameters: {
             readonly query?: never;
@@ -822,6 +850,37 @@ export interface components {
         readonly EthereumAddress: string;
         /** @description Arbitrary-length hex-encoded byte string. */
         readonly Hex: string;
+        /**
+         * @description 32-byte hex hash (UserOp hash, transaction hash).
+         * @example 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         */
+        readonly Bytes32: string;
+        readonly UserOpInnerCall: {
+            readonly to: components["schemas"]["EthereumAddress"];
+            /** @description Native value in wei (decimal string). */
+            readonly value: string;
+            /** @description 4-byte function selector of `data` (`0x00000000` for a value-only call). */
+            readonly selector: string;
+            readonly data: components["schemas"]["Hex"];
+        };
+        readonly UserOpStatusResponse: {
+            readonly userOpHash: components["schemas"]["Bytes32"];
+            readonly sender?: components["schemas"]["EthereumAddress"];
+            /**
+             * @description `pending` means the bundler accepted the op and it is not yet
+             *     mined. It is not a failure.
+             * @enum {string}
+             */
+            readonly executionStatus: "pending" | "confirmed" | "failed";
+            readonly transactionHash?: components["schemas"]["Hex"];
+            /** @description Block number as a hex string when mined. */
+            readonly blockNumber?: string;
+            /** @description Inner UserOp success from the bundler receipt. Absent while pending. */
+            readonly success?: boolean;
+            readonly calls?: readonly components["schemas"]["UserOpInnerCall"][];
+            /** @description Present when the inner call reverted and there is a single inner call. */
+            readonly failedCall?: components["schemas"]["UserOpInnerCall"];
+        };
         /**
          * @description ULID identifier (26-char Crockford base32).
          * @example 01JG2FE5MDVKBPHEG0PEYSDKAC
@@ -3140,6 +3199,37 @@ export interface operations {
             };
             readonly 400: components["responses"]["BadRequest"];
             readonly 401: components["responses"]["Unauthorized"];
+        };
+    };
+    readonly getUserOp: {
+        readonly parameters: {
+            readonly query?: {
+                /**
+                 * @description The chain to operate on (a single value). Omit to use the aggregator
+                 *     default (the request's JWT `aud` chain, then the gateway default).
+                 */
+                readonly chainId?: components["parameters"]["ChainIdQuery"];
+            };
+            readonly header?: never;
+            readonly path: {
+                readonly userOpHash: components["schemas"]["Bytes32"];
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Typed UserOp status and inner calls. */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["UserOpStatusResponse"];
+                };
+            };
+            readonly 400: components["responses"]["BadRequest"];
+            readonly 401: components["responses"]["Unauthorized"];
+            readonly 404: components["responses"]["NotFound"];
         };
     };
     readonly runTrigger: {

--- a/packages/types/src/v4.ts
+++ b/packages/types/src/v4.ts
@@ -134,6 +134,10 @@ export type AuthExchangeResponse = components["schemas"]["AuthExchangeResponse"]
 
 export type RunNodeRequest = components["schemas"]["RunNodeRequest"];
 export type RunNodeResponse = components["schemas"]["RunNodeResponse"];
+
+export type Bytes32 = components["schemas"]["Bytes32"];
+export type UserOpInnerCall = components["schemas"]["UserOpInnerCall"];
+export type UserOpStatusResponse = components["schemas"]["UserOpStatusResponse"];
 export type RunTriggerRequest = components["schemas"]["RunTriggerRequest"];
 export type RunTriggerResponse = components["schemas"]["RunTriggerResponse"];
 

--- a/scripts/heal-fixture-entities.ts
+++ b/scripts/heal-fixture-entities.ts
@@ -35,6 +35,7 @@
  *
  * Set SEPOLIA_RPC to a working endpoint; CHAIN_ENDPOINT in .env may be stale.
  */
+import type { v4 } from "@avaprotocol/types";
 import { JsonRpcProvider, Wallet as EthersWallet } from "ethers";
 
 import { getFundedClient, getFundedWallet } from "../tests/utils/client";
@@ -50,11 +51,8 @@ const SIGNERS_SELECTOR = "0x217178fb"; // keccak("signers(uint32,address)")[:4]
 // aa.SingleSignerValidationModuleAddressHex in EigenLayer-AVS.
 const SINGLE_SIGNER_MODULE = "0x00000000000099DE0BF6fA90dEB851E2A2df7d83";
 
-interface CleanupPayload {
-  readonly entityId?: number;
-  readonly target?: string;
-  readonly callData?: string;
-  readonly chainId?: number;
+function validEntityId(entityId: unknown): entityId is number {
+  return typeof entityId === "number" && Number.isInteger(entityId) && entityId >= 1;
 }
 
 async function entityInstalled(
@@ -88,10 +86,14 @@ async function main(): Promise<void> {
   console.log(CONFIRM ? "mode:   APPLY (sends transactions)\n" : "mode:   dry-run (pass --confirm to send)\n");
 
   const listed = await client.policies.list(wallet.address, { chainId: CHAIN_ID });
-  const pending: Array<{ id: string; cleanup: CleanupPayload }> = [];
+  const pending: Array<{ id: string; cleanup: v4.OnChainRevokeCleanup }> = [];
   for (const policy of listed.items) {
-    const cleanup = (policy as { onChainCleanup?: CleanupPayload }).onChainCleanup;
+    const cleanup = policy.onChainCleanup;
     if (!cleanup?.callData || !cleanup.target) continue;
+    if (!validEntityId(cleanup.entityId)) {
+      console.log(`  skip ${policy.id}: cleanup payload missing a valid entityId`);
+      continue;
+    }
     pending.push({ id: policy.id, cleanup });
   }
 
@@ -101,7 +103,7 @@ async function main(): Promise<void> {
   }
 
   for (const { id, cleanup } of pending) {
-    const entity = cleanup.entityId ?? -1;
+    const entity = cleanup.entityId;
     // Storage's belief that cleanup is required can outlive the actual
     // teardown (the gateway only learns on the next prepare), so trust the
     // chain, not the flag.

--- a/scripts/heal-fixture-entities.ts
+++ b/scripts/heal-fixture-entities.ts
@@ -1,0 +1,140 @@
+/**
+ * Clear leftover validation entities off a runner so new grants can install.
+ *
+ * Revoking a grant is a storage change only. An applied grant's validation
+ * stays installed on the account until the OWNER sends uninstallValidation —
+ * the gateway controller cannot self-uninstall a policied grant. Leftovers are
+ * not merely untidy: the next grant's deferred install is an install/replace
+ * BATCH that tries to tear the old entities down, and when that teardown
+ * reverts the whole batch reverts. The gateway reports it exactly:
+ *
+ *   SESSION_GRANT_INSTALL_FAILED: deferred grant install/replace did not land
+ *   (new entity not installed; prior entities not torn down): ... AA23 reverted
+ *
+ * At that point every new grant on the runner fails, and the only way out is
+ * for the owner to clear the leftovers. That is what this does.
+ *
+ * KNOWN BLOCKER (2026-08-22): on a runner whose entity was only PARTIALLY
+ * installed, the payload the gateway hands back is itself malformed and the
+ * send reverts with ArrayLengthMismatch() (0xa24a13a6) at gas estimation.
+ * BuildOnChainRevokeCleanup derives hookUninstallData from the STORED grant, so
+ * it lists one entry per hook the grant believes it installed. The Sepolia
+ * fixture's entity 3 has the signer and allowlist hooks on chain but no
+ * TimeRange hook, so storage says three and the account has two.
+ *
+ * That is self-perpetuating: teardown can never succeed, and because every
+ * later grant's install/replace batch includes that teardown, the whole batch
+ * reverts and no new grant can install on the runner either. Until the payload
+ * is reconciled against chain state, this script can identify the leftovers but
+ * not clear them.
+ *
+ * SENDS ON-CHAIN TRANSACTIONS from the owner EOA. Dry-run by default.
+ *
+ *   TEST_ENV=railway npx tsx scripts/heal-fixture-entities.ts
+ *   TEST_ENV=railway npx tsx scripts/heal-fixture-entities.ts --confirm
+ *
+ * Set SEPOLIA_RPC to a working endpoint; CHAIN_ENDPOINT in .env may be stale.
+ */
+import { JsonRpcProvider, Wallet as EthersWallet } from "ethers";
+
+import { getFundedClient, getFundedWallet } from "../tests/utils/client";
+
+const CHAIN_ID = Number(process.env.CHAIN_ID || 11155111);
+const RPC = process.env.SEPOLIA_RPC || "https://ethereum-sepolia-rpc.publicnode.com";
+const CONFIRM = process.argv.includes("--confirm");
+
+// SingleSignerValidationModule.signers(uint32,address) — non-zero means the
+// entity is still installed. The uninstall is NOT idempotent (re-sending after
+// it is clear reverts), so this is the gate before every send.
+const SIGNERS_SELECTOR = "0x217178fb"; // keccak("signers(uint32,address)")[:4]
+// aa.SingleSignerValidationModuleAddressHex in EigenLayer-AVS.
+const SINGLE_SIGNER_MODULE = "0x00000000000099DE0BF6fA90dEB851E2A2df7d83";
+
+interface CleanupPayload {
+  readonly entityId?: number;
+  readonly target?: string;
+  readonly callData?: string;
+  readonly chainId?: number;
+}
+
+async function entityInstalled(
+  provider: JsonRpcProvider,
+  moduleAddr: string,
+  account: string,
+  entity: number,
+): Promise<boolean> {
+  const data =
+    SIGNERS_SELECTOR +
+    entity.toString(16).padStart(64, "0") +
+    account.toLowerCase().replace(/^0x/, "").padStart(64, "0");
+  const out = await provider.call({ to: moduleAddr, data });
+  return out !== "0x" && BigInt(out) !== 0n;
+}
+
+async function main(): Promise<void> {
+  const { client, owner, privateKey } = await getFundedClient();
+  const wallet = await getFundedWallet(client);
+  if (!wallet) throw new Error("no funded wallet resolved");
+
+  const provider = new JsonRpcProvider(RPC);
+  const signer = new EthersWallet(privateKey, provider);
+  if (signer.address.toLowerCase() !== owner.toLowerCase()) {
+    throw new Error(`key is ${signer.address}, expected owner ${owner}`);
+  }
+
+  console.log(`owner:  ${owner}`);
+  console.log(`runner: ${wallet.address}`);
+  console.log(`rpc:    ${RPC}`);
+  console.log(CONFIRM ? "mode:   APPLY (sends transactions)\n" : "mode:   dry-run (pass --confirm to send)\n");
+
+  const listed = await client.policies.list(wallet.address, { chainId: CHAIN_ID });
+  const pending: Array<{ id: string; cleanup: CleanupPayload }> = [];
+  for (const policy of listed.items) {
+    const cleanup = (policy as { onChainCleanup?: CleanupPayload }).onChainCleanup;
+    if (!cleanup?.callData || !cleanup.target) continue;
+    pending.push({ id: policy.id, cleanup });
+  }
+
+  if (pending.length === 0) {
+    console.log("no policies report an on-chain cleanup payload; nothing to clear");
+    return;
+  }
+
+  for (const { id, cleanup } of pending) {
+    const entity = cleanup.entityId ?? -1;
+    // Storage's belief that cleanup is required can outlive the actual
+    // teardown (the gateway only learns on the next prepare), so trust the
+    // chain, not the flag.
+    const installed = await entityInstalled(provider, SINGLE_SIGNER_MODULE, wallet.address, entity);
+    if (!installed) {
+      console.log(`  entity ${entity} (${id}): already clear on chain — skipping`);
+      continue;
+    }
+    if (!CONFIRM) {
+      console.log(`  entity ${entity} (${id}): WOULD send uninstallValidation to ${cleanup.target}`);
+      continue;
+    }
+    console.log(`  entity ${entity} (${id}): sending uninstallValidation...`);
+    const tx = await signer.sendTransaction({ to: cleanup.target, data: cleanup.callData });
+    const receipt = await tx.wait();
+    const ok = receipt?.status === 1;
+    console.log(`    tx ${tx.hash} status=${ok ? "success" : "REVERTED"}`);
+    if (!ok) {
+      console.error("    stopping: a reverted teardown means the rest is guesswork");
+      process.exitCode = 1;
+      return;
+    }
+    const stillThere = await entityInstalled(provider, SINGLE_SIGNER_MODULE, wallet.address, entity);
+    console.log(`    entity ${entity} installed after: ${stillThere}`);
+  }
+
+  if (CONFIRM) {
+    console.log("\nleftovers cleared. Re-grant with scripts/refresh-fixture-grant.ts,");
+    console.log("then confirm the new entity has a NON-ZERO timeRanges window, not just a signer.");
+  }
+}
+
+main().catch((err) => {
+  console.error("failed:", err);
+  process.exit(1);
+});

--- a/tests/v4/core/wallet.test.ts
+++ b/tests/v4/core/wallet.test.ts
@@ -33,6 +33,12 @@ import {
   removeCreatedWorkflows,
   TEST_AUTH_CHAIN_ID,
 } from "../../utils/client";
+
+// Every other network-touching suite raises this; wallet.test.ts was left on
+// Jest's 5s default. Three tests here now stand up their own isolated client
+// (a full SIWE round-trip) before doing any wallet work, which does not fit in
+// 5s whenever the gateway is cold — e.g. right after a redeploy.
+jest.setTimeout(60_000);
 import { createFromTemplate } from "../../utils/templates";
 
 // The multi-chain stack (Railway, or an explicitly multi-chain local run).

--- a/tests/v4/core/wallet.test.ts
+++ b/tests/v4/core/wallet.test.ts
@@ -33,13 +33,13 @@ import {
   removeCreatedWorkflows,
   TEST_AUTH_CHAIN_ID,
 } from "../../utils/client";
+import { createFromTemplate } from "../../utils/templates";
 
 // Every other network-touching suite raises this; wallet.test.ts was left on
 // Jest's 5s default. Three tests here now stand up their own isolated client
 // (a full SIWE round-trip) before doing any wallet work, which does not fit in
 // 5s whenever the gateway is cold — e.g. right after a redeploy.
 jest.setTimeout(60_000);
-import { createFromTemplate } from "../../utils/templates";
 
 // The multi-chain stack (Railway, or an explicitly multi-chain local run).
 // Matches the flags expansion-chains-e2e.test.ts already uses.

--- a/tests/v4/onchain-helpers.test.ts
+++ b/tests/v4/onchain-helpers.test.ts
@@ -268,6 +268,50 @@ describe("readContractWriteExecutions", () => {
     expect(out[0].success).toBe(false);
   });
 
+  test("copies inner calls and failedCall from the receipt", () => {
+    const call = {
+      to: "0xToken",
+      value: "0",
+      selector: "0xa9059cbb",
+      data: "0xa9059cbb",
+    };
+    const out = readContractWriteExecutions(
+      resp({
+        results: [
+          {
+            methodName: "transfer",
+            success: false,
+            receipt: {
+              executionStatus: "failed",
+              userOpHash: "0xuo",
+              transactionHash: "0xtx",
+              calls: [call, { selector: "0x" }, null],
+              failedCall: call,
+            },
+          },
+        ],
+      }),
+    );
+    expect(out[0].calls).toEqual([call]);
+    expect(out[0].failedCall).toEqual(call);
+  });
+
+  test("omits calls when the receipt has none", () => {
+    const out = readContractWriteExecutions(
+      resp({
+        results: [
+          {
+            methodName: "approve",
+            success: true,
+            receipt: { executionStatus: "confirmed", userOpHash: "0xuo", transactionHash: "0xtx" },
+          },
+        ],
+      }),
+    );
+    expect(out[0].calls).toBeUndefined();
+    expect(out[0].failedCall).toBeUndefined();
+  });
+
   test("returns [] when the response has no results array", () => {
     expect(readContractWriteExecutions(resp(undefined))).toEqual([]);
     expect(readContractWriteExecutions(resp({}))).toEqual([]);

--- a/tests/v4/smoke.test.ts
+++ b/tests/v4/smoke.test.ts
@@ -31,6 +31,7 @@ describe("v4 SDK smoke", () => {
       expect(client.nodes).toBeDefined();
       expect(client.triggers).toBeDefined();
       expect(client.operators).toBeDefined();
+      expect(client.userops).toBeDefined();
     });
 
     test("baseUrl trailing slash is normalized", () => {
@@ -255,6 +256,46 @@ describe("v4 SDK smoke", () => {
         }
       ).config;
       expect(config.queries[0].topics).toEqual([transferTopic, ""]);
+    });
+  });
+
+  describe("userops.retrieve", () => {
+    test("GETs /userops/{hash}?chainId=... with the JWT", async () => {
+      let captured: { url: string; method?: string; auth?: string } | undefined;
+      const fakeFetch: typeof fetch = async (input, init) => {
+        const headers = new Headers(init?.headers);
+        captured = {
+          url: String(input),
+          method: init?.method,
+          auth: headers.get("Authorization") ?? undefined,
+        };
+        return new Response(
+          JSON.stringify({
+            userOpHash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            executionStatus: "pending",
+            calls: [{ to: "0xToken", value: "0", selector: "0xa9059cbb", data: "0xa9059cbb" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      };
+      const client = new Client({
+        baseUrl: "http://example.test/api/v1",
+        token: "jwt-token",
+        fetchImpl: fakeFetch,
+      });
+      const got = await client.userops.retrieve(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        { chainId: 8453 },
+      );
+      expect(captured?.method).toBe("GET");
+      expect(captured?.auth).toBe("Bearer jwt-token");
+      const url = new URL(captured!.url);
+      expect(url.pathname).toBe(
+        "/api/v1/userops/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      );
+      expect(url.searchParams.get("chainId")).toBe("8453");
+      expect(got.executionStatus).toBe("pending");
+      expect(got.calls?.[0]?.selector).toBe("0xa9059cbb");
     });
   });
 


### PR DESCRIPTION
- **test: raise the jest timeout in wallet.test.ts**

It was the only network-touching suite still on Jest's 5s default; every other
one sets 60s or more. Two different tests timed out on consecutive production
runs right after the 4.17.2 redeploy — different tests each time, which is the
signature of a budget that is too tight rather than a logic fault.

Partly self-inflicted: d2a1275 moved three tests onto their own
getIsolatedClient(), so each now does a full SIWE authentication before any
wallet call. That does not fit in 5s against a cold gateway.

Verified 12/12 against production 4.17.2.


- **chore: add fixture entity-teardown tool, and record why it cannot finish**

Diagnosing why the Sepolia fixture stopped accepting new grants turned up a
chain of three linked failures. This tool is the operator half; it currently
identifies the problem but cannot clear it, and the reason is worth recording.

What the gateway actually reported (from Railway logs — it was never visible in
the API response, see the withdraw message fix):

  SESSION_GRANT_INSTALL_FAILED: deferred grant install/replace did not land
  (new entity not installed; prior entities not torn down): ... AA23 reverted

A grant's deferred install is an install/replace BATCH: tear down the prior
entities, install the new one. Revoking only changes storage — an applied
grant stays installed until the OWNER sends uninstallValidation, because a
policied grant cannot self-uninstall. So leftovers accumulate, and the next
grant's batch has to clear them.

Sending that uninstall by hand reverts at estimation with 0xa24a13a6 =
ArrayLengthMismatch(). BuildOnChainRevokeCleanup builds hookUninstallData from
the STORED grant, one entry per hook it believes was installed. The fixture's
entity 3 has its signer and allowlist hooks on chain but NO TimeRange hook, so
storage says three and the account has two.

That closes a loop with no exit: the partial install makes teardown impossible,
impossible teardown makes every later install/replace revert, and the runner
accepts no further grants. Entity 4 is stuck pending for exactly this reason.

The fix is gateway-side — derive or reconcile the cleanup payload against chain
state instead of storage belief — so this script stops at reporting. Dry-run
lists the leftovers; --confirm attempts the sends and halts on the first revert
rather than guessing at the rest.


- **feat: typed UserOp inner calls and JWT status GET**

Adopt EigenLayer-AVS N14.a (#774). readContractWriteExecutions now
copies receipt.calls[] and failedCall so Auto execute cards can show
what the UserOp actually called.

client.userops.retrieve(userOpHash, { chainId }) re-polls a pending
UserOp behind the same user JWT as nodes.run. OpenAPI types
regenerated from AVS staging.