### PR TITLE
test: give each CI suite a static funded MA v2 salt

### DIFF
--- a/.github/workflows/dev-test-on-pr.yml
+++ b/.github/workflows/dev-test-on-pr.yml
@@ -68,7 +68,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [core, workflows, executions, triggers, nodes, templates]
+        include:
+          # Static MA v2 salt per shard so parallel UserOps do not share
+          # an EntryPoint nonce (#263). Must stay inside 0/1/2.
+          - suite: core
+            funded_salt: "0"
+          - suite: workflows
+            funded_salt: "0"
+          - suite: executions
+            funded_salt: "1"
+          - suite: triggers
+            funded_salt: "0"
+          - suite: nodes
+            funded_salt: "2"
+          - suite: templates
+            funded_salt: "0"
 
     env:
       # The gateway/worker run in containers, so a stub server bound on the
@@ -76,6 +90,8 @@ jobs:
       # docker-compose maps this name to the host (extra_hosts + host-gateway);
       # tests/utils/stubServer.ts builds its base URL from it.
       TEST_STUB_HOST: host.docker.internal
+      # Wins over Jest testPath inference in fundedWalletSalt().
+      FUNDED_WALLET_SALT: ${{ matrix.funded_salt }}
       # Secrets
       TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
       ECDSA_PRIVATE_KEY: ${{ secrets.ECDSA_PRIVATE_KEY }}

--- a/docs/changes/20260908-funded-wallet-salt-per-suite.md
+++ b/docs/changes/20260908-funded-wallet-salt-per-suite.md
@@ -1,0 +1,34 @@
+# Funded UserOp salt per CI suite
+
+- **Date**: 2026-09-08
+- **Status**: Implemented
+- **Branch**: staging
+- **Related**: [#263](https://github.com/AvaProtocol/ava-sdk-js/issues/263), [docs/changes/20260907-remove-v3-archive-fix-ci-operator-auth.md](20260907-remove-v3-archive-fix-ci-operator-auth.md)
+
+## Problem
+
+Every real-bundler test used `getFundedFixture()` → MA v2 salt `"0"` on `TEST_PRIVATE_KEY`. GitHub Actions runs `core` / `executions` / `nodes` (and the other shards) in parallel, so two `eth_sendUserOperation`s raced one EntryPoint nonce. The bundler returned `replacement underpriced`; `workflows.trigger` folded that into `1 of 2 steps failed: <nodeId>`, so envelope-level retry did not fire.
+
+Retrying sequential withdraws in one file is still useful (`--runInBand`). It cannot fix cross-job races.
+
+## Decision
+
+Assign a **static salt per CI suite directory**, not per `test()` case:
+
+| Suite | Salt | Why |
+|---|---|---|
+| `tests/v4/core` (withdraw) | `"0"` | Real UserOps |
+| `tests/v4/executions` (gasTracking) | `"1"` | Real UserOps |
+| `tests/v4/nodes` (contractWrite, ethTransfer) | `"2"` | Real UserOps; files in this shard share a salt because they run `--runInBand` |
+| templates / workflows / triggers | `"0"` | No parallel bundler send (templates USDC path is Tenderly simulate) |
+
+Only `"0" | "1" | "2"` so a `TEST_ENV=railway` run stays inside production's 3-wallet cap. `FUNDED_WALLET_SALT` env still overrides for debugging.
+
+`getFundedWallet` / `getFundedFixture` call `fundedWalletSalt()`, which reads Jest `testPath`. CREATE2(owner, factory, salt) is stable — fund each of the three addresses once.
+
+Per-test-case salts were rejected: a file can send several UserOps sequentially (withdraw), and more than three unique salts on one owner 429s on production.
+
+## Verification
+
+- `fundedSaltForTestPath` unit tests in `tests/v4/core/suiteSalt.test.ts` (no gateway).
+- Skip messages print the suite salt + derived address so an unfunded shard is obvious.

--- a/docs/changes/20260908-funded-wallet-salt-per-suite.md
+++ b/docs/changes/20260908-funded-wallet-salt-per-suite.md
@@ -24,11 +24,11 @@ Assign a **static salt per CI suite directory**, not per `test()` case:
 
 Only `"0" | "1" | "2"` so a `TEST_ENV=railway` run stays inside production's 3-wallet cap. `FUNDED_WALLET_SALT` env still overrides for debugging.
 
-`getFundedWallet` / `getFundedFixture` call `fundedWalletSalt()`, which reads Jest `testPath`. CREATE2(owner, factory, salt) is stable — fund each of the three addresses once.
+`getFundedWallet` / `getFundedFixture` call `fundedWalletSalt()`. CI sets `FUNDED_WALLET_SALT` per matrix job (source of truth on GitHub Actions). Local `yarn test:<suite>` infers the same map from Jest `testPath`. Under Jest with no path and no env, it throws rather than silently reusing salt `"0"`. CREATE2(owner, factory, salt) is stable — fund each of the three addresses once.
 
 Per-test-case salts were rejected: a file can send several UserOps sequentially (withdraw), and more than three unique salts on one owner 429s on production.
 
 ## Verification
 
-- `fundedSaltForTestPath` unit tests in `tests/v4/core/suiteSalt.test.ts` (no gateway).
+- `fundedSaltForTestPath` / `fundedWalletSalt` unit tests in `tests/v4/core/suiteSalt.test.ts` (no gateway).
 - Skip messages print the suite salt + derived address so an unfunded shard is obvious.

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,6 +54,8 @@ CI suite** so parallel matrix jobs do not share an EntryPoint nonce
 | templates / workflows / triggers | `0` |
 
 Those are the only three salts allowed under production's 3-wallet cap.
-CREATE2(owner, factory, salt) is stable for `TEST_PRIVATE_KEY` — fund
-each derived address on Sepolia with ETH and USDC. Unfunded shards skip
-or fail with the address in the message. Override with `FUNDED_WALLET_SALT`.
+CI sets `FUNDED_WALLET_SALT` per matrix job; local `yarn test:<suite>`
+infers the same map from the file path. CREATE2(owner, factory, salt)
+is stable for `TEST_PRIVATE_KEY` — fund each derived address on Sepolia
+with ETH and USDC. Unfunded shards skip or fail with the address in the
+message. Override with `FUNDED_WALLET_SALT`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,3 +41,19 @@ exact string (EigenLayer-AVS #767). A lowercase spelling connects, then
 fails every Ping/Sync with `operator authentication required`, and every
 block/event workflow create 400s with `no connected operator currently
 monitors chain_id=11155111`.
+
+Real-bundler tests (`getFundedFixture`) use a **static MA v2 salt per
+CI suite** so parallel matrix jobs do not share an EntryPoint nonce
+([#263](https://github.com/AvaProtocol/ava-sdk-js/issues/263)):
+
+| Suite | Salt |
+|---|---|
+| `yarn test:core` (withdraw) | `0` |
+| `yarn test:executions` (gasTracking) | `1` |
+| `yarn test:nodes` (contractWrite) | `2` |
+| templates / workflows / triggers | `0` |
+
+Those are the only three salts allowed under production's 3-wallet cap.
+CREATE2(owner, factory, salt) is stable for `TEST_PRIVATE_KEY` — fund
+each derived address on Sepolia with ETH and USDC. Unfunded shards skip
+or fail with the address in the message. Override with `FUNDED_WALLET_SALT`.

--- a/tests/utils/client.ts
+++ b/tests/utils/client.ts
@@ -100,7 +100,7 @@ export async function getSuiteClient(
 
 /**
  * Shared `TEST_PRIVATE_KEY` client. Only for tests that need the
- * pre-funded MA v2 salt-0 wallet. Does not isolate.
+ * pre-funded MA v2 fixture wallet. Does not isolate.
  *
  * Prefer {@link getFundedFixture} for real UserOps — that helper also
  * ensures the session grant the gateway requires to sign.
@@ -336,20 +336,76 @@ export interface CreateSmartWalletOptions {
  * SimpleAccount factory `0xB99BC2…2834` still holds historical ETH on
  * salt-2, but `policies:prepare` refuses it with SESSION_WALLET_NOT_MA_V2.
  *
- * Salt `"0"`: the owner's default MA v2 wallet. It is already in
- * production's 3-wallet cap, and CREATE2(owner, factory, 0) is the
- * address to fund once. `policiesLive.test.ts` uses an isolated EOA
- * so its grant-then-revoke cannot tear this fixture down.
- *
  * Address is CREATE2(owner, factory, salt) — stable across runs for a
  * given `TEST_PRIVATE_KEY`. Fund that address, not a fresh salt.
  */
-export const FUNDED_WALLET_SALT = "0";
 export const FUNDED_FACTORY_ADDRESS =
   "0x00000000000017c61b5bEe81050EC8eFc9c6fecd";
 
 /**
- * Resolve the MA v2 salt-0 wallet on the authenticated owner.
+ * Default funded salt (core suite, and anything that is not a parallel
+ * UserOp shard). Prefer {@link fundedWalletSalt} at call sites.
+ */
+export const FUNDED_WALLET_SALT = "0";
+
+/**
+ * Static MA v2 salt for real-bundler tests, keyed by the CI matrix
+ * suite (the `tests/v4/<suite>/` directory).
+ *
+ * GitHub Actions runs those directories in parallel. They used to
+ * share salt `"0"`, so two `eth_sendUserOperation`s raced one
+ * EntryPoint nonce (`replacement underpriced` / #263). Files inside
+ * one suite run `--runInBand`, so they keep one salt.
+ *
+ * Only `"0" | "1" | "2"` — production's 3-wallet cap. Override with
+ * `FUNDED_WALLET_SALT` in the environment when debugging a shard.
+ */
+export const FUNDED_SALT_BY_SUITE = {
+  core: "0",
+  executions: "1",
+  nodes: "2",
+  templates: "0",
+  workflows: "0",
+  triggers: "0",
+} as const;
+
+export type FundedSuite = keyof typeof FUNDED_SALT_BY_SUITE;
+
+/** Map a jest testPath onto {@link FUNDED_SALT_BY_SUITE}. Unknown → `"0"`. */
+export function fundedSaltForTestPath(testPath: string): string {
+  const normalized = testPath.replace(/\\/g, "/");
+  const match = /\/tests\/v4\/([^/]+)\//.exec(normalized);
+  const suite = match?.[1];
+  if (suite && suite in FUNDED_SALT_BY_SUITE) {
+    return FUNDED_SALT_BY_SUITE[suite as FundedSuite];
+  }
+  return FUNDED_WALLET_SALT;
+}
+
+function currentJestTestPath(): string | undefined {
+  try {
+    const g = globalThis as { expect?: { getState?: () => { testPath?: string } } };
+    return g.expect?.getState?.().testPath;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Salt `getFundedWallet` / `getFundedFixture` will use in this process.
+ * `FUNDED_WALLET_SALT` env wins (CI/debug); otherwise the calling test
+ * file's suite directory.
+ */
+export function fundedWalletSalt(): string {
+  const fromEnv = process.env.FUNDED_WALLET_SALT;
+  if (fromEnv) return fromEnv;
+  const testPath = currentJestTestPath();
+  if (testPath) return fundedSaltForTestPath(testPath);
+  return FUNDED_WALLET_SALT;
+}
+
+/**
+ * Resolve the MA v2 funded wallet on the authenticated owner.
  *
  * Looks up the existing (factory, salt) row and only creates if none
  * exists. Never falls back to the legacy SimpleAccount factory.
@@ -358,11 +414,12 @@ export const FUNDED_FACTORY_ADDRESS =
  */
 export async function getFundedWallet(
   client: Client,
+  salt: string = fundedWalletSalt(),
 ): Promise<v4.Wallet | undefined> {
   const listed = await client.wallets.list();
   const existing = listed.data.find(
     (w) =>
-      w.salt === FUNDED_WALLET_SALT &&
+      w.salt === salt &&
       w.factoryAddress?.toLowerCase() ===
         FUNDED_FACTORY_ADDRESS.toLowerCase(),
   );
@@ -370,7 +427,7 @@ export async function getFundedWallet(
 
   try {
     return await client.wallets.create({
-      salt: FUNDED_WALLET_SALT,
+      salt,
       factoryAddress: FUNDED_FACTORY_ADDRESS,
     });
   } catch (error) {
@@ -380,10 +437,11 @@ export async function getFundedWallet(
 }
 
 /**
- * Bundler still holds a prior UserOp for this sender. CI matrix jobs
- * (and sequential tests in one file) share MA v2 salt-0, so a second
+ * Bundler still holds a prior UserOp for this sender. Sequential
+ * tests in one file share a salt (runInBand), so a second
  * `eth_sendUserOperation` comes back `replacement underpriced` / AA25
- * until the first leaves the mempool.
+ * until the first leaves the mempool. Parallel CI shards use
+ * {@link fundedWalletSalt} so they do not share a sender.
  */
 export const USEROP_CONTENTION =
   /replacement underpriced|AA25 invalid account nonce|invalid account nonce/i;
@@ -424,9 +482,10 @@ export async function retryOnUserOpContention<T>(
 }
 
 /**
- * The funded UserOp fixture: shared EOA + MA v2 salt-0 runner + a
- * covering session grant. Every real-bundler test should take the
- * wallet from here so funding one address covers the suite.
+ * The funded UserOp fixture: shared EOA + MA v2 runner for this
+ * suite's static salt ({@link fundedWalletSalt}) + a covering session
+ * grant. Parallel CI shards (core / executions / nodes) each get a
+ * different salt so they do not share an EntryPoint nonce.
  */
 export async function getFundedFixture(
   overrides?: Partial<ClientOptions>,
@@ -437,10 +496,11 @@ export async function getFundedFixture(
   wallet: v4.Wallet;
 }> {
   const { client, owner, privateKey } = await getFundedClient(overrides);
-  const wallet = await getFundedWallet(client);
+  const salt = fundedWalletSalt();
+  const wallet = await getFundedWallet(client, salt);
   if (!wallet) {
     throw new Error(
-      `MA v2 funded wallet is not registered (salt ${FUNDED_WALLET_SALT}, factory ${FUNDED_FACTORY_ADDRESS}). ` +
+      `MA v2 funded wallet is not registered (salt ${salt}, factory ${FUNDED_FACTORY_ADDRESS}). ` +
         `Create it once for this owner, fund it on Sepolia with ETH and USDC, then re-run.`,
     );
   }
@@ -462,7 +522,7 @@ export function assertUserOpTriggerOk(
   if (trig.status === "failed" || trig.status === "error" || trig.error) {
     throw new Error(
       `UserOp failed for MA v2 funded wallet ${walletAddress} ` +
-        `(salt ${FUNDED_WALLET_SALT}, factory ${FUNDED_FACTORY_ADDRESS}): ` +
+        `(salt ${fundedWalletSalt()}, factory ${FUNDED_FACTORY_ADDRESS}): ` +
         `${trig.status ?? ""}${trig.error ? `: ${trig.error}` : ""}. ` +
         `Fund this address on Sepolia with ETH (and USDC for ERC-20 tests).`,
     );

--- a/tests/utils/client.ts
+++ b/tests/utils/client.ts
@@ -338,6 +338,9 @@ export interface CreateSmartWalletOptions {
  *
  * Address is CREATE2(owner, factory, salt) — stable across runs for a
  * given `TEST_PRIVATE_KEY`. Fund that address, not a fresh salt.
+ *
+ * `policiesLive.test.ts` uses {@link getIsolatedClient} so its
+ * grant-then-revoke cannot tear this fixture down.
  */
 export const FUNDED_FACTORY_ADDRESS =
   "0x00000000000017c61b5bEe81050EC8eFc9c6fecd";
@@ -357,8 +360,9 @@ export const FUNDED_WALLET_SALT = "0";
  * EntryPoint nonce (`replacement underpriced` / #263). Files inside
  * one suite run `--runInBand`, so they keep one salt.
  *
- * Only `"0" | "1" | "2"` — production's 3-wallet cap. Override with
- * `FUNDED_WALLET_SALT` in the environment when debugging a shard.
+ * Only `"0" | "1" | "2"` — production's 3-wallet cap. CI sets
+ * `FUNDED_WALLET_SALT` per matrix job; this map is the local
+ * `yarn test:<suite>` path. Env still wins when debugging a shard.
  */
 export const FUNDED_SALT_BY_SUITE = {
   core: "0",
@@ -382,25 +386,37 @@ export function fundedSaltForTestPath(testPath: string): string {
   return FUNDED_WALLET_SALT;
 }
 
+function jestGetState(): (() => { testPath?: string }) | undefined {
+  const g = globalThis as {
+    expect?: { getState?: () => { testPath?: string } };
+  };
+  return g.expect?.getState;
+}
+
 function currentJestTestPath(): string | undefined {
-  try {
-    const g = globalThis as { expect?: { getState?: () => { testPath?: string } } };
-    return g.expect?.getState?.().testPath;
-  } catch {
-    return undefined;
-  }
+  return jestGetState()?.().testPath;
 }
 
 /**
  * Salt `getFundedWallet` / `getFundedFixture` will use in this process.
  * `FUNDED_WALLET_SALT` env wins (CI/debug); otherwise the calling test
- * file's suite directory.
+ * file's suite directory. Under Jest with no path and no env, throw —
+ * defaulting to salt `"0"` is the #263 nonce race.
+ *
+ * Scripts outside Jest (no `expect.getState`) still get salt `"0"`.
  */
 export function fundedWalletSalt(): string {
   const fromEnv = process.env.FUNDED_WALLET_SALT;
   if (fromEnv) return fromEnv;
   const testPath = currentJestTestPath();
   if (testPath) return fundedSaltForTestPath(testPath);
+  if (typeof jestGetState() === "function") {
+    throw new Error(
+      "fundedWalletSalt: Jest has no tests/v4/<suite>/ testPath and " +
+        "FUNDED_WALLET_SALT is unset. Refusing to default to salt 0 " +
+        "(that is the #263 nonce race).",
+    );
+  }
   return FUNDED_WALLET_SALT;
 }
 

--- a/tests/v4/core/suiteSalt.test.ts
+++ b/tests/v4/core/suiteSalt.test.ts
@@ -13,6 +13,7 @@ import {
   TIGHT_WALLET_CAP_LIMIT,
   FUNDED_SALT_BY_SUITE,
   fundedSaltForTestPath,
+  fundedWalletSalt,
   suiteSalt,
   tightWalletCap,
 } from "../../utils/client";
@@ -100,5 +101,43 @@ describe("fundedSaltForTestPath", () => {
       expect(salt).toBeGreaterThanOrEqual(0);
       expect(salt).toBeLessThan(TIGHT_WALLET_CAP_LIMIT);
     }
+  });
+});
+
+describe("fundedWalletSalt", () => {
+  const original = process.env.FUNDED_WALLET_SALT;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.FUNDED_WALLET_SALT;
+    else process.env.FUNDED_WALLET_SALT = original;
+  });
+
+  test("FUNDED_WALLET_SALT env wins over the test file's suite", () => {
+    process.env.FUNDED_WALLET_SALT = "2";
+    expect(fundedWalletSalt()).toBe("2");
+  });
+
+  test("without an override, this file (tests/v4/core) maps to salt 0", () => {
+    delete process.env.FUNDED_WALLET_SALT;
+    expect(fundedWalletSalt()).toBe("0");
+  });
+
+  test("throws under Jest when testPath is missing and no env override", () => {
+    delete process.env.FUNDED_WALLET_SALT;
+    const state = expect.getState();
+    const spy = jest.spyOn(expect, "getState").mockReturnValue({
+      ...state,
+      testPath: undefined,
+    });
+    let threw: unknown;
+    try {
+      fundedWalletSalt();
+    } catch (error) {
+      threw = error;
+    } finally {
+      spy.mockRestore();
+    }
+    expect(threw).toBeInstanceOf(Error);
+    expect(String(threw)).toMatch(/#263 nonce race/);
   });
 });

--- a/tests/v4/core/suiteSalt.test.ts
+++ b/tests/v4/core/suiteSalt.test.ts
@@ -9,7 +9,13 @@
  * a test outside it is collected by neither, and a test that never runs is
  * worse than no test. It needs no gateway; it just rides the core shard.
  */
-import { TIGHT_WALLET_CAP_LIMIT, suiteSalt, tightWalletCap } from "../../utils/client";
+import {
+  TIGHT_WALLET_CAP_LIMIT,
+  FUNDED_SALT_BY_SUITE,
+  fundedSaltForTestPath,
+  suiteSalt,
+  tightWalletCap,
+} from "../../utils/client";
 
 describe("suiteSalt", () => {
   const originalTightCap = process.env.TIGHT_WALLET_CAP;
@@ -68,5 +74,31 @@ describe("suiteSalt", () => {
     const numeric = produced.map(Number);
     expect(numeric).toEqual([...numeric].sort((a, b) => a - b));
     expect(Math.max(...numeric)).toBeGreaterThanOrEqual(TIGHT_WALLET_CAP_LIMIT);
+  });
+});
+
+describe("fundedSaltForTestPath", () => {
+  test("maps each CI shard directory onto a static salt inside the 3-wallet cap", () => {
+    expect(fundedSaltForTestPath("/repo/tests/v4/core/withdraw.test.ts")).toBe("0");
+    expect(fundedSaltForTestPath("/repo/tests/v4/executions/gasTracking.test.ts")).toBe("1");
+    expect(fundedSaltForTestPath("/repo/tests/v4/nodes/contractWrite.test.ts")).toBe("2");
+    expect(fundedSaltForTestPath("/repo/tests/v4/nodes/ethTransfer.test.ts")).toBe("2");
+    expect(fundedSaltForTestPath("/repo/tests/v4/templates/workflow-usdc-read-write-customcode.test.ts")).toBe("0");
+    expect(fundedSaltForTestPath("/repo/tests/v4/workflows/workflow.test.ts")).toBe("0");
+    expect(fundedSaltForTestPath("/repo/tests/v4/triggers/block.test.ts")).toBe("0");
+  });
+
+  test("unknown paths fall back to salt 0", () => {
+    expect(fundedSaltForTestPath("/repo/tests/v4/smoke.test.ts")).toBe("0");
+    expect(fundedSaltForTestPath("withdraw.test.ts")).toBe("0");
+  });
+
+  test("the map only uses salts inside the production wallet cap", () => {
+    const salts = Object.values(FUNDED_SALT_BY_SUITE).map(Number);
+    expect(new Set(salts).size).toBeLessThanOrEqual(TIGHT_WALLET_CAP_LIMIT);
+    for (const salt of salts) {
+      expect(salt).toBeGreaterThanOrEqual(0);
+      expect(salt).toBeLessThan(TIGHT_WALLET_CAP_LIMIT);
+    }
   });
 });

--- a/tests/v4/core/withdraw.test.ts
+++ b/tests/v4/core/withdraw.test.ts
@@ -13,17 +13,15 @@
  * carries a single client-scoped Bearer JWT, so per-request auth
  * overrides don't exist.
  *
- * The funded-wallet helper looks up MA v2 salt "0" (see
- * getFundedFixture). If the wallet is unfunded, on-chain tests skip
- * with the address to fund; the validation tests still run.
+ * The funded-wallet helper looks up this suite's static MA v2 salt
+ * (core → `"0"`; see `fundedWalletSalt`). If the wallet is unfunded,
+ * on-chain tests skip with the address to fund; the validation tests
+ * still run.
  *
- * Every funded UserOp in this repo (withdraw, contractWrite trigger,
- * gasTracking) shares that one sender. CI matrix jobs race the same
- * EntryPoint nonce; a second send while the first is in the bundler
- * mempool comes back `replacement underpriced`. Contention is retried
- * via `retryOnUserOpContention`; this helper also waits for a receipt
- * when the gateway returns one so the next test in this file does not
- * collide with itself.
+ * Sequential withdraws in this file share one sender. Contention is
+ * retried via `retryOnUserOpContention`; this helper also waits for a
+ * receipt when the gateway returns one so the next test does not
+ * collide with itself. Parallel CI shards use other salts.
  */
 
 import { ethers } from "ethers";
@@ -35,7 +33,7 @@ import {
   getFundedClient,
   getFundedFixture,
   FUNDED_FACTORY_ADDRESS,
-  FUNDED_WALLET_SALT,
+  fundedWalletSalt,
   retryOnUserOpContention,
   createSmartWallet,
 } from "../../utils/client";
@@ -80,7 +78,7 @@ async function pollReceipt(
 
 function fundedSkipMessage(address: string, detail: string): string {
   return (
-    `Skipping — ${detail}. Fund MA v2 salt-${FUNDED_WALLET_SALT} wallet ` +
+    `Skipping — ${detail}. Fund MA v2 salt-${fundedWalletSalt()} wallet ` +
     `${address} (factory ${FUNDED_FACTORY_ADDRESS}) on Sepolia with ETH and USDC.`
   );
 }

--- a/tests/v4/nodes/contractWrite.test.ts
+++ b/tests/v4/nodes/contractWrite.test.ts
@@ -13,9 +13,10 @@
  *     value (bool for approve/transfer, struct for tuple returns).
  *   - `result.executionContext.is_simulated = true` for sim paths.
  *
- * The MA v2 salt-0 funded wallet + session grant is required for
- * the real deploy+trigger path. Simulation of `transfer` also uses
- * that wallet because Tenderly does not override ERC-20 balances.
+ * The MA v2 funded wallet for this suite (nodes → salt `"2"`) + session
+ * grant is required for the real deploy+trigger path. Simulation of
+ * `transfer` also uses that wallet because Tenderly does not override
+ * ERC-20 balances.
  */
 
 import { Chains, Client, Nodes, Protocols, Tokens, Triggers } from "@avaprotocol/sdk-js";
@@ -75,7 +76,7 @@ describe("ContractWrite Node Tests", () => {
     });
 
     test("simulates a transfer call against the funded wallet", async () => {
-      // MA v2 salt-0 holds Sepolia USDC. A suite wallet (fresh salt /
+      // This suite's funded MA v2 wallet holds Sepolia USDC. A suite wallet (fresh salt /
       // isolated EOA) has none, and Tenderly does not override ERC-20
       // balances — transfer would revert with "amount exceeds balance".
       const { client: funded, owner } = await getFundedClient();

--- a/tests/v4/templates/workflow-usdc-read-write-customcode.test.ts
+++ b/tests/v4/templates/workflow-usdc-read-write-customcode.test.ts
@@ -95,11 +95,11 @@ describe("Template: USDC read+write+customCode", () => {
 
   test("simulates the workflow with both contractReads + contractWrite + customCode", async () => {
     // Tenderly does not override ERC-20 balances; the transfer step
-    // needs the MA v2 salt-0 wallet that actually holds Sepolia USDC.
+    // needs the suite's funded MA v2 wallet (templates → salt "0") that holds Sepolia USDC.
     const { client: funded, owner } = await getFundedClient();
     const wallet = await getFundedWallet(funded);
     if (!wallet) {
-      console.log("Skipping — funded MA v2 salt-0 wallet not available");
+      console.log("Skipping — funded MA v2 wallet not available");
       return;
     }
     eoaAddress = owner;


### PR DESCRIPTION
## Summary

GitHub Actions shards `core` / `executions` / `nodes` in parallel. They all used MA v2 salt `0` on `TEST_PRIVATE_KEY`, so two `eth_sendUserOperation`s raced one EntryPoint nonce (`replacement underpriced`). `workflows.trigger` folded that into `1 of 2 steps failed: <nodeId>`, so envelope-level retry never fired ([#263](https://github.com/AvaProtocol/ava-sdk-js/issues/263)).

This PR assigns a **static salt per CI suite** instead of retrying the envelope:

| Suite | Salt |
|---|---|
| `tests/v4/core` | `0` |
| `tests/v4/executions` | `1` |
| `tests/v4/nodes` | `2` |
| templates / workflows / triggers | `0` |

Only `"0" \| "1" \| "2"` so a `TEST_ENV=railway` run stays inside production's 3-wallet cap. `FUNDED_WALLET_SALT` still overrides. Files inside one shard stay `--runInBand` and share that shard's salt.

Sepolia MA v2 factory `0x00000000000017c61b5bEe81050EC8eFc9c6fecd` (owner `0x72D841F43241957b558097A5110A8Ed68c6fD88c`):

- salt 0 `0xd162D90140a288f4c2D62ebbE8af9035C400720b` (core / templates / workflows / triggers)
- salt 1 `0xBd455f985AF91A1cbDECc46cF561567fc78d650e` (executions)
- salt 2 `0x6ed5eeC8452e656b256C72B2f61fdDA5FC256133` (nodes)

All three are funded on Sepolia (ETH + Circle USDC). Addresses #263.

See [docs/changes/20260908-funded-wallet-salt-per-suite.md](docs/changes/20260908-funded-wallet-salt-per-suite.md).
