### PR TITLE
fix: set repository.url so 4.14.0 can publish

### DIFF
--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -24,6 +24,11 @@
   },
   "author": "Vinh Nguyen (https://github.com/v9n), Chris Li (https://github.com/chrisli30)",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AvaProtocol/ava-sdk-js.git",
+    "directory": "packages/sdk-js"
+  },
   "engines": {
     "node": ">=20.18.0",
     "yarn": ">=1.22.19"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,6 +17,11 @@
   },
   "author": "Vinh Nguyen (https://github.com/v9n), Chris Li (https://github.com/chrisli30)",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AvaProtocol/ava-sdk-js.git",
+    "directory": "packages/types"
+  },
   "engines": {
     "node": ">=20.18.0",
     "yarn": ">=1.22.19"


### PR DESCRIPTION
## Summary

`@avaprotocol/sdk-js@4.14.0` did not land on npm. Release run https://github.com/AvaProtocol/ava-sdk-js/actions/runs/33732216545 authenticated via OIDC and signed provenance, then npm returned 422:

package.json `repository.url` was empty; provenance expected `https://github.com/AvaProtocol/ava-sdk-js`.

Adds `repository` on `sdk-js` and `types` (same shape as `@avaprotocol/protocols`). No changeset — 4.14.0 is already cut and unpublished; merging this re-runs Release and publishes that version.

## Test plan

- [ ] Merge to `main` → Release workflow publishes `@avaprotocol/sdk-js@4.14.0`
- [ ] `npm view @avaprotocol/sdk-js version` is `4.14.0`
